### PR TITLE
Fix mixed content warnings/broken placeholder images

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -53,7 +53,7 @@ def grab_officer_faces(officer_ids, engine):
     
     for officer_id in officer_ids:
         if officer_id not in officer_images.keys():
-            officer_images.update({officer_id: 'http://placehold.it/200x200'})
+            officer_images.update({officer_id: 'https://placehold.it/200x200'})
 
     return officer_images
 


### PR DESCRIPTION
My understanding of the code is that this will only fix things on first
retrieval of a new officer and a db update may be necessary to fix the
existing placeholder images; that said, it's still a necessary fix.
