### PR TITLE
Test data command line utility

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -29,7 +29,10 @@ with the password `terriblepassword`.
 For the webapp, the credentials for the testing/development environment are expected to be in a file `$PGPASS`, so set that up: 
 
 `echo "localhost:5432:openoversight-dev:openoversight:terriblepassword" >> ~/.pgpass`
+
 `echo "export PGPASS=~/.pgpass" >> ~/.bashrc`
+
+`source ~/.bashrc`
 
 In the `/vagrant/OpenOversight` directory, there is a script to create the database:
 

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -17,7 +17,7 @@
     {% for error in form.dept.errors %}
         <p><span style="color: red;">[{{ error }}]</span></p>
     {% endfor %}
-    <p>Don't see your department? Want to bring OpenOversight to your city? Email us at <a href="mailto:openoversight@redshiftzero.com">OpenOversight</a>.</p>
+    <p>Don't see your department? Want to bring OpenOversight to your city? Email us at <a href="mailto:info@lucyparsonslabs.com">OpenOversight</a>.</p>
      
     <h4>Rank: {{ form.rank }}</h4>
     {% for error in form.rank.errors %}

--- a/OpenOversight/create_db.py
+++ b/OpenOversight/create_db.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 from migrate.versioning import api
 from config import SQLALCHEMY_DATABASE_URI
 from config import SQLALCHEMY_MIGRATE_REPO

--- a/OpenOversight/test_data.py
+++ b/OpenOversight/test_data.py
@@ -1,4 +1,8 @@
+#!/usr/bin/python
+
+import argparse
 from datetime import datetime
+import sys
 
 from app import db, models
 
@@ -57,6 +61,11 @@ def populate():
 
 def cleanup():
     """ Cleanup database"""
+
+    faces = models.Face.query.all()
+    for face in faces:
+        db.session.delete(face)
+
     officers = models.Officer.query.all()
     for po in officers:
         db.session.delete(po)
@@ -65,12 +74,35 @@ def cleanup():
     for assn in assignments:
         db.session.delete(assn)
 
-    faces = models.Face.query.all()
-    for face in faces:
-        db.session.delete(face)
-
     images = models.Image.query.all()
     for image in images:
         db.session.delete(image)
 
+    # TODO: Reset primary keys on all these tables
     db.session.commit()
+
+
+if __name__=="__main__":
+   parser = argparse.ArgumentParser()
+   parser.add_argument("-p", "--populate", action='store_true',
+                       help="populate the database with test data")
+   parser.add_argument("-c", "--cleanup", action='store_true',
+                       help="delete all test data from the database")
+   args = parser.parse_args()
+
+   if args.populate:
+       print("[*] Populating database with test data...")
+       try:
+           populate()
+           print("[*] Completed successfully!")
+       except:
+           print("[!] Encountered an unknown issue, exiting.")
+           sys.exit(1)
+   if args.cleanup:
+       print("[*] Cleaning up database...")
+       try:
+           cleanup()
+           print("[*] Completed successfully!")
+       except:
+           print("[!] Encountered an unknown issue, exiting.")
+           sys.exit(1)


### PR DESCRIPTION
This implements #69 to make the test data population a little command line utility: 

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ ./test_data.py --help
usage: test_data.py [-h] [-p] [-c]

optional arguments:
  -h, --help      show this help message and exit
  -p, --populate  populate the database with test data
  -c, --cleanup   delete all test data from the database

vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ ./test_data.py --populate
[*] Populating database with test data...
[*] Completed successfully!
vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ ./test_data.py --cleanup
[*] Cleaning up database...
[*] Completed successfully!
```