### PR TITLE
remove ampersand which throws errors in systemd

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -75,7 +75,8 @@ SECRET_KEY = 'changemeplzorelsehax'
 
 # Systemd
 
-You can write a simple systemd unit file to launch OpenOversight on boot. We defined ours in `/etc/systemd/system/openoversight.service`. You should create the proper usernames and groups that are defined in the unit file since this allows you to drop privileges on boot. This unit file was adopted from this [DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-centos-7).
+You can write a simple systemd unit file to launch OpenOversight on boot. We defined ours in `/etc/systemd/system/openoversight.service`. You should create the proper usernames and groups that are defined in the unit file since this allows you to drop privileges on boot. This unit file was adopted from this [DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-centos-7). Special care should be taken when using the environment variables defined in `CONTRIB.md`.
+
 ```
 [Unit]
 Description=Gunicorn instance to serve OpenOversight
@@ -84,9 +85,9 @@ After=network.target
 [Service]
 User=nginx
 Group=nginx
-WorkingDirectory= /home/nginx/oovirtenv/OpenOversight/OpenOversight
+WorkingDirectory=/home/nginx/oovirtenv/OpenOversight/OpenOversight
 Environment="PATH=/home/nginx/oovirtenv/bin"
-ExecStart=/usr/local/bin/gunicorn -w 4 -b 127.0.0.1:4000 app:app &
+ExecStart=/usr/local/bin/gunicorn -w 4 -b 127.0.0.1:4000 app:app 
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
fixes #75 but the line about env variables in `CONTRIB.md` is still what is borked on our deployment. @r4v5 and I can inspect the server but this PR should fix other deployments.