### PR TITLE
Implement search by name and badge number

### DIFF
--- a/OpenOversight/app/forms.py
+++ b/OpenOversight/app/forms.py
@@ -1,6 +1,8 @@
 from flask_wtf import FlaskForm as Form
-from wtforms import StringField, BooleanField, DecimalField, SelectField, IntegerField, FileField
-from wtforms.validators import DataRequired, AnyOf, NumberRange
+from wtforms import (StringField, BooleanField, DecimalField,
+                     SelectField, IntegerField, FileField)
+from wtforms.validators import (DataRequired, AnyOf, NumberRange, Regexp,
+                                Length, Optional)
 from flask_wtf.file import FileAllowed
 
 
@@ -32,6 +34,13 @@ class HumintContribution(Form):
 
 
 class FindOfficerForm(Form):
+    name = StringField('name', default='',
+                       validators=[Regexp('\w*'),
+                                   Length(max=50),
+                                   Optional()])
+    badge = StringField('badge', default='',
+                         validators=[Regexp('\w*'),
+                                     Length(max=10)])
     dept = SelectField('dept', default='ChicagoPD', choices=DEPT_CHOICES,
                        validators=[DataRequired(),
                                    AnyOf(allowed_values(DEPT_CHOICES))])

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -19,6 +19,26 @@
     {% endfor %}
     <p>Don't see your department? Want to bring OpenOversight to your city? Email us at <a href="mailto:info@lucyparsonslabs.com">OpenOversight</a>.</p>
      
+    <div class="page-header">
+        <h2>Partial Name or Badge Number</h2>
+    </div>
+
+    <h4>Do you remember any part of the Officer's last name?</h4>
+    {{ form.name }}
+    {% for error in form.name.errors %}
+        <p><span style="color: red;">[{{ error }}]</span></p>
+    {% endfor %}
+
+    <h4>Do you remember any part of the Officer's badge number?</h4>
+    {{ form.badge }}
+    {% for error in form.badge.errors %}
+        <p><span style="color: red;">[{{ error }}]</span></p>
+    {% endfor %}
+
+    <div class="page-header">
+        <h2>Rank</h2>
+    </div>
+
     <h4>Rank: {{ form.rank }}</h4>
     {% for error in form.rank.errors %}
         <p><span style="color: red;">[{{ error }}]</span></p>

--- a/OpenOversight/app/templates/partials/officer_form_fields_hidden.html
+++ b/OpenOversight/app/templates/partials/officer_form_fields_hidden.html
@@ -1,3 +1,5 @@
+{{ form.name(class="hidden") }}
+{{ form.badge(class="hidden") }}
 {{ form.dept(class="hidden") }}
 {{ form.gender(class="hidden") }}
 {{ form.race(class="hidden") }}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -3,6 +3,7 @@ import datetime
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import desc, asc
+from sqlalchemy.sql.expression import cast
 from app import app
 from app.models import Officer, Assignment, Image, Face
 import pdb
@@ -11,18 +12,18 @@ db = SQLAlchemy(app)
 
 
 def filter_by_form(form, officer_query):
-    if form['race'] in ('BLACK', 'WHITE', 'ASIAN', 'HISPANIC', 'PACIFIC ISLANDER'):
-        officer_query = officer_query.filter(Officer.race.like('%%{}%%'.format(form['race'])))
+    if form['name']:
+        officer_query = officer_query.filter(
+            Officer.last_name.like('%%{}%%'.format(form['name']))
+            )
+    if form['race'] in ('BLACK', 'WHITE', 'ASIAN', 'HISPANIC',
+                        'PACIFIC ISLANDER'):
+        officer_query = officer_query.filter(
+            Officer.race.like('%%{}%%'.format(form['race']))
+            )
     if form['gender'] in ('M', 'F'):
         officer_query = officer_query.filter(Officer.gender == form['gender'])
-    if form['rank'] =='PO':
-        officer_query = officer_query.filter(db.or_(Assignment.rank.like('%%PO%%'),
-                                                    Assignment.rank.like('%%POLICE OFFICER%%'),
-                                                    Assignment.rank == None))
-    if form['rank'] in ('FIELD', 'SERGEANT', 'LIEUTENANT', 'CAPTAIN', 'COMMANDER',
-                        'DEP CHIEF', 'CHIEF', 'DEPUTY SUPT', 'SUPT OF POLICE'):
-        officer_query = officer_query.filter(db.or_(Assignment.rank.like('%%{}%%'.format(form['rank'])),
-                                                    Assignment.rank == None))
+
 
     current_year = datetime.datetime.now().year
     min_birth_year = current_year - int(form['min_age'])
@@ -30,6 +31,27 @@ def filter_by_form(form, officer_query):
     officer_query = officer_query.filter(db.or_(db.and_(Officer.birth_year <= min_birth_year,
                                                         Officer.birth_year >= max_birth_year),
                                                 Officer.birth_year == None))
+
+    officer_query = officer_query.join(Assignment)
+    if form['badge']:
+        officer_query = officer_query.filter(
+                cast( Assignment.star_no, db.String ) \
+                .like('%%{}%%'.format(form['badge']))
+            )
+    if form['rank'] =='PO':
+        officer_query = officer_query.filter(
+            db.or_(Assignment.rank.like('%%PO%%'),
+                   Assignment.rank.like('%%POLICE OFFICER%%'),
+                   Assignment.rank == None)
+            )
+    if form['rank'] in ('FIELD', 'SERGEANT', 'LIEUTENANT', 'CAPTAIN',
+                        'COMMANDER', 'DEP CHIEF', 'CHIEF', 'DEPUTY SUPT',
+                        'SUPT OF POLICE'):
+        officer_query = officer_query.filter(
+            db.or_(Assignment.rank.like('%%{}%%'.format(form['rank'])),
+                   Assignment.rank == None)
+            )
+
     # This handles the sorting upstream of pagination and pushes officers w/o tagged faces to the end of list
     officer_query = officer_query.outerjoin(Face).order_by(Face.officer_id.asc()).order_by(Officer.id.desc())
     return officer_query

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -7,32 +7,45 @@ from app.models import Officer, Assignment, Image, Face
 class TestUtils(unittest.TestCase):
     def test_race_filter_select_all_black_officers(self):
         results = utils.grab_officers({'race': 'BLACK', 'gender': 'Not Sure',
-                                      'rank': 'Not Sure', 'min_age': 16, 'max_age': 85})
+                                      'rank': 'Not Sure', 'min_age': 16, 'max_age': 85,
+                                      'name': '', 'badge': ''})
         for element in results:
-            self.assertEquals(element.Officer.race, 'BLACK')
+            self.assertEquals(element.race, 'BLACK')
 
     def test_gender_filter_select_all_male_officers(self):
         results = utils.grab_officers({'race': 'Not Sure', 'gender': 'M',
-                                      'rank': 'Not Sure', 'min_age': 16, 'max_age': 85})
+                                      'rank': 'Not Sure', 'min_age': 16, 'max_age': 85,
+                                      'name': '', 'badge': ''})
         for element in results:
-            self.assertEquals(element.Officer.gender, 'M')
+            self.assertEquals(element.gender, 'M')
 
     def test_rank_filter_select_all_commanders(self):
         results = utils.grab_officers({'race': 'Not Sure', 'gender': 'Not Sure',
-                                       'rank': 'COMMANDER', 'min_age': 16, 'max_age': 85})
+                                       'rank': 'COMMANDER', 'min_age': 16, 'max_age': 85,
+                                       'name': '', 'badge': ''})
         for element in results:
-            self.assertEquals(element.Assignment.rank, 'COMMANDER')
+            assignment = element.assignments.first()
+            self.assertEquals(assignment.rank, 'COMMANDER')
 
     def test_get_badge_number(self):
         results = utils.grab_officers({'race': 'Not Sure', 'gender': 'Not Sure',
-                                       'rank': 'COMMANDER', 'min_age': 16, 'max_age': 85})
+                                       'rank': 'COMMANDER', 'min_age': 16, 'max_age': 85,
+                                       'name': '', 'badge': ''})
         for element in results:
-            self.assertEquals(element.Assignment.star_no, 1234)
+            assignment = element.assignments.first()
+            self.assertEquals(assignment.star_no, 1234)
 
-    def test_no_face_found(self):
-        result = utils.grab_officer_faces([0])
-        self.assertEquals(result[0], 'https://placehold.it/200x200')
+    def test_filter_by_name(self):
+        results = utils.grab_officers({'race': 'Not Sure', 'gender': 'Not Sure',
+                                       'rank': 'Not Sure', 'min_age': 16, 'max_age': 85,
+                                       'name': 'J', 'badge': ''})
+        for element in results:
+            self.assertIn('J', element.last_name)
 
-    def test_found_face(self):
-        result = utils.grab_officer_faces([1])
-        self.assertEquals(result[1], u'static/images/test_cop1.png')
+    def test_filter_by_badge_no(self):
+        results = utils.grab_officers({'race': 'Not Sure', 'gender': 'Not Sure',
+                                       'rank': 'Not Sure', 'min_age': 16, 'max_age': 85,
+                                       'name': '', 'badge': '12'})
+        for element in results:
+            assignment = element.assignments.first()
+            self.assertIn('12', str(assignment.star_no))


### PR DESCRIPTION
Closes #24 and closes #92 

# Search by Partial Name

## Form

<img width="578" alt="screen shot 2016-10-22 at 3 11 37 pm" src="https://cloud.githubusercontent.com/assets/7832803/19622994/8c8cc2c2-986d-11e6-9596-0dafdd978312.png">

## Result 

<img width="631" alt="screen shot 2016-10-22 at 3 11 45 pm" src="https://cloud.githubusercontent.com/assets/7832803/19622996/96387a78-986d-11e6-9872-0005741cb8b2.png">

# Search by Partial Badge Number

## Form

<img width="523" alt="screen shot 2016-10-22 at 3 11 15 pm" src="https://cloud.githubusercontent.com/assets/7832803/19622997/9e0c518e-986d-11e6-8f84-cab7d578ebbf.png">

## Result

<img width="889" alt="screen shot 2016-10-22 at 3 11 22 pm" src="https://cloud.githubusercontent.com/assets/7832803/19623001/a48a3f26-986d-11e6-864e-6a532dd63a55.png">

Also wrote a couple of unit tests to automate the above check.

I noticed that filtering by anything in the assignments table was broken, so I fixed that and made an issue to write some unit tests for pagination (we should do #102 first). 