### PR TITLE
Tagging feature

### DIFF
--- a/OpenOversight/app/forms.py
+++ b/OpenOversight/app/forms.py
@@ -64,3 +64,15 @@ class FindOfficerForm(Form):
         NumberRange(min=-180, max=180)
         ])
 
+
+class FindOfficerIDForm(Form):
+    name = StringField('name', default='',
+                       validators=[Regexp('\w*'),
+                                   Length(max=50),
+                                   Optional()])
+    badge = StringField('badge', default='',
+                         validators=[Regexp('\w*'),
+                                     Length(max=10)])
+    dept = SelectField('dept', default='ChicagoPD', choices=DEPT_CHOICES,
+                       validators=[DataRequired(),
+                                   AnyOf(allowed_values(DEPT_CHOICES))])

--- a/OpenOversight/app/static/theme.css
+++ b/OpenOversight/app/static/theme.css
@@ -20,3 +20,29 @@ body {
 .glyphicon {
     font-size: 30px;
 }
+
+.thumbnail_container {
+     position: relative;
+     width: 100%;
+     padding-bottom: 100%;
+     float:left;
+}
+
+.thumbnail {
+    position:absolute;
+    width:80%;
+    height:80%;
+}
+.thumbnail img {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+}
+
+img{
+    max-height:80%;
+    max-width:80%;
+}

--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -1,34 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 
-<style>
-.thumbnail_container {
-     position: relative;
-     width: 100%;
-     padding-bottom: 100%;
-     float:left;
-}
-
-.thumbnail {
-    position:absolute;
-    width:80%;
-    height:80%;
-}
-.thumbnail img {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
-}
-
-img{
-    max-height:80%;
-    max-width:80%;
-}
-</style>
-
 <div class="container theme-showcase" role="main">
 
     <div class="container">

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -4,8 +4,23 @@
 <div class="container theme-showcase" role="main">
 <h1>Label Officer Images</h1>
 
-We're looking for volunteers to help us sort through images! Email <a href="mailto:info@lucyparsonslabs.com">info@lucyparsonslabs.com</a> to find out how to get started.
- 
+<p>We're looking for volunteers to help us sort through images! Email <a href="mailto:info@lucyparsonslabs.com">info@lucyparsonslabs.com</a> to find out how to get started.</p>
+
+<div class="page-header">
+    <h1>Tools for Volunteers</h1>
+</div>
+<p>If you're already signed up to review, then you can use the tools below.</p>
+
+<h2>Find an Officer's OpenOversight ID</h2>
+
+<p>To link a submitted face with a given officer in the database, first you
+need to find the Officer's OpenOversight ID in the database. Use the following
+form to put in the details you can see in the image:</p>
+
+<p>
+  <a href="/taggerfind"><button type="button" class="btn btn-lg btn-primary">Launch OpenOversight ID Lookup Form</button></a>
+</p>
+
 </div>
 
 {% endblock %}

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -11,15 +11,43 @@
 </div>
 <p>If you're already signed up to review, then you can use the tools below.</p>
 
-<h2>Find an Officer's OpenOversight ID</h2>
+<div class="page-header">
+    <h2>Find an Officer's OpenOversight ID</h2>
+</div>
 
 <p>To link a submitted face with a given officer in the database, first you
-need to find the Officer's OpenOversight ID in the database. Use the following
+need to find the Officer's OpenOversight ID.</p> 
+<p>Use the following
 form to put in the details you can see in the image:</p>
 
+<form action="{{ url_for('get_tagger_gallery') }}" method="post">
+{{ form.hidden_tag() }}
+
+<h4>Department: {{ form.dept }}</h4>
+{% for error in form.dept.errors %}
+    <p><span style="color: red;">[{{ error }}]</span></p>
+{% endfor %}
+
+<h4>What is visible from the officer's name tag?</h4>
+{{ form.name }}
+{% for error in form.name.errors %}
+    <p><span style="color: red;">[{{ error }}]</span></p>
+{% endfor %}
+
+<h4>What is visible from the badge number?</h4>
+{{ form.badge }}
+{% for error in form.badge.errors %}
+    <p><span style="color: red;">[{{ error }}]</span></p>
+{% endfor %}
+
+<br><br>
 <p>
-  <a href="/taggerfind"><button type="button" class="btn btn-lg btn-primary">Launch OpenOversight ID Lookup Form</button></a>
+<input class="btn btn-lg" type="submit" value="Lookup name/badge number in roster" />
 </p>
+</form>
+
+</div>
+
 
 </div>
 

--- a/OpenOversight/app/templates/partials/roster_form_fields.html
+++ b/OpenOversight/app/templates/partials/roster_form_fields.html
@@ -1,0 +1,4 @@
+{{ form.name(class="hidden") }}
+{{ form.badge(class="hidden") }}
+{{ form.dept(class="hidden") }}
+{{ form.hidden_tag() }}

--- a/OpenOversight/app/templates/partials/roster_paginate.html
+++ b/OpenOversight/app/templates/partials/roster_paginate.html
@@ -1,0 +1,20 @@
+<div class="top-paginate">
+    <span class="paginate-navigate">
+	{% if officers.has_prev %}
+	    <form action="{{ url_for('get_tagger_gallery', page=officers.prev_num) }}" method="post">
+		{% include 'partials/roster_form_fields.html' %}
+		<input type="submit" value="<< " />
+	    </form>
+	{% endif %}
+	{% if officers.has_next %}
+	    <form action="{{ url_for('get_tagger_gallery', page=officers.next_num) }}" method="post">
+		{% include 'partials/roster_form_fields.html' %}
+		<input type="submit" value=">> " />
+	    </form>
+	{% endif %}
+    </span>
+    {% if officers.total > 0 %}
+    <span class="paginate-info">Page {{ officers.page }} of {{ officers.pages }}</span>
+    {% endif %}
+</div>
+<!-- /.top-paginate -->

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <h1 class="page-header">Matching Officers</h1>
+            </div>
+            <div class="container">
+            {% include 'partials/roster_paginate.html' %}
+            {% for officer in officers.items %}
+                {% if officer.face.first() is none %}
+                    {% set officer_image = '/static/images/placeholder.png' %}
+                {% else %}
+                    {% set officer_image = officer.face.first().image.filepath %}
+                {% endif %}
+            {% set assignment = officer.assignments.first() %}
+            <div class="col-md-3 col-sm-4 col-xs-12">
+                <div class="thumbnail_container">
+                <div class="row">
+                <h4>{{ officer.first_name.lower()|title }}
+                {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
+                {{ officer.last_name.lower()|title }} <small>#{{ assignment.star_no }}</small></h4>
+                <h5>OpenOversight ID: {{ officer.id }}</h5>
+                <h5>Race: {{ officer.race }}</h5>
+                <h5>Gender: {{ officer.gender }}</h5>
+
+                </div>
+                <img class="img-responsive thumbnail" src="{{ officer_image }}" alt="Officer face">
+                </div>
+                <br><br><br><br>
+            </div>
+            {% endfor %}
+            </div>
+
+            {% if officers.items|length == 0 %}
+            <div class="container">
+            <h4>Sorry, no officers found in the roster. <a href="/label">Try again</a></h4>
+            </div>
+            {% endif %}
+
+        </div>
+
+</div>
+</div>
+{% endblock %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -57,8 +57,30 @@ def filter_by_form(form, officer_query):
     return officer_query
 
 
+def filter_roster(form, officer_query):
+    if form['name']:
+        officer_query = officer_query.filter(
+            Officer.last_name.ilike('%%{}%%'.format(form['name']))
+            )
+
+    officer_query = officer_query.join(Assignment)
+    if form['badge']:
+        officer_query = officer_query.filter(
+                cast( Assignment.star_no, db.String ) \
+                .like('%%{}%%'.format(form['badge']))
+            )
+
+    officer_query = officer_query.outerjoin(Face).order_by(Face.officer_id.asc()).order_by(Officer.id.desc())
+    return officer_query
+
+
+def roster_lookup(form):
+    return filter_roster(form, Officer.query)
+
+
 def grab_officers(form):
     return filter_by_form(form, Officer.query)
+
 
 def allowed_file(filename):
     return '.' in filename and \


### PR DESCRIPTION
This is a new form for volunteers to use to find the OpenOversight ID of the officers in their images. In order to add new tags we need volunteers to figure out which officers are in there. We have people writing down the badge number / name parts that are visible from the photo but once this is deployed they can directly search through the database to find the officer and just give us the OpenOversight ID so we can add the tag. This feature implements step 2 in #106 (master issue for getting new officer images into the database). Closes #111.