### PR TITLE
Working fabric file

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,29 @@
+from __future__ import with_statement
+from fabric.api import env, local, run, sudo, cd, hosts, get
+from fabric.context_managers import prefix
+import datetime
+
+env.use_ssh_config = False
+
+# Hosts
+# env.hosts list references aliases in ~/.ssh/config or IP address. When using .ssh/config,
+# fab will use the ssh keyfile referenced by the host alias, otherwise need to do what is
+# being done in dev to assign env a key_filename
+def staging():
+    env.hosts=['162.243.156.49']
+    env.user='root'
+    env.host='staging.openoversight'
+
+def production():
+    env.hosts=['45.55.11.175']
+    env.user='root'
+    env.host='openoversight.lucyparsonslabs.com'
+
+def deploy():
+    if env.host=='openoversight.lucyparsonslabs.com':
+        code_dir='/home/nginx/oovirtenv/OpenOversight/OpenOversight'
+    else:
+	code_dir='/home/nginx/oovirtenv/venv/OpenOversight/OpenOversight'
+    with cd(code_dir):
+        sudo("git pull", user="nginx", pty=False)
+        run('sudo systemctl restart openoversight')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy-migrate
 flask-sqlalchemy>=2.1
 nose>=1.3.1
 gunicorn==17.5
+fabric


### PR DESCRIPTION
initial one line deploy for #38 . A couple of caveats, the staging environment was throwing `out: /bin/bash: /root/.bash_profile: Permission denied` which I don't quite understand. but it works!  If @r4v5 or @scuerda have ideas about making it better, let me know. Also, it has not been tested in prod, only because I assume we only want to deploy dot releases. Is that correct @redshiftzero ? 

```
fab staging deploy
Executing task 'deploy'
run: source /home/nginx/.bashrc
sudo: git pull
out: /bin/bash: /root/.bash_profile: Permission denied
out: From https://github.com/lucyparsons/OpenOversight
out:  + bcf9292...818c0d5 onelinefabric -> origin/onelinefabric  (forced update)
out: Already up-to-date.
out: 

[162.243.156.49] run: sudo systemctl restart openoversight

Done.
```