### PR TITLE
Add explicit back buttons to top and bottom of gallery page

### DIFF
--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -9,6 +9,7 @@
                 <h1 class="page-header">Digital Gallery <small>Do you see the officer here?</small></h1>
             </div>
             <div class="container">
+            <a href="/find"><button type="button" class="btn btn-info btn-sm">Go Back to Search</button></a>
             <!--<h3><small>We found</small> {{ officers.rowcount }} <small>matching officers.</small></h3>-->
             {% include 'partials/paginate.html' %}
             {% for officer in officers.items %}
@@ -59,6 +60,7 @@
 <p><b>Officer race</b>: {{ form_data['race'] }}</p>
 <p><b>Officer gender</b>: {{ form_data['gender'] }}</p>
 <p><b>Officer age</b>: {{ form_data['min_age'] }} to {{ form_data['max_age'] }}</p>
+<a href="/find"><button type="button" class="btn btn-info btn-sm">Search Again</button></a>
 
 </div>
 


### PR DESCRIPTION
Adds explicit links back to the search form at the top of the results page and at the bottom under the query details:

![screen shot 2016-12-15 at 6 49 32 pm](https://cloud.githubusercontent.com/assets/7832803/21250085/5dbb5652-c2f7-11e6-823b-55fda3017bcc.png)
![screen shot 2016-12-15 at 6 49 29 pm](https://cloud.githubusercontent.com/assets/7832803/21250088/5fabf566-c2f7-11e6-8729-a1716291616e.png)
