### PR TITLE
Scale officer images

### DIFF
--- a/OpenOversight/app/static/theme.css
+++ b/OpenOversight/app/static/theme.css
@@ -28,11 +28,6 @@ body {
      float:left;
 }
 
-.thumbnail {
-    position:absolute;
-    width:80%;
-    height:80%;
-}
 .thumbnail img {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Small CSS change to close #98, making the images properly scaled: 

![screen shot 2016-12-15 at 6 54 38 pm](https://cloud.githubusercontent.com/assets/7832803/21250237/859c7560-c2f8-11e6-8a22-72d94589607d.png)
