### PR TITLE
Fix run.py to run dev server

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -27,7 +27,7 @@ If you run the app in debug mode, you can see these changes take effect on every
 $ sudo service gunicorn stop
  * Stopping Gunicorn workers
  [oo] *
-vagrant@vagrant-ubuntu-trusty-64:~$ cd /vagrant/
+vagrant@vagrant-ubuntu-trusty-64:~$ cd /vagrant/OpenOversight/
 vagrant@vagrant-ubuntu-trusty-64:/vagrant$ ~/oovirtenv/bin/python ./run.py
  * Running on http://127.0.0.1:3000/ (Press CTRL+C to quit)
  * Restarting with stat

--- a/OpenOversight/run.py
+++ b/OpenOversight/run.py
@@ -1,5 +1,5 @@
 import os
-from OpenOversight.app import create_app, db
+from app import create_app
 config = os.getenv('FLASK_CONFIG') or 'default'
 app = create_app(config)
 app.run(port=3000, host='0.0.0.0')


### PR DESCRIPTION
After #136, run.py was in the wrong location, so this PR moves it and updates the developer documentation (in case people are using `run.py` and not `gunicorn` in the dev environment). 