### PR TITLE
Serve nicely formatted error pages

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from config import config
 
@@ -11,6 +11,18 @@ def create_app(config_name='default'):
 
     from .main import main as main_blueprint
     app.register_blueprint(main_blueprint)
+
+    @app.errorhandler(404)
+    def page_not_found(e):
+        return render_template('404.html'), 404
+
+    @app.errorhandler(403)
+    def forbidden(e):
+        return render_template('403.html'), 403
+
+    @app.errorhandler(500)
+    def internal_error(e):
+        return render_template('500.html'), 500
 
     return app
 

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -48,7 +48,7 @@ class FindOfficerForm(Form):
 		       validators=[AnyOf(allowed_values(RANK_CHOICES))])
     race = SelectField('race', default='WHITE', choices=RACE_CHOICES,
 		       validators=[AnyOf(allowed_values(RACE_CHOICES))])
-    gender = SelectField('gender', default='MALE',
+    gender = SelectField('gender', default='M',
 			 choices=GENDER_CHOICES,
 			 validators=[AnyOf(allowed_values(GENDER_CHOICES))])
     min_age = IntegerField('min_age', default=16, validators=[

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -25,13 +25,12 @@ def get_officer():
 def label_data():
     form = FindOfficerIDForm()
     if form.validate_on_submit():
-        #  flash('[DEBUG] Forms validate correctly')
         return redirect(url_for('main.get_tagger_gallery'), code=307)
     return render_template('label_data.html', form=form)
 
 
-@main.route('/tagger_gallery/<int:page>', methods=['POST'])
-@main.route('/tagger_gallery', methods=['POST'])
+@main.route('/tagger_gallery/<int:page>', methods=['GET', 'POST'])
+@main.route('/tagger_gallery', methods=['GET', 'POST'])
 def get_tagger_gallery(page=1):
     form = FindOfficerIDForm()
     if form.validate_on_submit():
@@ -46,8 +45,8 @@ def get_tagger_gallery(page=1):
         return redirect(url_for('main.label_data'), code=307)
 
 
-@main.route('/gallery/<int:page>', methods=['POST'])
-@main.route('/gallery', methods=['POST'])
+@main.route('/gallery/<int:page>', methods=['GET', 'POST'])
+@main.route('/gallery', methods=['GET','POST'])
 def get_gallery(page=1):
     form = FindOfficerForm()
     if form.validate_on_submit():

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -35,12 +35,12 @@ def get_tagger_gallery(page=1):
     form = FindOfficerIDForm()
     if form.validate_on_submit():
         OFFICERS_PER_PAGE = int(current_app.config['OFFICERS_PER_PAGE'])
-        form_values = form.data
-        officers = roster_lookup(form_values).paginate(page, OFFICERS_PER_PAGE, False)
+        form_data = form.data
+        officers = roster_lookup(form_data).paginate(page, OFFICERS_PER_PAGE, False)
         return render_template('tagger_gallery.html',
                                officers=officers,
                                form=form,
-                               form_data=form_values)
+                               form_data=form_data)
     else:
         return redirect(url_for('main.label_data'), code=307)
 
@@ -51,12 +51,12 @@ def get_gallery(page=1):
     form = FindOfficerForm()
     if form.validate_on_submit():
         OFFICERS_PER_PAGE = int(current_app.config['OFFICERS_PER_PAGE'])
-        form_values = form.data
-        officers = grab_officers(form_values).paginate(page, OFFICERS_PER_PAGE, False)
+        form_data = form.data
+        officers = grab_officers(form_data).paginate(page, OFFICERS_PER_PAGE, False)
         return render_template('gallery.html',
                                officers=officers,
                                form=form,
-                               form_data=form_values)
+                               form_data=form_data)
     else:
         return redirect(url_for('main.get_officer'))
 

--- a/OpenOversight/app/templates/403.html
+++ b/OpenOversight/app/templates/403.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Forbidden{% endblock %}
+
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+<h1>Forbidden</h1>
+<p>You do not have permissions to view this page. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/403.html
+++ b/OpenOversight/app/templates/403.html
@@ -6,7 +6,7 @@
 <div class="container theme-showcase" role="main">
 
 <h1>Forbidden</h1>
-<p>You do not have permissions to view this page. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+<p>You do not have permissions to view this page. <a href="{{ url_for('main.index') }}">Return to homepage</a>.</p>
 
 </div>
 {% endblock %}

--- a/OpenOversight/app/templates/404.html
+++ b/OpenOversight/app/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Page Not Found{% endblock %}
+
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+<h1>Page Not Found</h1>
+<p>We couldn't find the page you are looking for. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/404.html
+++ b/OpenOversight/app/templates/404.html
@@ -6,7 +6,7 @@
 <div class="container theme-showcase" role="main">
 
 <h1>Page Not Found</h1>
-<p>We couldn't find the page you are looking for. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+<p>We couldn't find the page you are looking for. <a href="{{ url_for('main.index') }}">Return to homepage</a>.</p>
 
 </div>
 {% endblock %}

--- a/OpenOversight/app/templates/500.html
+++ b/OpenOversight/app/templates/500.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Internal Server Error{% endblock %}
+
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+<h1>Internal Server Error</h1>
+<p>Oops! Something went wrong. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/500.html
+++ b/OpenOversight/app/templates/500.html
@@ -6,7 +6,7 @@
 <div class="container theme-showcase" role="main">
 
 <h1>Internal Server Error</h1>
-<p>Oops! Something went wrong. <a href="{{ url_for('main.get_tagger_gallery') }}">Return to homepage</a>.</p>
+<p>Oops! Something went wrong. <a href="{{ url_for('main.index') }}">Return to homepage</a>.</p>
 
 </div>
 {% endblock %}

--- a/OpenOversight/app/templates/complaint.html
+++ b/OpenOversight/app/templates/complaint.html
@@ -12,15 +12,15 @@
             <div class="col-xs-12 col-sm-6 col-lg-8">
             <p>Now that you've found the offending officer, it's time to submit a complaint to the relevant oversight body. For complaints regarding Chicago Police Department officers, complaints are accepted through the link below. Clicking below will open a new browser tab where you can copy the officer details from this page into the complaint form when requested.</p>
 
-            
+
             <center><h3>Warning! <small>The following link will open an external site in a new browser tab:</small></h3></p>
-<a href="http://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:2709570244836141" target="_blank"><button type="button" class="btn btn-info btn-lrg">File Complaint Online</button></a></center> 
+<a href="http://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:2709570244836141" target="_blank"><button type="button" class="btn btn-info btn-lrg">File Complaint Online</button></a></center>
             </div>
             <div class="col-xs-6 col-lg-4">
                 <center>
                 <img class="img-responsive" src="{{ officer_image }}" alt="Officer face">
                 </center>
-                <h4>Officer name: {{ officer_first_name.lower()|title }} 
+                <h4>Officer name: {{ officer_first_name.lower()|title }}
                 {% if officer_middle_initial %}{{ officer_middle_initial }}. {% endif %}
                 {{ officer_last_name.lower()|title }} </h4>
                 <h4>Officer badge number: #{{ officer_star }} </h4>

--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -10,7 +10,7 @@
   <div class="row">
   {% for officer in officers.items %}
     {% if officer.face.first() is none %}
-      {% set officer_image = '/static/images/placeholder.png' %}
+      {% set officer_image = 'images/placeholder.png' %}
     {% else %}
       {% set officer_image = officer.face.first().image.filepath %}
     {% endif %}

--- a/OpenOversight/app/templates/partials/paginate.html
+++ b/OpenOversight/app/templates/partials/paginate.html
@@ -1,5 +1,6 @@
 <div class="top-paginate">
     <span class="paginate-navigate">
+
 	{% if officers.has_prev %}
 	    <form action="{{ url_for('main.get_gallery', page=officers.prev_num) }}" method="post">
 		{% include 'partials/officer_form_fields_hidden.html' %}

--- a/OpenOversight/run.py
+++ b/OpenOversight/run.py
@@ -2,4 +2,4 @@ import os
 from app import create_app
 config = os.getenv('FLASK_CONFIG') or 'default'
 app = create_app(config)
-app.run(port=3000, host='0.0.0.0')
+app.run(port=3000, host='0.0.0.0', debug=True)

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -20,9 +20,7 @@ def test_routes_ok(route, client):
 
 
 @pytest.mark.parametrize("route", [
-    ('/gallery'),
-    ('/upload'),
-    ('/tagger_gallery')
+    ('/upload')
 ])
 def test_route_method_not_allowd(route, client):
     rv = client.get(route)


### PR DESCRIPTION
Make error pages nicer for UX wins:

* Adds GET requests to the /*gallery views since a not-very-user-friendly “Method Not Allowed” error appears when a user refreshes a page (we are correctly POSTing the form values, and after validation we are serving a redirect such that the last request the browser sees is a GET).
* Adds nicely formatted error pages for 404, 403 (needed in advance of the upcoming user accounts branch), and 500 errors.
