### PR TITLE
Set placeholder image path in /gallery

### DIFF
--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -10,7 +10,7 @@
   <div class="row">
   {% for officer in officers.items %}
     {% if officer.face.first() is none %}
-      {% set officer_image = 'images/placeholder.png' %}
+      {% set officer_image = '/static/images/placeholder.png' %}
     {% else %}
       {% set officer_image = officer.face.first().image.filepath %}
     {% endif %}


### PR DESCRIPTION
The placeholder image is working on prod for the `/tagger_gallery`:

<img width="920" alt="screen shot 2016-12-23 at 8 57 08 pm" src="https://cloud.githubusercontent.com/assets/7832803/21465316/ad992896-c952-11e6-9f5f-36e846a3e492.png">

However the path is broken for `/gallery`. This commit fixes the placeholder image in the `/gallery` route. @freddymartinez9 go ahead and deploy to staging, if all looks good we can deploy to prod. 