### PR TITLE
Photo submissions to S3

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -33,8 +33,8 @@ class BaseConfig(object):
     # AWS Settings
     AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
-    AWS_DEFAULT_REGION = 'us-west-2'
-    S3_BUCKET_NAME = 'openoversight'
+    AWS_DEFAULT_REGION = os.environ.get('AWS_DEFAULT_REGION')
+    S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME')
 
     # Upload Settings
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -13,10 +13,6 @@ class BaseConfig(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 
-    # File Upload Settings
-    UNLABELLED_UPLOADS = 'uploads/'
-    ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'mpeg', 'mp4'])
-
     # pagination
     OFFICERS_PER_PAGE = os.environ.get('OFFICERS_PER_PAGE', 20)
 
@@ -33,6 +29,15 @@ class BaseConfig(object):
     OO_MAIL_SUBJECT_PREFIX = '[OpenOversight]'
     OO_MAIL_SENDER = 'OpenOversight <OpenOversight@gmail.com>'
     # OO_ADMIN = os.environ.get('OO_ADMIN')
+
+    # AWS Settings
+    AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
+    AWS_DEFAULT_REGION = 'us-west-2'
+    S3_BUCKET_NAME = 'openoversight'
+
+    # Upload Settings
+    MAX_CONTENT_LENGTH = 16 * 1024 * 1024
 
     SEED = 666
 

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -1,9 +1,9 @@
 from flask_wtf import FlaskForm as Form
 from wtforms import (StringField, BooleanField, DecimalField,
-		     SelectField, IntegerField, FileField)
+		     SelectField, IntegerField, SubmitField)
 from wtforms.validators import (DataRequired, AnyOf, NumberRange, Regexp,
 				Length, Optional)
-from flask_wtf.file import FileAllowed
+from flask_wtf.file import FileField, FileAllowed, FileRequired
 
 
 # Choices are a list of (value, label) tuples
@@ -26,11 +26,10 @@ def allowed_values(choices):
 
 
 class HumintContribution(Form):
-    photo = FileField('image', validators=[
-	DataRequired(),
-	FileAllowed(['png', 'jpg', 'jpeg', 'mpg', 'mpeg', 'mp4', 'mov'],
-		    'Images and movies only!')
-    ])
+    photo = FileField('image', validators=[FileRequired(message='There was no file!'),
+	                                       FileAllowed(['png', 'jpg', 'jpeg'],
+		                                                message='Images only!')])
+    submit = SubmitField(label='Upload')
 
 
 class FindOfficerForm(Form):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -108,20 +108,19 @@ def submit_data():
             try:
                  url = upload_file(safe_local_path, original_filename,
                                    new_filename)
+                 # Update the database to add the image
+                 new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
+                                   date_image_inserted=datetime.datetime.now(),
+                                   # TODO: Get the following field from exif data
+                                   date_image_taken=datetime.datetime.now())
+                 db.session.add(new_image)
+                 db.session.commit()
+
+                 flash('File {} successfully uploaded!'.format(original_filename))
             except:
                 flash("Your file could not be uploaded at this time due to a server problem. Please retry again later.")
             os.remove(safe_local_path)
             os.rmdir(tmpdir)
-
-            # Update the database to add the image
-            new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
-                              date_image_inserted=datetime.datetime.now(),
-                              # TODO: Get the following field from exif data
-                              date_image_taken=datetime.datetime.now())
-            db.session.add(new_image)
-            db.session.commit()
-
-            flash('File {} successfully uploaded!'.format(original_filename))
         else:
             flash('This photograph has already been uploaded to OpenOversight.')
     elif request.method == 'POST':

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -7,7 +7,7 @@ from flask_login import (LoginManager, login_user, logout_user,
 from werkzeug import secure_filename
 
 from . import main
-from ..utils import grab_officers, roster_lookup, upload_file, hash_file
+from ..utils import grab_officers, roster_lookup, upload_file, compute_hash
 from .forms import FindOfficerForm, FindOfficerIDForm, HumintContribution
 from ..models import db, Image
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -105,7 +105,11 @@ def submit_data():
             os.umask(SAVED_UMASK)
 
             # Upload file from local filesystem to S3 bucket and delete locally
-            url = upload_file(safe_local_path, original_filename, new_filename)
+            try:
+                 url = upload_file(safe_local_path, original_filename,
+                                   new_filename)
+            except:
+                flash("Your file could not be uploaded at this time due to a server problem. Please retry again later.")
             os.remove(safe_local_path)
             os.rmdir(tmpdir)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -6,8 +6,8 @@ from flask_login import (LoginManager, login_user, logout_user,
 from werkzeug import secure_filename
 
 from . import main
-from ..utils import allowed_file, grab_officers, roster_lookup
-from .forms import FindOfficerForm, FindOfficerIDForm
+from ..utils import allowed_file, grab_officers, roster_lookup, upload_file
+from .forms import FindOfficerForm, FindOfficerIDForm, HumintContribution
 
 
 @main.route('/')
@@ -76,24 +76,11 @@ def submit_complaint():
 
 @main.route('/submit')
 def submit_data():
-    return render_template('submit.html')
-
-
-@main.route('/upload', methods=['POST'])
-def upload_file():
-    file = request.files['file']
-    if file and allowed_file(file.filename):
-        filename = secure_filename(file.filename)
-        file.save(os.path.join(current_app.config['UNLABELLED_UPLOADS'], filename))
-        return redirect(url_for('main.show_upload',
-                                filename=filename))
-
-
-@main.route('/show_upload/<filename>')
-def show_upload(filename):
-    # return send_from_directory('../'+config.UNLABELLED_UPLOADS,
-    #                           filename)
-    return 'Successfully uploaded: {}'.format(filename)
+    form = HumintContribution()
+    if form.validate_on_submit():
+        upload_file()  # No arg needed because it is stored in the request
+        flash('File successfully uploaded!')
+    return render_template('submit.html', form=form)
 
 
 @main.route('/about')

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -90,7 +90,9 @@ def submit_data():
 
         if not hash_found:
             open(os.path.join('/tmp', filename), 'w').write(image_data)
-            url = upload_file(filename)
+            file_extension = filename.split('.')[-1]
+            url = upload_file(filename, '{}.{}'.format(hash_img,
+                                                       file_extension))
 
             new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
                               date_image_inserted=datetime.datetime.now(),

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -50,7 +50,11 @@
           <ul class="nav navbar-nav">
             <li><a href="/">Home</a></li>
             <li><a href="/find">Find an Officer</a></li>
-            <li><a href="https://script.google.com/macros/s/AKfycbyNg7oVOPSFBHZkncDn7Z23qbJFWQZM1QXcEE0TO2Txa6wB8tU/exec">Submit Images</a></li>
+            {% if current_user and current_user.is_authenticated %}
+                 <li><a href="/submit">Submit Images</a></li>
+            {% else %}
+                 <li><a href="https://script.google.com/macros/s/AKfycbyNg7oVOPSFBHZkncDn7Z23qbJFWQZM1QXcEE0TO2Txa6wB8tU/exec">Submit Images</a></li>
+            {% endif %}
             <li><a href="/label">Get Involved</a></li>
             <li><a href="/about">About</a></li>
             <li><a href="/contact">Contact</a></li>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -25,7 +25,11 @@
         <h1>Contribute Images or Get Involved</h1>
       </div>
       <p>
-        <a href="https://script.google.com/macros/s/AKfycbyNg7oVOPSFBHZkncDn7Z23qbJFWQZM1QXcEE0TO2Txa6wB8tU/exec">
+        {% if current_user and current_user.is_authenticated %}
+            <a href="/submit">
+        {% else %}
+            <a href="https://script.google.com/macros/s/AKfycbyNg7oVOPSFBHZkncDn7Z23qbJFWQZM1QXcEE0TO2Txa6wB8tU/exec">
+        {% endif %}
             <button type="button" class="btn btn-lg btn-primary">Submit Images</button></a>
       </p>
       <p>

--- a/OpenOversight/app/templates/submit.html
+++ b/OpenOversight/app/templates/submit.html
@@ -3,7 +3,7 @@
 
 <div class="container theme-showcase" role="main">
    <div class="page-header">
-        <h1>Submit Images/Videos <small>containing faces/badge numbers of uniformed police officers</small></h1>
+        <h1>Submit Image <small>containing faces/badge numbers of uniformed police officers</small></h1>
    </div>
 
    <div class="input-group input-group-lg">

--- a/OpenOversight/app/templates/submit.html
+++ b/OpenOversight/app/templates/submit.html
@@ -1,18 +1,29 @@
 {% extends "base.html" %}
+<!--{% import "bootstrap/wtf.html" as wtf %}-->
 {% block content %}
 
 <div class="container theme-showcase" role="main">
    <div class="page-header">
         <h1>Submit Image <small>containing faces/badge numbers of uniformed police officers</small></h1>
    </div>
-
    <div class="input-group input-group-lg">
-   <form action="upload" method="post" enctype="multipart/form-data">
+   <form action="submit" method="post" enctype="multipart/form-data">
      {{ form.hidden_tag() }}
-     <input type="file" name="file"><br><br>
-     <input type="submit" value="Upload">
+     <label class="control-label">Select a photograph containing a picture of the face of 1 or more police officers with their badge number and/or name clearly displayed.</label>
+     {{ form.photo }}
+
+     <script>
+     $(document).ready(function(){
+        $("#user-notification").on("click", function(){
+           $("#loader").show();
+        });
+     });
+     </script>
+
+     <input type="submit" class="btn btn-primary"  value="Go!" id="user-notification" /> <img id="loader" style="display:none;" src="{{url_for('static', filename='images/page-loader.gif')}}">
    </form>
-   </div>
+ </div>
+ <!--{{ wtf.quick_form(form) }}-->
 
 </div>
 

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -15,7 +15,7 @@ def compute_hash(data_to_hash):
 
 def upload_file(src_filename, dest_filename):
     s3_client = boto3.client('s3')
-    s3_client.upload_file('/tmp/{}'.format(src_filename),
+    s3_client.upload_file('/tmp/{}'.format(dest_filename),
                           current_app.config['S3_BUCKET_NAME'],
                           dest_filename,
                           ExtraArgs={'ACL': 'public-read'})

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -9,8 +9,8 @@ from sqlalchemy.sql.expression import cast
 from .models import db, Officer, Assignment, Image, Face
 
 
-def hash_file(file_to_hash):
-    return hashlib.sha256(file_to_hash).hexdigest()
+def compute_hash(data_to_hash):
+    return hashlib.sha256(data_to_hash).hexdigest()
 
 
 def upload_file(src_filename, dest_filename):

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -4,6 +4,7 @@ import datetime
 from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
 import hashlib
+import os
 from sqlalchemy import desc, asc, func
 from sqlalchemy.sql.expression import cast
 from .models import db, Officer, Assignment, Image, Face
@@ -20,14 +21,14 @@ def generate_s3_url(dest_filename):
     return url
 
 
-def upload_file(src_filename, dest_filename):
+def upload_file(safe_local_path, src_filename, dest_filename):
     s3_client = boto3.client('s3')
 
     # Folder to store files in on S3 is first two chars of dest_filename
     s3_folder = dest_filename[0:2]
     s3_filename = dest_filename[2:]
     s3_path = '{}/{}'.format(s3_folder, s3_filename)
-    s3_client.upload_file('/tmp/{}'.format(dest_filename),
+    s3_client.upload_file(safe_local_path,
                           current_app.config['S3_BUCKET_NAME'],
                           s3_path,
                           ExtraArgs={'ACL': 'public-read'})

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -14,13 +14,6 @@ def compute_hash(data_to_hash):
     return hashlib.sha256(data_to_hash).hexdigest()
 
 
-def generate_s3_url(dest_filename):
-    url = "https://s3-{}.amazonaws.com/{}/{}".format(
-                   current_app.config['AWS_DEFAULT_REGION'],
-                   current_app.config['S3_BUCKET_NAME'], dest_filename)
-    return url
-
-
 def upload_file(safe_local_path, src_filename, dest_filename):
     s3_client = boto3.client('s3')
 
@@ -33,7 +26,11 @@ def upload_file(safe_local_path, src_filename, dest_filename):
                           s3_path,
                           ExtraArgs={'ACL': 'public-read'})
 
-    return generate_s3_url(s3_path)
+    url = "https://s3-{}.amazonaws.com/{}/{}".format(
+                   current_app.config['AWS_DEFAULT_REGION'],
+                   current_app.config['S3_BUCKET_NAME'], s3_path)
+
+    return url
 
 
 def filter_by_form(form, officer_query):

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -13,9 +13,9 @@ def hash_file(file_to_hash):
     return hashlib.sha256(file_to_hash).hexdigest()
 
 
-def upload_file(dest_filename):
+def upload_file(src_filename, dest_filename):
     s3_client = boto3.client('s3')
-    s3_client.upload_file('/tmp/{}'.format(dest_filename),
+    s3_client.upload_file('/tmp/{}'.format(src_filename),
                           current_app.config['S3_BUCKET_NAME'],
                           dest_filename,
                           ExtraArgs={'ACL': 'public-read'})

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -7,6 +7,14 @@ from sqlalchemy.sql.expression import cast
 from .models import db, Officer, Assignment, Image, Face
 import pdb
 
+
+def upload_file():
+    file = request.files['file']
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        file.save(os.path.join(current_app.config['UNLABELLED_UPLOADS'], filename))
+
+
 def filter_by_form(form, officer_query):
     if form['name']:
         officer_query = officer_query.filter(

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -13,17 +13,26 @@ def compute_hash(data_to_hash):
     return hashlib.sha256(data_to_hash).hexdigest()
 
 
+def generate_s3_url(dest_filename):
+    url = "https://s3-{}.amazonaws.com/{}/{}".format(
+                   current_app.config['AWS_DEFAULT_REGION'],
+                   current_app.config['S3_BUCKET_NAME'], dest_filename)
+    return url
+
+
 def upload_file(src_filename, dest_filename):
     s3_client = boto3.client('s3')
+
+    # Folder to store files in on S3 is first two chars of dest_filename
+    s3_folder = dest_filename[0:2]
+    s3_filename = dest_filename[2:]
+    s3_path = '{}/{}'.format(s3_folder, s3_filename)
     s3_client.upload_file('/tmp/{}'.format(dest_filename),
                           current_app.config['S3_BUCKET_NAME'],
-                          dest_filename,
+                          s3_path,
                           ExtraArgs={'ACL': 'public-read'})
 
-    url = "https://s3-{}.amazonaws.com/{}/{}".format(
-               current_app.config['AWS_DEFAULT_REGION'],
-               current_app.config['S3_BUCKET_NAME'], dest_filename)
-    return url
+    return generate_s3_url(s3_path)
 
 
 def filter_by_form(form, officer_query):

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -148,7 +148,8 @@ def mockdata(session, request):
 
     test_user = models.User(email='jen@example.org',
                             username='test_user',
-                            password='dog')
+                            password='dog',
+                            confirmed=True)
     session.add(test_user)
     session.commit()
     return assignments[0].star_no

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -66,7 +66,8 @@ def build_assignment(officer, unit):
 
 def assign_faces(officer, images):
     if random.uniform(0, 1) >= 0.5:
-        return models.Face(officer_id=officer.id, img_id=random.choice(images).id)
+        return models.Face(officer_id=officer.id,
+                           img_id=random.choice(images).id)
     else:
         return False
 
@@ -114,6 +115,10 @@ def session(db, request):
         connection.close()
         session.remove()
 
+        # Cleanup users table
+        models.User.query.delete()
+        session.commit()
+
     request.addfinalizer(teardown)
     return session
 
@@ -140,6 +145,11 @@ def mockdata(session, request):
     session.add_all(officers)
     session.add_all(assignments)
     session.add_all(faces)
+
+    test_user = models.User(email='jen@example.org',
+                            username='test_user',
+                            password='dog')
+    session.add(test_user)
     session.commit()
     return assignments[0].star_no
 

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -15,7 +15,8 @@ from urlparse import urlparse
     ('/label'),
     ('/auth/login'),
     ('/auth/register'),
-    ('/auth/reset')
+    ('/auth/reset'),
+    ('/complaint?officer_star=1901&officer_first_name=HUGH&officer_last_name=BUTZ&officer_middle_initial=&officer_image=static%2Fimages%2Ftest_cop2.png')
 ])
 def test_routes_ok(route, client):
     rv = client.get(route)
@@ -24,6 +25,7 @@ def test_routes_ok(route, client):
 
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route", [
+    ('/submit'),
     ('/auth/unconfirmed'),
     ('/auth/logout'),
     ('/auth/confirm/abcd1234'),

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -107,11 +107,12 @@ def login_user(client):
         data=form.data,
         follow_redirects=False
         )
+    return rv
 
 
 def test_valid_user_can_login(mockdata, client, session):
     with current_app.test_request_context():
-        login_user(client)
+        rv = login_user(client)
         assert rv.status_code == 302
         assert urlparse(rv.location).path == '/index'
 
@@ -126,6 +127,17 @@ def test_invalid_user_cannot_login(mockdata, client, session):
             data=form.data
             )
         assert 'Invalid username or password.' in rv.data
+
+
+def test_user_can_logout(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+
+        rv = client.get(
+            url_for('auth.logout'),
+            follow_redirects=True
+            )
+        assert 'You have been logged out.' in rv.data
 
 
 def test_user_cannot_submit_invalid_file_extension(mockdata, client, session):

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -98,16 +98,20 @@ def test_tagger_gallery_bad_form(client, session):
         assert urlparse(rv.location).path == '/label'
 
 
+def login_user(client):
+    form = LoginForm(email='jen@example.org',
+                     password='dog',
+                     remember_me=True)
+    rv = client.post(
+        url_for('auth.login'),
+        data=form.data,
+        follow_redirects=False
+        )
+
+
 def test_valid_user_can_login(mockdata, client, session):
     with current_app.test_request_context():
-        form = LoginForm(email='jen@example.org',
-                         password='dog',
-                         remember_me=True)
-        rv = client.post(
-            url_for('auth.login'),
-            data=form.data,
-            follow_redirects=False
-            )
+        login_user(client)
         assert rv.status_code == 302
         assert urlparse(rv.location).path == '/index'
 
@@ -122,17 +126,6 @@ def test_invalid_user_cannot_login(mockdata, client, session):
             data=form.data
             )
         assert 'Invalid username or password.' in rv.data
-
-
-def login_user(client):
-    form = LoginForm(email='jen@example.org',
-                     password='dog',
-                     remember_me=True)
-    rv = client.post(
-        url_for('auth.login'),
-        data=form.data,
-        follow_redirects=False
-        )
 
 
 def test_user_cannot_submit_invalid_file_extension(mockdata, client, session):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -1,3 +1,5 @@
+from mock import patch, Mock
+
 import OpenOversight
 
 
@@ -57,3 +59,15 @@ def test_compute_hash(mockdata):
     hash_result = OpenOversight.app.utils.compute_hash('bacon')
     expected_hash = '9cca0703342e24806a9f64e08c053dca7f2cd90f10529af8ea872afb0a0c77d4'
     assert hash_result == expected_hash
+
+
+def test_s3_url(mockdata):
+    local_path = 'OpenOversight/app/static/images/test_cop1.png'
+
+    mocked_connection = Mock()
+    with patch('boto3.client', Mock(return_value=mocked_connection)):
+        url = OpenOversight.app.utils.upload_file(local_path, 'doesntmatter.png',
+                                                  'test_cop1.png')
+    assert 'https' in url
+    # url should show folder structure with first two chars as folder name
+    assert 'te/st' in url

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_filter_by_badge_no(mockdata):
         assert '12' in str(assignment.star_no)
 
 
-def test_hash_file(mockdata):
-    hash_result = OpenOversight.app.utils.hash_file('bacon')
+def test_compute_hash(mockdata):
+    hash_result = OpenOversight.app.utils.compute_hash('bacon')
     expected_hash = '9cca0703342e24806a9f64e08c053dca7f2cd90f10529af8ea872afb0a0c77d4'
     assert hash_result == expected_hash

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -51,15 +51,3 @@ def test_filter_by_badge_no(mockdata):
     for element in results:
         assignment = element.assignments.first()
         assert '12' in str(assignment.star_no)
-
-
-def test_allowed_filenames(app):
-    extension = ['png', 'jpg', 'jpeg', 'mpeg', 'mp4']
-    for e in extension:
-        test_filename = 'test.{}'.format(e)
-	assert OpenOversight.app.utils.allowed_file(test_filename) == True
-
-
-def test_not_allowed_filenames(app):
-    test_filename = 'test.gif'
-    assert OpenOversight.app.utils.allowed_file(test_filename) == False

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -51,3 +51,9 @@ def test_filter_by_badge_no(mockdata):
     for element in results:
         assignment = element.assignments.first()
         assert '12' in str(assignment.star_no)
+
+
+def test_hash_file(mockdata):
+    hash_result = OpenOversight.app.utils.hash_file('bacon')
+    expected_hash = '9cca0703342e24806a9f64e08c053dca7f2cd90f10529af8ea872afb0a0c77d4'
+    assert hash_result == expected_hash

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ faker==0.7.3
 pytest-cov==2.4.0
 pytest-pep8==1.0.6
 xvfbwrapper
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=0.11.1
 python-dotenv
+mock
 boto3
 werkzeug>=0.11.1
 Flask-WTF>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 flask>=0.11.1
 python-dotenv
-mock
 boto3
 werkzeug>=0.11.1
 Flask-WTF>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask>=0.11.1
 python-dotenv
+boto3
 werkzeug>=0.11.1
 Flask-WTF>=0.13.1
 Flask-Login

--- a/test_data.py
+++ b/test_data.py
@@ -115,6 +115,13 @@ def populate():
     db.session.add_all(faces)
     db.session.commit()
 
+    test_user = models.User(email='test@example.org',
+                            username='test_user',
+                            password='testtest',
+                            confirmed=True)
+    db.session.add(test_user)
+    db.session.commit()
+
 
 def cleanup():
     """ Cleanup database"""
@@ -135,6 +142,9 @@ def cleanup():
     for face in faces:
         db.session.delete(face)
 
+    users = models.User.query.all()
+    for user in users:
+        db.session.delete(user)
     # TODO: Reset primary keys on all these tables
     db.session.commit()
 


### PR DESCRIPTION
This PR closes issue #5, to implement in-app photo uploads to S3. 

Submission route `/submit` is now available to logged in users of the application:

<img width="1012" alt="screen shot 2017-01-03 at 12 53 03 am" src="https://cloud.githubusercontent.com/assets/7832803/21597791/bbc9c384-d150-11e6-9d5d-4f27455c8d56.png">

Anonymous users will continue to use the Google Drive submission. However, once #90 (sanitize images (both to handle potentially malicious uploads and to remove metadata)) and #148 (privacy-respecting captcha on this form) are implemented then we can remove the login required decorator from this view and deprecate the Google drive submission form. 

Details:
* Uploads are limited in size and in file type (to images).
* Images are uploaded first to `/tmp` and then to the S3 bucket for OpenOversight. We should eventually have the S3 upload and deletion of the file from `/tmp` be a celery task. The first part (saving to `/tmp`) is quite fast
* A row is inserted in the images table with the date of upload, the hash of the image, the path to the image on S3.
* We disallow the upload of duplicate images in the form by first checking that there is not a matching hash already in the images table in the database. 

After we deploy this, we can go in and upload the non-troll pics from Google drive and the useful pics from our social media scrape to S3 using this form. Troll harder CPD
