### PR TITLE
Speed up unit tests

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -53,11 +53,9 @@ or
 
 ## Running Unit Tests
 
- Run tests with `nose`:
+ Run tests with `pytest`:
 
-```~/oovirtenv/bin/python ~/oovirtenv/bin/nosetests```
-
-Note: One could put `test_data.populate()` into `setUp` and `test_data.cleanup()` into `tearDown` but in this case we want the data to stay in the database so that we can play with the web application so we should just have vagrant run that during the provisioning of the development VM.
+```~/oovirtenv/bin/pytest```
 
 ## Migrating the Database
 

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -34,7 +34,6 @@ class BaseConfig(object):
     OO_MAIL_SENDER = 'OpenOversight <OpenOversight@gmail.com>'
     # OO_ADMIN = os.environ.get('OO_ADMIN')
 
-    NUM_OFFICERS = 15000
     SEED = 666
 
     @staticmethod
@@ -45,12 +44,14 @@ class BaseConfig(object):
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
+    NUM_OFFICERS = 15000
 
 
 class TestingConfig(BaseConfig):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     WTF_CSRF_ENABLED = False
+    NUM_OFFICERS = 120
 
 
 class ProductionConfig(BaseConfig):


### PR DESCRIPTION
Tests were taking a while because we were using a realistic number of officers (if we use all ~15k officers Travis builds time out), so I've made that variable config-specific. We use a realistic number of officers for the development config and a small set of officers for the unit tests and Travis config. 

Also updated the instructions in `CONTRIB.md` to instruct people how to use `pytest` as the unit test runner.