### PR TITLE
Prettify pagination

### DIFF
--- a/OpenOversight/app/templates/partials/paginate.html
+++ b/OpenOversight/app/templates/partials/paginate.html
@@ -1,21 +1,20 @@
 <div class="top-paginate">
-    <span class="paginate-navigate">
 
 	{% if officers.has_prev %}
 	    <form action="{{ url_for('main.get_gallery', page=officers.prev_num) }}" method="post">
 		{% include 'partials/officer_form_fields_hidden.html' %}
-		<input type="submit" value="<< " />
+		<input type="submit" class="btn btn-info btn-md" value=" << " />
 	    </form>
 	{% endif %}
+  {% if officers.total > 0 %}
+  Page {{ officers.page }} of {{ officers.pages }}
+  {% endif %}
 	{% if officers.has_next %}
 	    <form action="{{ url_for('main.get_gallery', page=officers.next_num) }}" method="post">
 		{% include 'partials/officer_form_fields_hidden.html' %}
-		<input type="submit" value=">> " />
+		<input type="submit" class="btn btn-info btn-md" value=" >> " />
 	    </form>
 	{% endif %}
-    </span>
-    {% if officers.total > 0 %}
-    <span class="paginate-info">Page {{ officers.page }} of {{ officers.pages }}</span>
-    {% endif %}
+
 </div>
 <!-- /.top-paginate -->

--- a/OpenOversight/app/templates/partials/roster_paginate.html
+++ b/OpenOversight/app/templates/partials/roster_paginate.html
@@ -1,20 +1,19 @@
 <div class="top-paginate">
-    <span class="paginate-navigate">
+
 	{% if officers.has_prev %}
 	    <form action="{{ url_for('main.get_tagger_gallery', page=officers.prev_num) }}" method="post">
 		{% include 'partials/roster_form_fields.html' %}
-		<input type="submit" value="<< " />
+		<input type="submit" class="btn btn-info btn-md" value=" << " />
 	    </form>
 	{% endif %}
+  {% if officers.total > 0 %}
+  Page {{ officers.page }} of {{ officers.pages }}
+  {% endif %}
 	{% if officers.has_next %}
 	    <form action="{{ url_for('main.get_tagger_gallery', page=officers.next_num) }}" method="post">
 		{% include 'partials/roster_form_fields.html' %}
-		<input type="submit" value=">> " />
+		<input type="submit" class="btn btn-info btn-md" value=" >> " />
 	    </form>
 	{% endif %}
-    </span>
-    {% if officers.total > 0 %}
-    <span class="paginate-info">Page {{ officers.page }} of {{ officers.pages }}</span>
-    {% endif %}
+
 </div>
-<!-- /.top-paginate -->


### PR DESCRIPTION
Use bootstrap icons for pagination navigation

Before:
<img width="311" alt="screen shot 2017-01-03 at 6 11 00 am" src="https://cloud.githubusercontent.com/assets/7832803/21600469/1ca14156-d17d-11e6-8490-fb00b07398e5.png">

After:
<img width="357" alt="screen shot 2017-01-03 at 6 19 59 am" src="https://cloud.githubusercontent.com/assets/7832803/21600472/20f41e5e-d17d-11e6-98db-38762538d587.png">
