### PR TITLE
Add basic Dockerfile for the webapp

### DIFF
--- a/DOCKER_DEPLOY.md
+++ b/DOCKER_DEPLOY.md
@@ -1,0 +1,31 @@
+# Deployment with Docker
+
+The included Dockerfile can be used to build a Docker image for the web
+application. You will still need to set up the database manually.
+
+The image can be built as normal:
+```sh
+docker build -t openoversight .
+```
+
+When running the container, you will need to provide values for the
+`SQLALCHEMY_DATABASE_URI` and `SECRET_KEY` environment variables. The database
+URI should contain the user, password, server, and database needed to connect
+to the application, and `SECRET_KEY` should include a random string that's at
+least 16 characters long.
+
+If you're running Docker standalone, you can use a command similar to the
+following:
+```sh
+docker run --rm \
+    -e SQLALCHEMY_DATABASE_URI=postgresql://openoversight:hunter2@192.0.2.15/openoversight \
+    -e SECRET_KEY=4Q6ZaQQdiqtmvZaxP1If \
+    openoversight
+```
+
+Once you get the container running, you can use the included script to create
+the necessary database schema. You'll need to replace the container ID, which
+can be obtained from `docker ps`, in the following example:
+```sh
+docker exec -it CONTAINER_ID python /usr/src/app/create_db.py
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY OpenOversight /usr/src/app/OpenOversight/
 COPY create_db.py test_data.py /usr/src/app/
 
+# create a blank .env file to avoid warnings
+RUN touch /usr/src/app/OpenOversight/.env
+
 WORKDIR /usr/src/app/OpenOversight
 EXPOSE 8080
 USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:2
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY OpenOversight /usr/src/app/OpenOversight/
+COPY create_db.py test_data.py /usr/src/app/
+
+WORKDIR /usr/src/app/OpenOversight
+EXPOSE 8080
+USER www-data
+
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8080", "--timeout", "90", "app:app"]


### PR DESCRIPTION
This Dockerfile can be used for a containerized deployment with Kubernetes or similar platforms. It doesn't currently do any database setup, but DOCKER_DEPLOY.md provides instructions on how to do this manually.