### PR TITLE
State-changing routes on /sort are POST only

### DIFF
--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -30,11 +30,19 @@
           </div>
           <div class="col-md-6">
             <h3>Do you see at least one face of a police officer with a badge number or name visible on their uniform?</h3>
-            <p><a href="{{ url_for('main.classify_submission', image_id=image.id, contains_cops=0) }}"
-                  class="btn btn-lg btn-primary" role="button">No police officers with badge numbers or names are visible</a></p>
-            <p><a href="{{ url_for('main.classify_submission', image_id=image.id, contains_cops=1) }}"
-                  class="btn btn-lg btn-primary" role="button">Police officers are clearly
-                  visible with badge numbers or names</a></p>
+
+            <p><form action="{{ url_for('main.classify_submission', image_id=image.id, contains_cops=0) }}" method="post">
+              <button type="submit" name="action" class="btn btn-lg btn-primary">
+                No police officers with badge numbers or names are visible
+              </button>
+            </form></p>
+
+            <p><form action="{{ url_for('main.classify_submission', image_id=image.id, contains_cops=1) }}" method="post">
+              <button type="submit" name="action" class="btn btn-lg btn-primary">
+                Police officers are clearly visible with badge numbers or names
+              </button>
+            </form></p>
+
           </div>
         </div>
       {% elif current_user.is_disabled == True %}


### PR DESCRIPTION
Forgot to modify the buttons on `/sort` to be POST only during #169. Definitely need to write functional tests to catch stuff like this (appended to my ever increasing to do list)