### PR TITLE
Update unit tests for user registration

### DIFF
--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -345,6 +345,21 @@ def test_user_can_register_with_legit_credentials(mockdata, client, session):
         assert 'A confirmation email has been sent to you by email.' in rv.data
 
 
+def test_user_cannot_register_with_weak_password(mockdata, client, session):
+    with current_app.test_request_context():
+        form = RegistrationForm(email='jen@example.com',
+                                username='redshiftzero',
+                                password='weak',
+                                password2='weak')
+        rv = client.post(
+            url_for('auth.register'),
+            data=form.data,
+            follow_redirects=True
+            )
+
+        assert 'A confirmation email has been sent to you by email.' not in rv.data
+
+
 def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -331,10 +331,11 @@ def test_user_cannot_register_if_passwords_dont_match(mockdata, client, session)
 
 def test_user_can_register_with_legit_credentials(mockdata, client, session):
     with current_app.test_request_context():
+        diceware_password = 'operative hamster perservere verbalize curling'
         form = RegistrationForm(email='jen@example.com',
                                 username='redshiftzero',
-                                password='dog',
-                                password2='dog')
+                                password=diceware_password,
+                                password2=diceware_password)
         rv = client.post(
             url_for('auth.register'),
             data=form.data,


### PR DESCRIPTION
Updates unit tests for user registration to:

* use a strong password in the user registration with legit credentials unit test
* add a unit test to verify that users with a weak password cannot register