### PR TITLE
Add exception handling for when a user tries to insert duplicate tags

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -6,6 +6,7 @@ from flask_login import (LoginManager, login_user, logout_user,
                          current_user, login_required)
 from functools import wraps
 import re
+from sqlalchemy.exc import IntegrityError
 import tempfile
 from werkzeug import secure_filename
 
@@ -195,9 +196,11 @@ def label_data(image_id=None):
                            face_height=form.dataHeight.data,
                            user_id=current_user.id)
             db.session.add(new_tag)
+            db.session.commit()
             flash('Tag added to database')
-        except:
-            flash('Unknown error occured, tag not added to database.')
+        except IntegrityError:
+            db.session.rollback()
+            flash('Tag already exists between this officer and image! Tag not added.')
     return render_template('cop_face.html', form=form,
                            image=image, path=proper_path)
 

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -11,7 +11,7 @@ from OpenOversight.app.auth.forms import (LoginForm, RegistrationForm,
                                           ChangePasswordForm, PasswordResetForm,
                                           PasswordResetRequestForm,
                                           ChangeEmailForm)
-from OpenOversight.app.models import User
+from OpenOversight.app.models import User, Face
 
 
 @pytest.mark.parametrize("route", [
@@ -271,6 +271,25 @@ def test_user_can_add_tag(mockdata, client, session):
             follow_redirects=True
             )
         assert 'Tag added to database' in rv.data
+
+
+def test_user_cannot_add_tag_if_it_exists(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+        tag = Face.query.first()
+        form = FaceTag(officer_id=tag.officer_id,
+                       image_id=tag.img_id,
+                       dataX=34,
+                       dataY=32,
+                       dataWidth=3,
+                       dataHeight=33)
+
+        rv = client.post(
+            url_for('main.label_data', image_id=tag.img_id),
+            data=form.data,
+            follow_redirects=True
+            )
+        assert 'Tag already exists between this officer and image! Tag not added.' in rv.data
 
 
 def test_user_can_finish_tagging(mockdata, client, session):


### PR DESCRIPTION
A user trying to insert duplicate tags can run into an IntegrityError:

```
IntegrityError: (psycopg2.IntegrityError) duplicate key value violates unique constraint 
"unique_faces"
DETAIL:  Key (officer_id, img_id)=(2, 1) already exists.
```

This PR adds exception handling for this situation, by rolling back the database transaction and flashing a message to the user letting them know the tag already exists (so they can try again):

<img width="635" alt="screen shot 2017-02-13 at 5 53 30 pm" src="https://cloud.githubusercontent.com/assets/7832803/22916946/b7ccb8f2-f236-11e6-884c-e18ad8091ef9.png">

This PR also adds a unit test for the case when a user tries to insert a duplicate tag. 