### PR TITLE
Fix filepath field length

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -64,16 +64,16 @@ In addition to running the development server, `manage.py` (OpenOversight's mana
 ```
 (oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py
 usage: manage.py [-?]
-                 {shell,downgrade_db,runserver,upgrade_db,migrate_db,make_admin_user}
+                 {shell,makemigrations,migrate,downgrade_db,runserver,make_admin_user}
                  ...
 
 positional arguments:
-  {shell,downgrade_db,runserver,upgrade_db,migrate_db,make_admin_user}
+  {shell,makemigrations,migrate,downgrade_db,runserver,make_admin_user}
     shell               Runs a Python shell inside Flask application context.
+    makemigrations      Make database migrations
+    migrate             Migrate/upgrade the database
     downgrade_db        Downgrade the database
     runserver           Runs the Flask development server i.e. app.run()
-    upgrade_db          Upgrade the database
-    migrate_db          Migrate the database
     make_admin_user     Add confirmed administrator account
 
 optional arguments:
@@ -100,17 +100,22 @@ Administrator redshiftzero successfully added
 
 ## Migrating the Database
 
-If you e.g. add a new column or table, you'll need to migrate the database. You can use the management interface to do this:
+If you e.g. add a new column or table, you'll need to migrate the database.
+
+You can use the management interface to first generate migrations:
 
 ```
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py migrate_db
+(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py makemigrations
 New migration saved as /vagrant/OpenOversight/app/db_repository/versions/002_migration.py
-Current database version: 2
 ```
 
-to do this.
+And then you should inspect/edit the migrations. You can then apply the migrations:
 
-`python manage.py upgrade_db` and `python manage.py downgrade_db` can also be used as necessary. Note that we followed [this tutorial](http://blog.miguelgrinberg.com/post/the-flask-mega-tutorial-part-iv-database) to set this up.
+```
+(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py migrate
+```
+
+You can also downgrade the database using `python manage.py downgrade_db`.
 
 ## Changing the Development Environment
 

--- a/OpenOversight/app/db_repository/versions/002_migration.py
+++ b/OpenOversight/app/db_repository/versions/002_migration.py
@@ -1,11 +1,11 @@
-from sqlalchemy import *
-from migrate import *
+from sqlalchemy import *  # pragma: no cover
+from migrate import *  # pragma: no cover
 
 
-from migrate.changeset import schema
-pre_meta = MetaData()
-post_meta = MetaData()
-raw_images = Table('raw_images', post_meta,
+from migrate.changeset import schema  # pragma: no cover
+pre_meta = MetaData()  # pragma: no cover
+post_meta = MetaData()  # pragma: no cover
+raw_images = Table('raw_images', post_meta,  # pragma: no cover
     Column('id', Integer, primary_key=True, nullable=False),
     Column('filepath', String(length=255)),
     Column('hash_img', String(length=120)),
@@ -17,7 +17,7 @@ raw_images = Table('raw_images', post_meta,
 )
 
 
-def upgrade(migrate_engine):
+def upgrade(migrate_engine):  # pragma: no cover
     # Upgrade operations go here. Don't create your own engine; bind
     # migrate_engine to your metadata
     pre_meta.bind = migrate_engine
@@ -25,7 +25,7 @@ def upgrade(migrate_engine):
     post_meta.tables['raw_images'].columns['filepath'].alter(type=String(255))
 
 
-def downgrade(migrate_engine):
+def downgrade(migrate_engine):  # pragma: no cover
     # Operations to reverse the above upgrade go here.
     pre_meta.bind = migrate_engine
     post_meta.bind = migrate_engine

--- a/OpenOversight/app/db_repository/versions/002_migration.py
+++ b/OpenOversight/app/db_repository/versions/002_migration.py
@@ -1,0 +1,32 @@
+from sqlalchemy import *
+from migrate import *
+
+
+from migrate.changeset import schema
+pre_meta = MetaData()
+post_meta = MetaData()
+raw_images = Table('raw_images', post_meta,
+    Column('id', Integer, primary_key=True, nullable=False),
+    Column('filepath', String(length=255)),
+    Column('hash_img', String(length=120)),
+    Column('date_image_inserted', DateTime),
+    Column('date_image_taken', DateTime),
+    Column('contains_cops', Boolean),
+    Column('user_id', Integer),
+    Column('is_tagged', Boolean, default=ColumnDefault(False)),
+)
+
+
+def upgrade(migrate_engine):
+    # Upgrade operations go here. Don't create your own engine; bind
+    # migrate_engine to your metadata
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['raw_images'].columns['filepath'].alter(type=String(255))
+
+
+def downgrade(migrate_engine):
+    # Operations to reverse the above upgrade go here.
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['raw_images'].columns['filepath'].alter(type=String(120))

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -80,7 +80,7 @@ class Image(db.Model):
     __tablename__ = 'raw_images'
 
     id = db.Column(db.Integer, primary_key=True)
-    filepath = db.Column(db.String(120), unique=False)
+    filepath = db.Column(db.String(255), unique=False)
     hash_img = db.Column(db.String(120), unique=False, nullable=True)
 
     # Track when the image was put into our database

--- a/OpenOversight/manage.py
+++ b/OpenOversight/manage.py
@@ -20,8 +20,8 @@ def make_shell_context():
 manager.add_command("shell", Shell(make_context=make_shell_context))
 
 @manager.command
-def migrate_db(config_name="default"):
-    """Migrate the database"""
+def makemigrations(config_name="default"):
+    """Make database migrations"""
 
     SQLALCHEMY_MIGRATE_REPO = config['default'].SQLALCHEMY_MIGRATE_REPO
     SQLALCHEMY_DATABASE_URI = config['default'].SQLALCHEMY_DATABASE_URI
@@ -33,16 +33,13 @@ def migrate_db(config_name="default"):
     exec(old_model, tmp_module.__dict__)
     script = api.make_update_script_for_model(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO, tmp_module.meta, db.metadata)
     open(migration, "wt").write(script)
-    api.upgrade(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO)
-    v = api.db_version(SQLALCHEMY_DATABASE_URI, SQLALCHEMY_MIGRATE_REPO)
 
     print('New migration saved as ' + migration)
-    print('Current database version: ' + str(v))
-
+    print('Run python manage.py upgrade_db to upgrade the database')
 
 @manager.command
-def upgrade_db(config_name="default"):
-    """Upgrade the database"""
+def migrate(config_name="default"):
+    """Migrate/upgrade the database"""
 
     SQLALCHEMY_MIGRATE_REPO = config['default'].SQLALCHEMY_MIGRATE_REPO
     SQLALCHEMY_DATABASE_URI = config['default'].SQLALCHEMY_DATABASE_URI


### PR DESCRIPTION
Fixes #194, where the filepath in the images table was too small. 

Also, in the course of making this change, I ran into a situation where the automatically generated migrations by `sqlalchemy-migrate` did not work, and instead I had to [manually write the migrations](https://sqlalchemy-migrate.readthedocs.io/en/v0.7.1/changeset.html). To make it easier for developers in the future, I've modified `manage.py` a bit (this workflow will seem familiar to Django people):

* First, a developer will run `python manage.py makemigrations` in order to have `sqlalchemy-migrate` attempt to automatically generate the migrations. 
* Then, a developer will inspect and edit them (if necessary) and _then_ will run `python manage.py migrate` to actually apply the migrations. 

For deploying to staging and prod, since we're committing the migrations as we ensure that they work, the admin will just need to run `python manage.py migrate`.