### PR TITLE
Update the fabfile to run migrations

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -54,6 +54,12 @@ def deploy():
             run('sudo systemctl restart openoversight')
 
 
+def migrate():
+    with cd(env.code_dir):
+        if confirm("Apply any outstanding database migrations?", default=False):
+            run('su %s -c "%s/bin/python OpenOversight/manage.py migrate"' % (env.unprivileged_user, env.venv_dir))
+            run('sudo systemctl restart openoversight')
+
 def backup():
     run("su %s -c 'mkdir -p %s'" % (env.unprivileged_user, env.backup_dir))
     with cd(env.backup_dir):


### PR DESCRIPTION
This was tested on staging:
```
27 ganglia openoversight % fab staging migrate
[staging.openoversight.lucyparsonslabs.com] Executing task 'migrate'
Apply any outstanding database migrations? [y/N] y
[staging.openoversight.lucyparsonslabs.com] run: su nginx -c "/home/nginx/oovirtenv/venv/bin/python OpenOversight/manage.py migrate"
[staging.openoversight.lucyparsonslabs.com] out: --------------------------------------------------------------------------------
[staging.openoversight.lucyparsonslabs.com] out: INFO in __init__ [/home/nginx/oovirtenv/venv/OpenOversight/OpenOversight/app/__init__.py:52]:
[staging.openoversight.lucyparsonslabs.com] out: OpenOversight startup
[staging.openoversight.lucyparsonslabs.com] out: --------------------------------------------------------------------------------
[staging.openoversight.lucyparsonslabs.com] out: Current database version: 2
[staging.openoversight.lucyparsonslabs.com] out:

[staging.openoversight.lucyparsonslabs.com] run: sudo systemctl restart openoversight

Done.
Disconnecting from staging.openoversight.lucyparsonslabs.com... done.
```