### PR TITLE
Remove reference to non-global variable

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -14,7 +14,7 @@ from .models import db, Officer, Assignment, Image, Face, User
 
 def serve_image(filepath):
     if 'http' in filepath:
-        return proper_path
+        return filepath
     if 'static' in filepath:
         return url_for('static', filename=filepath.replace('static/', ''))
 


### PR DESCRIPTION
Naive fix for the following stacktrace, seen when viewing /sort route on staging:

```
2017-03-03 04:15:04 [5053] [ERROR] Error handling request
 Traceback (most recent call last):
   File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 126, in handle_request
     respiter = self.wsgi(environ, resp.start_response)
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2000, in __call__
     return self.wsgi_app(environ, start_response)
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1991, in wsgi_app
     response = self.make_response(self.handle_exception(e))
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1567, in handle_exception
     reraise(exc_type, exc_value, tb)
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1988, in wsgi_app
     response = self.full_dispatch_request()
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1641, in full_dispatch_request
     rv = self.handle_user_exception(e)
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1544, in handle_user_exception
     reraise(exc_type, exc_value, tb)
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1639, in full_dispatch_request
     rv = self.dispatch_request()
   File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1625, in dispatch_request
     return self.view_functions[rule.endpoint](**req.view_args)
   File "/usr/local/lib/python2.7/dist-packages/flask_login/utils.py", line 228, in decorated_view
     return func(*args, **kwargs)
   File "/home/nginx/oovirtenv/venv/OpenOversight/OpenOversight/app/main/views.py", line 74, in sort_images
     proper_path = serve_image(image.filepath)
   File "/home/nginx/oovirtenv/venv/OpenOversight/OpenOversight/app/utils.py", line 17, in serve_image
     return proper_path
 NameError: global name 'proper_path' is not defined
```
Need @redshiftzero to let me know if she intended other sanitization there or if it was just a typo.