### PR TITLE
Refactor tagging route

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -189,7 +189,10 @@ def label_data(image_id=None):
 
     form = FaceTag()
     if form.validate_on_submit():
-        try:
+        existing_tag = db.session.query(Face) \
+                         .filter(Face.officer_id==form.officer_id.data) \
+                         .filter(Face.img_id==form.image_id.data).first()
+        if not existing_tag:
             new_tag = Face(officer_id=form.officer_id.data,
                            img_id=form.image_id.data,
                            face_position_x=form.dataX.data,
@@ -200,9 +203,9 @@ def label_data(image_id=None):
             db.session.add(new_tag)
             db.session.commit()
             flash('Tag added to database')
-        except IntegrityError:
-            db.session.rollback()
+        else:
             flash('Tag already exists between this officer and image! Tag not added.')
+
     return render_template('cop_face.html', form=form,
                            image=image, path=proper_path)
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -111,16 +111,16 @@ def session(db, request):
     db.session = session
 
     def teardown():
-        transaction.rollback()
-        connection.close()
-        session.remove()
-
         # Cleanup tables
         models.User.query.delete()
         models.Officer.query.delete()
         models.Image.query.delete()
         models.Face.query.delete()
         session.commit()
+
+        transaction.rollback()
+        connection.close()
+        session.remove()
 
     request.addfinalizer(teardown)
     return session

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -112,17 +112,8 @@ def session(db, request):
 
     def teardown():
         transaction.rollback()
-        session.remove()
-
-        # Cleanup tables
-        models.User.query.delete()
-        models.Officer.query.delete()
-        models.Image.query.delete()
-        models.Face.query.delete()
-        session.commit()
-        session.flush()
-
         connection.close()
+        session.remove()
 
     request.addfinalizer(teardown)
     return session
@@ -174,6 +165,15 @@ def mockdata(session, request):
                                         password='dog', confirmed=False)
     session.add(test_unconfirmed_user)
     session.commit()
+    def teardown():
+        # Cleanup tables
+        models.User.query.delete()
+        models.Officer.query.delete()
+        models.Image.query.delete()
+        models.Face.query.delete()
+        session.commit()
+        session.flush()
+
     return assignments[0].star_no
 
 @pytest.fixture

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -111,16 +111,18 @@ def session(db, request):
     db.session = session
 
     def teardown():
+        transaction.rollback()
+        session.remove()
+
         # Cleanup tables
         models.User.query.delete()
         models.Officer.query.delete()
         models.Image.query.delete()
         models.Face.query.delete()
         session.commit()
+        session.flush()
 
-        transaction.rollback()
         connection.close()
-        session.remove()
 
     request.addfinalizer(teardown)
     return session


### PR DESCRIPTION
On the tagging route, rolling back transactions was causing errors as the User object was no longer bound to a session. This was causing a test failure. I've refactored this to avoid doing a rollback by testing if the row exists first. It is not a very [EAFP](https://docs.python.org/2/glossary.html?highlight=eafp#term-eafp) solution but... it is a working one where tests pass. So for now we can keep it like this.  