### PR TITLE
Rate limit requests

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -3,8 +3,10 @@ from logging.handlers import RotatingFileHandler
 
 from flask import Flask, render_template
 from flask_bootstrap import Bootstrap
-from flask_mail import Mail
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
+from flask_mail import Mail
 
 from config import config
 
@@ -27,6 +29,11 @@ def create_app(config_name='default'):
     mail.init_app(app)
     db.init_app(app)
     login_manager.init_app(app)
+
+    limiter = Limiter(app,
+        key_func=get_remote_address,
+        global_limits=["100 per minute", "5 per second"],
+    )
 
     from .main import main as main_blueprint  # noqa
     app.register_blueprint(main_blueprint)

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -30,10 +30,9 @@ def create_app(config_name='default'):
     db.init_app(app)
     login_manager.init_app(app)
 
-    limiter = Limiter(app,
-        key_func=get_remote_address,
-        global_limits=["100 per minute", "5 per second"],
-    )
+    Limiter(app,
+            key_func=get_remote_address,
+            global_limits=["100 per minute", "5 per second"])
 
     from .main import main as main_blueprint  # noqa
     app.register_blueprint(main_blueprint)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ python-dotenv
 boto3
 werkzeug>=0.11.1
 Flask-WTF>=0.13.1
+Flask-Limiter
 Flask-Login
 Flask-Script
 Flask-Mail


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #154.

Changes proposed in this pull request:

 - Adds Flask-Limiter
 - Sets up rate limiting using an in-memory store (100/min, 5/sec)

## Notes for Deployment

Need to install the new addition to requirements.txt. That should be it!

## Tests and linting
 
 - [x] I have rebased my changes on current `develop`
 
 - [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
