### PR TITLE
Improvements to cop identification workflow

### DIFF
--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -33,7 +33,7 @@
               <div class="img-preview preview-lg"></div>
             </div>
             <div class="docs-data">
-              <form action="{{ url_for('main.label_data') }}" method="post">
+              <form action="{{ url_for('main.label_data', image_id=image.id) }}" method="post">
                 {{ form.hidden_tag() }}
                 <div class="input-group input-group-sm">
                   <input type="text" class="hidden form-control" name="dataX" id="dataX" placeholder="x">

--- a/OpenOversight/app/templates/image.html
+++ b/OpenOversight/app/templates/image.html
@@ -80,6 +80,15 @@
               </button>
             </form>
           </p>
+          <h3>Identify <small>Admin only</small></h3>
+          <p>
+              <a href="{{ url_for('main.label_data', image_id=image.id) }}">
+                <button class="btn btn-primary">
+                  Tag this image
+                </button>
+              </a>
+            </form>
+          </p>
           {% endif %}
         </div>
       </div>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -62,6 +62,15 @@
               </button>
             </form>
           </p>
+          <h3>Add additional tags <small>Admin only</small></h3>
+          <p>
+              <a href="{{ url_for('main.label_data', image_id=face.image.id) }}">
+                <button class="btn btn-primary">
+                  Tag this image
+                </button>
+              </a>
+            </form>
+          </p>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These are some changes to the volunteer tagging workflow for the 0.2 release (x-link #174). 

Changes proposed in this pull request:
 - Enable the addition of tags on the `/cop_face/<image_id>` route (previously you would have to label the first image returned from querying all untagged images in order).
 - Add button to the `/tag` and `/image` routes to enable admins to quickly enter the cop identification app for a particular image.

## Notes for Deployment

Nothing special needed

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
