### PR TITLE
Add skip buttons to classification and identification apps

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -4,7 +4,6 @@ from flask import (abort, render_template, request, redirect, url_for,
                    flash, current_app)
 from flask_login import current_user, login_required
 from functools import wraps
-import random
 import re
 import sys
 import tempfile

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -4,6 +4,7 @@ from flask import (abort, render_template, request, redirect, url_for,
                    flash, current_app)
 from flask_login import current_user, login_required
 from functools import wraps
+import random
 import re
 import sys
 import tempfile
@@ -12,7 +13,7 @@ from werkzeug import secure_filename
 
 from . import main
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
-                     serve_image, compute_leaderboard_stats)
+                     serve_image, compute_leaderboard_stats, get_random_image)
 from .forms import (FindOfficerForm, FindOfficerIDForm, HumintContribution,
                     FaceTag)
 from ..models import db, Image, User, Face
@@ -65,7 +66,9 @@ def get_started_labeling():
 @login_required
 def sort_images():
     # Select a random unsorted image from the database
-    image = Image.query.filter_by(contains_cops=None).first()
+    image_query = Image.query.filter_by(contains_cops=None)
+    image = get_random_image(image_query)
+
     if image:
         proper_path = serve_image(image.filepath)
     else:
@@ -175,8 +178,9 @@ def label_data(image_id=None):
         image = Image.query.filter_by(id=image_id).one()
     else:
         # Select a random untagged image from the database
-        image = Image.query.filter_by(contains_cops=True) \
-                           .filter_by(is_tagged=False).first()
+        image_query = Image.query.filter_by(contains_cops=True) \
+                           .filter_by(is_tagged=False)
+        image = get_random_image(image_query)
 
     if image:
         proper_path = serve_image(image.filepath)

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -27,6 +27,7 @@
       {% if image and current_user.is_disabled == False %}
         <div class="row">
           <div class="col-md-5">
+            <p><a href="{{ url_for('main.label_data')}}" class="btn btn-lg btn-primary" role="button">Skip this picture</a></p>
             <h3>Add a tag for each officer</h3>
             <h4>1. Select the face of the officer</h4>
             <div class="preview docs-preview clearfix">

--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -43,6 +43,8 @@
               </button>
             </form></p>
 
+            <p><a href="{{ url_for('main.label_data') }}" class="btn btn-lg btn-primary" role="button">Skip this picture</a></p>
+
           </div>
         </div>
       {% elif current_user.is_disabled == True %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -1,12 +1,21 @@
 import boto3
 import datetime
 import hashlib
+import random
 from sqlalchemy import func
 from sqlalchemy.sql.expression import cast
 
 from flask import current_app, url_for
 
 from .models import db, Officer, Assignment, Image, Face, User
+
+
+def get_random_image(image_query):
+    if image_query.count() > 0:
+        rand = random.randrange(0, image_query.count())
+        return image_query[rand]
+    else:
+        return None
 
 
 def serve_image(filepath):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This resolves another annoyance I've noticed while testing the 0.2 release. Changes proposed in this pull request:

 - The image shown on the classification and identification apps is now random: if you go there again, a random different image will be shown.
 - You can also now click the new skip button to skip over an image you are having trouble with (this doesn't remove it from the queue and you may be shown the same image later).

## Notes for Deployment

Nothing special

## Screenshots (if appropriate)

<img width="483" alt="screen shot 2017-03-22 at 5 03 14 pm" src="https://cloud.githubusercontent.com/assets/7832803/24209034/6e660c66-0f25-11e7-9cc9-dc5312a1e1ce.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
