### PR TITLE
Create officer profiles

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,21 +1,23 @@
 import datetime
 import os
-from flask import (abort, render_template, request, redirect, url_for,
-                   flash, current_app)
-from flask_login import current_user, login_required
 from functools import wraps
 import re
+from sqlalchemy.orm.exc import NoResultFound
 import sys
 import tempfile
 from traceback import format_exc
 from werkzeug import secure_filename
+
+from flask import (abort, render_template, request, redirect, url_for,
+                   flash, current_app)
+from flask_login import current_user, login_required
 
 from . import main
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image)
 from .forms import (FindOfficerForm, FindOfficerIDForm, HumintContribution,
                     FaceTag)
-from ..models import db, Image, User, Face
+from ..models import db, Image, User, Face, Officer
 
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0077)
@@ -89,6 +91,15 @@ def profile(username):
     return render_template('profile.html', user=user)
 
 
+@main.route('/officer/<officer_id>')
+def officer_profile(officer_id):
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultsFound:
+        abort(404)
+    return render_template('officer.html', officer=officer)
+
+
 @main.route('/user/toggle/<int:uid>', methods=['POST'])
 @login_required
 @admin_required
@@ -101,7 +112,7 @@ def toggle_user(uid):
             user.is_disabled = True
         db.session.commit()
         flash('Updated user status')
-    except:
+    except NoResultFound:
         flash('Unknown error occurred')
     return redirect(url_for('main.profile', username=user.username))
 
@@ -112,7 +123,7 @@ def display_submission(image_id):
     try:
         image = Image.query.filter_by(id=image_id).one()
         proper_path = serve_image(image.filepath)
-    except:
+    except NoResultFound:
         abort(404)
     return render_template('image.html', image=image, path=proper_path)
 
@@ -123,7 +134,7 @@ def display_tag(tag_id):
     try:
         tag = Face.query.filter_by(id=tag_id).one()
         proper_path = serve_image(tag.image.filepath)
-    except:
+    except NoResultFound:
         abort(404)
     return render_template('tag.html', face=tag, path=proper_path)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -17,7 +17,7 @@ from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image)
 from .forms import (FindOfficerForm, FindOfficerIDForm, HumintContribution,
                     FaceTag)
-from ..models import db, Image, User, Face, Officer
+from ..models import db, Image, User, Face, Officer, Assignment
 
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0077)
@@ -95,9 +95,13 @@ def profile(username):
 def officer_profile(officer_id):
     try:
         officer = Officer.query.filter_by(id=officer_id).one()
-    except NoResultsFound:
+        face = Face.query.filter_by(id=officer_id).first()
+        assignments = Assignment.query.filter_by(id=officer_id).all()
+        proper_path = serve_image(face.image.filepath)
+    except NoResultFound:
         abort(404)
-    return render_template('officer.html', officer=officer)
+    return render_template('officer.html', officer=officer, path=proper_path,
+                           assignments=assignments)
 
 
 @main.route('/user/toggle/<int:uid>', methods=['POST'])

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -3,20 +3,24 @@
 
 <div class="container" role="main">
 
-
   <div class="page-header">
-    <h1>Officer Detail: {{ officer.first_name }} {{ officer.middle_initial }} {{ officer.last_name }}</h1>
+    <h1>Officer Detail: <b>{{ officer.first_name|title }} {{ officer.middle_initial }} {{ officer.last_name|title }}</b></h1>
   </div>
 
   <div class="row">
     <div class="col-sm-6">
+      <img src="{{ path }}" alt="Submission">
     </div>
     <div class="col-sm-6 col-md-4">
       <div class="thumbnail">
         <div class="caption">
-          <h3>Information</h3>
+          <h3>General Information</h3>
           <table class="table table-hover">
             <tbody>
+              <tr>
+                <td><b>OpenOversight ID</b></td>
+                <td>{{ officer.id }}</td>
+              </tr>
               <tr>
                 <td><b>Race</b></td>
                 <td>{{ officer.race }}</td>
@@ -30,19 +34,51 @@
                 <td>{{ officer.birth_year }}</td>
               </tr>
               <tr>
-                <td><b>Employment Date</b></td>
+                <td><b>First Employment Date</b></td>
                 <td>{{ officer.employment_date }}</td>
               </tr>
             </tbody>
           </table>
-
-          {% if current_user.is_administrator %}
-          <h3>Add Badge Number <small>Admin only</small></h3>
-          <p>
-            Admin only stuff will go here
-          </p>
-          {% endif %}
         </div>
+      </div>
+
+    <div class="thumbnail">
+      <div class="caption">
+        <h3>Assignment History</h3>
+        <table class="table table-hover">
+            <tr>
+              <th><b>Rank</b></th>
+              <th><b>Badge No.</b></th>
+              <th><b>Unit</b></th>
+              <th><b>End Date</b></th>
+            </tr>
+          <tbody>
+            {% for assignment in assignments %}
+            <tr>
+              <td>{{ assignment.rank }}
+              <td>{{ assignment.star_no }}</td>
+              <td>{% if assignment.unit: %}
+                  {{ assignment.unit }}
+                  {% else %}
+                  Unknown
+                  {% endif %}
+              </td>
+              <td>{% if assignment.resign_date: %}
+                  {{ assignment.resign_date }}
+                  {% else %}
+                  Unknown
+                  {% endif %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+        {% if current_user.is_administrator %}
+        <h3>Add Assignment<small> Admin only</small></h3>
+        <p>
+          Admin only stuff will go here
+        </p>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block content %}
+
+<div class="container" role="main">
+
+
+  <div class="page-header">
+    <h1>Officer Detail: {{ officer.first_name }} {{ officer.middle_initial }} {{ officer.last_name }}</h1>
+  </div>
+
+  <div class="row">
+    <div class="col-sm-6">
+    </div>
+    <div class="col-sm-6 col-md-4">
+      <div class="thumbnail">
+        <div class="caption">
+          <h3>Information</h3>
+          <table class="table table-hover">
+            <tbody>
+              <tr>
+                <td><b>Race</b></td>
+                <td>{{ officer.race }}</td>
+              </tr>
+              <tr>
+                <td><b>Gender</b></td>
+                <td>{{ officer.gender }}</td>
+              </tr>
+              <tr>
+                <td><b>Birth Year</b></td>
+                <td>{{ officer.birth_year }}</td>
+              </tr>
+              <tr>
+                <td><b>Employment Date</b></td>
+                <td>{{ officer.employment_date }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          {% if current_user.is_administrator %}
+          <h3>Add Badge Number <small>Admin only</small></h3>
+          <p>
+            Admin only stuff will go here
+          </p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+{% endblock %}

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -20,9 +20,9 @@
             <div class="col-md-3 col-sm-4 col-xs-12">
                 <div class="thumbnail_container">
                 <div class="row">
-                <h4>{{ officer.first_name.lower()|title }}
+                <h4><a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}">{{ officer.first_name.lower()|title }}
                 {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
-                {{ officer.last_name.lower()|title }} <small>#{{ assignment.star_no }}</small></h4>
+                {{ officer.last_name.lower()|title }}</a><small> #{{ assignment.star_no }}</small></h4>
                 <h5>OpenOversight ID: {{ officer.id }}</h5>
                 <h5>Race: {{ officer.race }}</h5>
                 <h5>Gender: {{ officer.gender }}</h5>

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -22,6 +22,7 @@ from OpenOversight.app.models import User, Face
     ('/contact'),
     ('/privacy'),
     ('/label'),
+    ('/officer/3'),
     ('/tutorial'),
     ('/auth/login'),
     ('/auth/register'),
@@ -208,6 +209,15 @@ def test_admin_sees_toggle_button_on_profiles(mockdata, client, session):
         assert 'test_user' in rv.data
         # Admin should be able to see the Toggle button
         assert 'Toggle (Disable/Enable) User' in rv.data
+
+
+def test_user_can_access_officer_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        rv = client.get(
+            url_for('main.officer_profile', officer_id=3),
+            follow_redirects=True
+        )
+        assert 'Officer Detail' in rv.data
 
 
 def test_user_can_view_submission(mockdata, client, session):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #160 and resolves #212.

Changes proposed in this pull request:

 - Adds officer profiles. A new route `officer/<officer_id>` exists for each officer. This route displays all the info we have on them: assignment history, demographic data, face.
 - The profile shows all known badge numbers for the officer.
 - Adds a link to these profiles in the tagger gallery.

## Notes for Deployment

Nothing special

## Screenshots (if appropriate)

<img width="1099" alt="screen shot 2017-03-25 at 1 17 01 am" src="https://cloud.githubusercontent.com/assets/7832803/24317586/dae5f67e-10f8-11e7-926c-56a61bb553bf.png">

<img width="575" alt="screen shot 2017-03-25 at 1 17 08 am" src="https://cloud.githubusercontent.com/assets/7832803/24317587/de730962-10f8-11e7-83f0-4e4b2b1bac2b.png">

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
