### PR TITLE
Generate face bounding box cutouts of submitted images

### DIFF
--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -17,10 +17,23 @@
     {% set assignment = officer.assignments.first() %}
       <div class="col-md-4 col-sm-4 col-xs-12">
         <div class="thumbnail_container">
-          <h4>{{ officer.first_name.lower()|title }}
+          <h4><a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}">
+                {{ officer.first_name.lower()|title }}
                 {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
-                {{ officer.last_name.lower()|title }} <small>#{{ assignment.star_no }}</small></h4>
-          <img class="img-responsive thumbnail" src="{{ officer_image }}" alt="Officer face">
+                {{ officer.last_name.lower()|title }}</a> <small>#{{ assignment.star_no }}</small></h4>
+
+          {% if officer.face.first().face_position_x %}
+          <div class="img-responsive thumbnail"
+               style="background-image: url({{ officer_image }});
+                      background-repeat: no-repeat;
+                      background-position: -{{ officer.face.first().face_position_x }}px -{{ officer.face.first().face_position_y }}px;
+                      width: {{ officer.face.first().face_width }}px;
+                      height: {{ officer.face.first().face_height }}px;">
+          </div>
+          {% else %}
+          <img src="{{ officer_image }}" class="img-responsive thumbnail">
+          {% endif %}
+
 		      <center><a href="{{ url_for('main.submit_complaint',
                            officer_last_name=officer.last_name,
                            officer_first_name=officer.first_name,

--- a/OpenOversight/app/templates/profile.html
+++ b/OpenOversight/app/templates/profile.html
@@ -20,7 +20,7 @@
                 <td>{{ user.classifications|length }}</td>
               </tr>
               <tr>
-                <td><b>Number of officers found</b></td>
+                <td><b>Number of officers identified</b></td>
                 <td>{{ user.tags|length }}</td>
               </tr>
             </tbody>
@@ -79,7 +79,7 @@
 {% if user.tags %}
   <div class="row">
     <div class="col-sm-12 col-md-12">
-    <h2>Officer Face Tags</h2>
+    <h2>Officer Identifications</h2>
       <table class="table table-hover">
         <thead>
           <tr>
@@ -92,7 +92,8 @@
           <tr>
             <td><a href="{{ url_for( 'main.display_tag', tag_id=tag.id ) }}">
                 Tag {{ tag.id }}</a></td>
-            <td>{{ tag.officer_id }}</td>
+            <td><a href="{{ url_for('main.officer_profile', officer_id=tag.officer_id) }}">
+                {{ tag.officer_id }}</a></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -9,12 +9,15 @@
   </div>
 
   <div class="row">
-    <div class="col-sm-6">
-      <img src="{{ path }}" alt="Submission">
-    </div>
     <div class="col-sm-6 col-md-4">
       <div class="thumbnail">
         <div class="caption">
+          <div style="background-image: url({{ path }});
+                      background-repeat: no-repeat;
+                      background-position: -{{ face.face_position_x }}px -{{ face.face_position_y }}px;
+                      width: {{ face.face_width }}px;
+                      height: {{ face.face_height }}px;">
+          </div>
           <h3>Image Cutout</h3>
           <table class="table table-hover">
             <tbody>
@@ -22,18 +25,6 @@
                 <td><b>Image ID</b></td>
                 <td><a href="{{ url_for('main.display_submission', image_id=face.image.id) }}">
                     {{ face.image.id }}</a></td>
-              </tr>
-              <tr>
-                <td><b>(x,y) position of face in image</b></td>
-                <td>({{ face.face_position_x }}, {{ face.face_position_y }})</td>
-              </tr>
-              <tr>
-                <td><b>Height of face bounding box</b></td>
-                <td>{{ face.face_height }}</td>
-              </tr>
-              <tr>
-                <td><b>Width of face bounding box</b></td>
-                <td>{{ face.face_width }}</td>
               </tr>
             </tbody>
           </table>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -43,7 +43,8 @@
             <tbody>
               <tr>
                 <td><b>OpenOversight ID</b></td>
-                <td>{{ face.officer_id }}</td>
+                <td> <a href="{{ url_for('main.officer_profile', officer_id=face.officer_id) }}">
+                  {{ face.officer_id }}</a> </td>
               </tr>
               <tr>
                 <td><b>Tagged by user</b></td>

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -28,7 +28,17 @@
                 <h5>Gender: {{ officer.gender }}</h5>
 
                 </div>
-                <img class="img-responsive thumbnail" src="{{ officer_image }}" alt="Officer face">
+                {% if officer.face.first().face_position_x %}
+                <div class="img-responsive thumbnail"
+                     style="background-image: url({{ officer_image }});
+                            background-repeat: no-repeat;
+                            background-position: -{{ officer.face.first().face_position_x }}px -{{ officer.face.first().face_position_y }}px;
+                            width: {{ officer.face.first().face_width }}px;
+                            height: {{ officer.face.first().face_height }}px;">
+                </div>
+                {% else %}
+                <img src="{{ officer_image }}" class="img-responsive thumbnail">
+                {% endif %}
                 </div>
                 <br><br><br><br>
             </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #177.

Changes proposed in this pull request:

 - Show only the face (not the full image) on the tag and gallery routes.
 - Add links to officer profiles on the user profile, main gallery, and tag route. 

## Notes for Deployment

Nothing special

## Screenshots (if appropriate)

<img width="1098" alt="screen shot 2017-03-26 at 1 05 16 am" src="https://cloud.githubusercontent.com/assets/7832803/24327241/f8df8b06-11c3-11e7-95e0-f9e780000c52.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
