### PR TITLE
Add notice that users should use SecureDrop for high security submissions

### DIFF
--- a/OpenOversight/app/templates/submit.html
+++ b/OpenOversight/app/templates/submit.html
@@ -22,7 +22,10 @@
 
      <input type="submit" class="btn btn-primary"  value="Go!" id="user-notification" /> <img id="loader" style="display:none;" src="{{url_for('static', filename='images/page-loader.gif')}}">
    </form>
- </div>
+   </div>
+   <h3>High Security Submissions</h3>
+   <p>For very high security upload of photos or videos, you can use the Lucy Parsons Labs SecureDrop instance:</p>
+   <p><a href="https://lucyparsonslabs.com/securedrop"><img src="{{url_for('static', filename='images/securedrop.png')}}"/> Launch SecureDrop Instructions</a></p>
  <!--{{ wtf.quick_form(form) }}-->
 
 </div>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #196.

Changes proposed in this pull request:

 - Adds a note to the submission page that SecureDrop is a great way to get us videos or images for the high security context. I don't want to encourage it too much since it's annoying af for us, but I think it's important that it's there just in case.

## Notes for Deployment

Nothing special

## Screenshots (if appropriate)

<img width="717" alt="screen shot 2017-03-26 at 1 49 30 am" src="https://cloud.githubusercontent.com/assets/7832803/24327353/f428b88c-11c6-11e7-866d-73cfc41194b7.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
