### PR TITLE
Rate limit uploads, add custom 429 error handler

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -18,6 +18,9 @@ login_manager = LoginManager()
 login_manager.session_protection = 'strong'
 login_manager.login_view = 'auth.login'
 
+limiter = Limiter(key_func=get_remote_address,
+                 global_limits=["100 per minute", "5 per second"])
+
 
 def create_app(config_name='default'):
     app = Flask(__name__)
@@ -29,10 +32,7 @@ def create_app(config_name='default'):
     mail.init_app(app)
     db.init_app(app)
     login_manager.init_app(app)
-
-    Limiter(app,
-            key_func=get_remote_address,
-            global_limits=["100 per minute", "5 per second"])
+    limiter.init_app(app)
 
     from .main import main as main_blueprint  # noqa
     app.register_blueprint(main_blueprint)
@@ -67,6 +67,10 @@ def create_app(config_name='default'):
     @app.errorhandler(500)
     def internal_error(e):
         return render_template('500.html'), 500
+
+    @app.errorhandler(429)
+    def rate_exceeded(e):
+        return render_template('429.html'), 429
 
     return app
 

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -19,7 +19,7 @@ login_manager.session_protection = 'strong'
 login_manager.login_view = 'auth.login'
 
 limiter = Limiter(key_func=get_remote_address,
-                 global_limits=["100 per minute", "5 per second"])
+                  global_limits=["100 per minute", "5 per second"])
 
 
 def create_app(config_name='default'):

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -56,6 +56,9 @@ def create_app(config_name='default'):
     app.logger.addHandler(file_handler)
     app.logger.info('OpenOversight startup')
 
+    # Also log when endpoints are getting hit hard
+    limiter.logger.addHandler(file_handler)
+
     @app.errorhandler(404)
     def page_not_found(e):
         return render_template('404.html'), 404

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -284,6 +284,7 @@ def submit_data():
 
 
 @main.route('/upload', methods=['POST'])
+@limiter.limit('250/minute')
 def upload():
     file_to_upload = request.files['file']
     if not allowed_file(file_to_upload.filename):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -13,6 +13,7 @@ from flask import (abort, render_template, request, redirect, url_for,
 from flask_login import current_user, login_required
 
 from . import main
+from .. import limiter
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
                      allowed_file)
@@ -91,7 +92,7 @@ def profile(username):
     return render_template('profile.html', user=user)
 
 
-@main.route('/officer/<officer_id>')
+@main.route('/officer/<int:officer_id>')
 def officer_profile(officer_id):
     try:
         officer = Officer.query.filter_by(id=officer_id).one()
@@ -143,7 +144,6 @@ def display_tag(tag_id):
     return render_template('tag.html', face=tag, path=proper_path)
 
 
-# Rate limiting / CAPTCHA needed on this route
 @main.route('/image/classify/<int:image_id>/<int:contains_cops>',
             methods=['POST'])
 @login_required
@@ -224,7 +224,6 @@ def label_data(image_id=None):
                            image=image, path=proper_path)
 
 
-# Rate limiting / CAPTCHA on this route
 @main.route('/image/tagged/<int:image_id>')
 @login_required
 def complete_tagging(image_id):
@@ -279,7 +278,7 @@ def submit_complaint():
 
 
 @main.route('/submit', methods=['GET', 'POST'])
-@login_required
+@limiter.limit('5/minute')
 def submit_data():
     return render_template('submit.html')
 

--- a/OpenOversight/app/templates/429.html
+++ b/OpenOversight/app/templates/429.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Too Many Requests{% endblock %}
+
+{% block content %}
+
+<div class="container theme-showcase" role="main">
+
+<h1>Too Many Requests</h1>
+<p>You're sending requests too fast. Wait a minute and try again. <a href="{{ url_for('main.index') }}">Return to homepage</a>.</p>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -57,14 +57,9 @@
           <ul class="nav navbar-nav">
             <li><a href="/">Home</a></li>
             <li><a href="/find">Find an Officer</a></li>
-            {% if current_user and current_user.is_authenticated %}
-                 <li><a href="/submit">Submit Images</a></li>
-                 <li><a href="/label">Volunteer</a></li>
-                 <li><a href="/leaderboard">Leaderboard</a></li>
-            {% else %}
-                 <li><a href="https://script.google.com/macros/s/AKfycbyNg7oVOPSFBHZkncDn7Z23qbJFWQZM1QXcEE0TO2Txa6wB8tU/exec">Submit Images</a></li>
-                 <li><a href="/label">Volunteer</a></li>
-            {% endif %}
+            <li><a href="/submit">Submit Images</a></li>
+            <li><a href="/label">Volunteer</a></li>
+            <li><a href="/leaderboard">Leaderboard</a></li>
             <li><a href="/about">About</a></li>
             <li><a href="/contact">Contact</a></li>
             <li><a href="/privacy">Privacy Policy</a></li>

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -19,6 +19,7 @@ from OpenOversight.app.models import User, Face
     ('/tagger_find'),
     ('/contact'),
     ('/privacy'),
+    ('/submit'),
     ('/label'),
     ('/officer/3'),
     ('/tutorial'),
@@ -34,7 +35,6 @@ def test_routes_ok(route, client, mockdata):
 
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route", [
-    ('/submit'),
     ('/auth/unconfirmed'),
     ('/sort'),
     ('/cop_face'),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Closes #148.

Changes proposed in this pull request:

 - Deprecates Google form in favor of uploading directly to the application (and remove login requirement for /submit)
 - Adds stricter rate limiting on the submit page only
 - Adds error handler for 429 too many requests

## Notes for Deployment

Nothing special

## Screenshots (if appropriate)

<img width="561" alt="screen shot 2017-03-28 at 6 56 39 pm" src="https://cloud.githubusercontent.com/assets/7832803/24419560/d12200d4-13ef-11e7-8868-b0c3cfd5d5fb.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
