### PR TITLE
Enable admins to add assignments for officers

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -1,9 +1,14 @@
 from flask_wtf import FlaskForm as Form
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms import (StringField, DecimalField,
                      SelectField, IntegerField, SubmitField)
+from wtforms.fields.html5 import DateField
+
 from wtforms.validators import (DataRequired, AnyOf, NumberRange, Regexp,
                                 Length, Optional)
 from flask_wtf.file import FileField, FileAllowed, FileRequired
+
+from ..utils import unit_choices
 
 
 # Choices are a list of (value, label) tuples
@@ -86,3 +91,12 @@ class FaceTag(Form):
     dataY = IntegerField('dataY', validators=[DataRequired()])
     dataWidth = IntegerField('dataWidth', validators=[DataRequired()])
     dataHeight = IntegerField('dataHeight', validators=[DataRequired()])
+
+
+class AssignmentForm(Form):
+    star_no = IntegerField('star_no')
+    rank = SelectField('rank', default='COMMANDER', choices=RANK_CHOICES,
+                       validators=[AnyOf(allowed_values(RANK_CHOICES))])
+    unit = QuerySelectField('unit', validators=[Optional()],
+                            query_factory=unit_choices)
+    star_date = DateField('star_date', validators=[Optional()])

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -176,6 +176,19 @@ def delete_tag(tag_id):
     return redirect(url_for('main.index'))
 
 
+@main.route('/assignment/add/<int:officer_id>', methods=['POST'])
+@login_required
+@admin_required
+def add_assignment(officer_id):
+    try:
+        new_assignment = Assignment(officer_id=officer_id)
+        db.session.commit()
+        flash('Added this badge number')
+    except:
+        flash('Unknown error occurred')
+    return redirect(redirect_url())
+
+
 @main.route('/leaderboard')
 @login_required
 def leaderboard():

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -2,6 +2,7 @@ import datetime
 import os
 from functools import wraps
 import re
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 import sys
 import tempfile
@@ -16,8 +17,14 @@ from . import main
 from .. import limiter
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
+<<<<<<< HEAD
                      allowed_file)
 from .forms import (FindOfficerForm, FindOfficerIDForm, FaceTag)
+=======
+                     add_new_assignment)
+from .forms import (FindOfficerForm, FindOfficerIDForm, HumintContribution,
+                    FaceTag, AssignmentForm)
+>>>>>>> Enable addition of assignments by admins only
 from ..models import db, Image, User, Face, Officer, Assignment
 
 # Ensure the file is read/write by the creator only
@@ -92,17 +99,28 @@ def profile(username):
     return render_template('profile.html', user=user)
 
 
-@main.route('/officer/<int:officer_id>')
+@main.route('/officer/<int:officer_id>', methods=['GET', 'POST'])
 def officer_profile(officer_id):
+    form = AssignmentForm()
     try:
         officer = Officer.query.filter_by(id=officer_id).one()
-        face = Face.query.filter_by(id=officer_id).first()
-        assignments = Assignment.query.filter_by(id=officer_id).all()
-        proper_path = serve_image(face.image.filepath)
     except NoResultFound:
         abort(404)
+
+    face = Face.query.filter_by(id=officer_id).first()
+    assignments = Assignment.query.filter_by(officer_id=officer_id).all()
+    proper_path = serve_image(face.image.filepath)
+
+    if form.validate_on_submit() and current_user.is_administrator:
+        try:
+            add_new_assignment(officer_id, form)
+            flash('Added new assignment!')
+        except IntegrityError:
+            flash('Assignment already exists')
+        return redirect(url_for('main.officer_profile',
+                                officer_id=officer_id), code=302)
     return render_template('officer.html', officer=officer, path=proper_path,
-                           assignments=assignments)
+                           assignments=assignments, form=form)
 
 
 @main.route('/user/toggle/<int:uid>', methods=['POST'])
@@ -176,19 +194,6 @@ def delete_tag(tag_id):
     return redirect(url_for('main.index'))
 
 
-@main.route('/assignment/add/<int:officer_id>', methods=['POST'])
-@login_required
-@admin_required
-def add_assignment(officer_id):
-    try:
-        new_assignment = Assignment(officer_id=officer_id)
-        db.session.commit()
-        flash('Added this badge number')
-    except:
-        flash('Unknown error occurred')
-    return redirect(redirect_url())
-
-
 @main.route('/leaderboard')
 @login_required
 def leaderboard():
@@ -216,6 +221,8 @@ def label_data(image_id=None):
 
     form = FaceTag()
     if form.validate_on_submit():
+        if not Officer.query.filter_by(id=form.officer_id.data).first():
+            flash('Invalid officer ID. Please select a valid OpenOversight ID!')
         existing_tag = db.session.query(Face) \
                          .filter(Face.officer_id == form.officer_id.data) \
                          .filter(Face.img_id == form.image_id.data).first()

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -17,14 +17,9 @@ from . import main
 from .. import limiter
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
-<<<<<<< HEAD
-                     allowed_file)
-from .forms import (FindOfficerForm, FindOfficerIDForm, FaceTag)
-=======
-                     add_new_assignment)
-from .forms import (FindOfficerForm, FindOfficerIDForm, HumintContribution,
+                     allowed_file, add_new_assignment)
+from .forms import (FindOfficerForm, FindOfficerIDForm,
                     FaceTag, AssignmentForm)
->>>>>>> Enable addition of assignments by admins only
 from ..models import db, Image, User, Face, Officer, Assignment
 
 # Ensure the file is read/write by the creator only

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -54,7 +54,7 @@ class Unit(db.Model):
     descrip = db.Column(db.String(120), index=True, unique=False)
 
     def __repr__(self):
-        return '<Unit ID {}: {}>'.format(self.id, self.descrip)
+        return 'Unit: {}'.format(self.descrip)
 
 
 class Face(db.Model):

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -122,9 +122,7 @@
     </div>
     </footer>
 
-    <!-- Bootstrap core JavaScript
-    ================================================== -->
-    <script>window.jQuery || document.write('<script src="{{ url_for('static', filename='/assets/js/vendor/jquery.min.js') }}"><\/script>')</script>
+    <script src="{{ url_for('static', filename='/assets/js/vendor/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
   </body>
 </html>

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -50,7 +50,7 @@
               <th><b>Rank</b></th>
               <th><b>Badge No.</b></th>
               <th><b>Unit</b></th>
-              <th><b>End Date</b></th>
+              <th><b>Assignment Date</b></th>
             </tr>
           <tbody>
             {% for assignment in assignments %}
@@ -63,8 +63,8 @@
                   Unknown
                   {% endif %}
               </td>
-              <td>{% if assignment.resign_date: %}
-                  {{ assignment.resign_date }}
+              <td>{% if assignment.star_date: %}
+                  {{ assignment.star_date }}
                   {% else %}
                   Unknown
                   {% endif %}</td>
@@ -75,14 +75,60 @@
 
         {% if current_user.is_administrator %}
         <h3>Add Assignment<small> Admin only</small></h3>
-        <p>
-          Admin only stuff will go here
-        </p>
+        <table class="table">
+          <tbody>
+          <form action="{{ url_for('main.officer_profile', officer_id=officer.id) }}" method="post">
+          {{ form.hidden_tag() }}
+
+          <tr>
+            <td><b>New badge number:</b></td>
+            <td>{{ form.star_no }}
+                  {% for error in form.star_no.errors %}
+                      <p><span style="color: red;">[{{ error }}]</span></p>
+                  {% endfor %}
+            </td>
+          </tr>
+
+          <tr>
+            <td><b>New rank:</b></td>
+            <td>{{ form.rank }}
+                  {% for error in form.rank.errors %}
+                      <p><span style="color: red;">[{{ error }}]</span></p>
+                  {% endfor %}
+            </td>
+          </tr>
+
+          <tr>
+            <td><b>New unit:</b></td>
+            <td>{{ form.unit }}
+                  {% for error in form.unit.errors %}
+                      <p><span style="color: red;">[{{ error }}]</span></p>
+                  {% endfor %}
+            </td>
+          </tr>
+
+          <tr>
+            <td><b>Start date of new assignment:</b></td>
+            <td>{{ form.star_date }}
+                  {% for error in form.star_date.errors %}
+                      <p><span style="color: red;">[{{ error }}]</span></p>
+                  {% endfor %}
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <input type="submit" value="Add Assignment" name="add-assignment" class="btn-sm btn-primary"/>
+            </td>
+          </tr>
+
+          </form>
+          </tbody>
+        </table>
         {% endif %}
       </div>
     </div>
   </div>
 
 </div>
-
 {% endblock %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -7,7 +7,22 @@ from sqlalchemy.sql.expression import cast
 
 from flask import current_app, url_for
 
-from .models import db, Officer, Assignment, Image, Face, User
+from .models import db, Officer, Assignment, Image, Face, User, Unit
+
+
+def unit_choices():
+    return db.session.query(Unit).all()
+
+
+def add_new_assignment(officer_id, form):
+    # Resign date should be null
+    new_assignment = Assignment(officer_id=officer_id,
+                                star_no=form.star_no.data,
+                                rank=form.rank.data,
+                                unit=form.unit.data.id,
+                                star_date=form.star_date.data)
+    db.session.add(new_assignment)
+    db.session.commit()
 
 
 def allowed_file(filename):

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -16,10 +16,16 @@ def unit_choices():
 
 def add_new_assignment(officer_id, form):
     # Resign date should be null
+
+    if form.unit.data:
+        unit = form.unit.data.id
+    else:
+        unit = None
+
     new_assignment = Assignment(officer_id=officer_id,
                                 star_no=form.star_no.data,
                                 rank=form.rank.data,
-                                unit=form.unit.data.id,
+                                unit=unit,
                                 star_date=form.star_date.data)
     db.session.add(new_assignment)
     db.session.commit()

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -184,12 +184,18 @@ def mockdata(session, request):
     session.add(test_unconfirmed_user)
     session.commit()
 
+    test_units = [models.Unit(descrip='District 13'),
+                  models.Unit(descrip='Bureau of Organized Crime')]
+    session.add_all(test_units)
+    session.commit()
+
     def teardown():
         # Cleanup tables
         models.User.query.delete()
         models.Officer.query.delete()
         models.Image.query.delete()
         models.Face.query.delete()
+        models.Unit.query.delete()
         session.commit()
         session.flush()
 

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -26,7 +26,7 @@ def test_face_repr(mockdata):
 
 def test_unit_repr(mockdata):
     unit = Unit.query.first()
-    assert unit.__repr__() == '<Unit ID {}: {}>'.format(unit.id, unit.descrip)
+    assert unit.__repr__() == 'Unit: {}'.format(unit.descrip)
 
 
 def test_user_repr(mockdata):

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -3,7 +3,9 @@ import pytest
 from flask import url_for, current_app
 from urlparse import urlparse
 
-from OpenOversight.app.main.forms import (FindOfficerIDForm, FaceTag)
+
+from OpenOversight.app.main.forms import (FindOfficerIDForm, AssignmentForm,
+                                          FaceTag)
 from OpenOversight.app.auth.forms import (LoginForm, RegistrationForm,
                                           ChangePasswordForm, PasswordResetForm,
                                           PasswordResetRequestForm,
@@ -216,6 +218,22 @@ def test_user_can_access_officer_profile(mockdata, client, session):
             follow_redirects=True
         )
         assert 'Officer Detail' in rv.data
+
+
+def test_user_can_add_officer_badge_number(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        form = AssignmentForm(star_no='1234',
+                              rank='COMMANDER')
+
+        rv = client.post(
+            url_for('main.officer_profile', officer_id=3),
+            data=form.data,
+            follow_redirects=True
+        )
+
+        assert 'Added new assignment' in rv.data
 
 
 def test_user_can_view_submission(mockdata, client, session):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -88,3 +88,8 @@ def test_user_cannot_submit_malicious_file(mockdata):
 def test_user_cannot_submit_invalid_file_extension(mockdata):
     file_to_submit = 'tests/test_models.py'
     assert OpenOversight.app.utils.allowed_file(file_to_submit) is False
+
+
+def test_unit_choices(mockdata):
+    unit_choices = [str(x) for x in OpenOversight.app.utils.unit_choices()]
+    assert 'Unit: Bureau of Organized Crime' in unit_choices

--- a/test_data.py
+++ b/test_data.py
@@ -124,6 +124,11 @@ def populate():
     db.session.add(test_user)
     db.session.commit()
 
+    test_units = [models.Unit(descrip='District 13'),
+                  models.Unit(descrip='Bureau of Organized Crime')]
+    db.session.add_all(test_units)
+    db.session.commit()
+
 
 def cleanup():
     """ Cleanup database"""
@@ -147,6 +152,10 @@ def cleanup():
     users = models.User.query.all()
     for user in users:
         db.session.delete(user)
+
+    units = models.Unit.query.all()
+    for unit in units:
+        db.session.delete(unit)
     # TODO: Reset primary keys on all these tables
     db.session.commit()
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Resolves #214.

Changes proposed in this pull request:

 - Adds a admin-only panel on the officer profile enabling an administrator to add a new assignment (and badge number, rank and unit) for an officer. An admin might do this when we get an updated roster, or when officers send us their updated data when they get promoted (this actually did happen). 

## Notes for Deployment

Nothing special

## Action gif!

![add_assignment](https://cloud.githubusercontent.com/assets/7832803/24518575/bfb05186-1582-11e7-9846-2d5fd128d1cb.gif)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
