### PR TITLE
Fixes from 0.2 QA round 1

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -122,7 +122,6 @@
     </div>
     </footer>
 
-    <script src="{{ url_for('static', filename='/assets/js/vendor/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
   </body>
 </html>

--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -43,7 +43,7 @@
               </button>
             </form></p>
 
-            <p><a href="{{ url_for('main.label_data') }}" class="btn btn-lg btn-primary" role="button">Skip this picture</a></p>
+            <p><a href="{{ url_for('main.sort_images') }}" class="btn btn-lg btn-primary" role="button">Skip this picture</a></p>
 
           </div>
         </div>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -3,21 +3,31 @@
 
 <div class="container" role="main">
 
-
   <div class="page-header">
     <h1>Tag {{ face.id }} Detail</h1>
   </div>
 
+</div>
+
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6 col-md-4">
+      <div style="background-image: url({{ path }});
+                  background-repeat: no-repeat;
+                  background-position: -{{ face.face_position_x }}px -{{ face.face_position_y }}px;
+                  width: {{ face.face_width }}px;
+                  height: {{ face.face_height }}px;">
+      </div>
+      <br>
+    </div>
+  </div>
+</div>
+
+<div class="container">
   <div class="row">
     <div class="col-sm-6 col-md-4">
       <div class="thumbnail">
         <div class="caption">
-          <div style="background-image: url({{ path }});
-                      background-repeat: no-repeat;
-                      background-position: -{{ face.face_position_x }}px -{{ face.face_position_y }}px;
-                      width: {{ face.face_width }}px;
-                      height: {{ face.face_height }}px;">
-          </div>
           <h3>Image Cutout</h3>
           <table class="table table-hover">
             <tbody>
@@ -67,6 +77,7 @@
         </div>
       </div>
     </div>
+
   </div>
 
 </div>

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -47,7 +47,7 @@
 
             {% if officers.items|length == 0 %}
             <div class="container">
-            <h4>Sorry, no officers found in the roster. <a href="/label">Try again</a></h4>
+            <h4>Sorry, no officers found in the roster. <a href="{{ url_for('main.get_ooid') }}">Try again</a></h4>
             </div>
             {% endif %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Noticed a few wonky things testing on staging today that I've fixed in this PR:
 - Link to "Skip picture" on classification app sent people to the wrong volunteer app.
 - "Try again" link on tagger search results went back to the volunteer homepage. Now it goes back to the tagger officer search form. 
 - If the cutouts of the tag were really large (we have some high res photos, we can see cop's pores) then they overflowed the box which was ugly.

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
