### PR TITLE
Make the fabfile backup and deploy better

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -121,7 +121,7 @@ User=nginx
 Group=nginx
 WorkingDirectory=/home/nginx/oovirtenv/OpenOversight/OpenOversight
 Environment="PATH=/home/nginx/oovirtenv/bin"
-ExecStart=/usr/local/bin/gunicorn -w 4 -b 127.0.0.1:4000 --timeout 90 app:app 
+ExecStart=/home/nginx/oovirtenv/bin/gunicorn -w 4 -b 127.0.0.1:4000 --timeout 90 app:app
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
DEPLOY.md (and, coincidentally, OO in staging and prod) asserts the
existence of a virtualenv but doesn't actually manage it very well. So,
for instance, the `pip install` command in `fabfile.py` installs
`requirements.txt`, but for some reason has a good chance of doing it in
the system python context. Which is not ideal, to say the least, because
user `nginx` can't write to `/usr` to populate these, and people who
think they've deployed a new dep may see the deployed service fail to
start. This change makes the virtualenv usage a little more explicit:
we're spawning a gunicorn installed and managed by the virtualenv, and
we're running the pip/python explicitly from the venv.

Also, the backup dumped the sql twice and gave it a name that
didn't sort lexicographically. This fixes that.

## Status

Ready for review

## Notes for Deployment

It should work now.

## Tests and linting
 
 [  :white_check_mark: ] I have rebased my changes on current `develop`
 
 [ :white_check_mark:  ] pytests pass in the development environment on my local machine
 
 [ :white_check_mark: ] `flake8` checks pass
