### PR TITLE
Add a user's email to the profile page

### DIFF
--- a/OpenOversight/app/templates/profile.html
+++ b/OpenOversight/app/templates/profile.html
@@ -46,6 +46,13 @@
             </form>
           </p>
           {% endif %}
+
+          {% if current_user.is_administrator %}
+          <h3>User Email</h3>
+          <p>
+            <code>{{ user.email }}</code>
+          </p>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -193,6 +193,8 @@ def test_user_can_access_profile(mockdata, client, session):
             follow_redirects=True
         )
         assert 'test_user' in rv.data
+        # User email should not appear
+        assert 'User Email' not in rv.data
         # Toggle button should not appear for this non-admin user
         assert 'Toggle (Disable/Enable) User' not in rv.data
 
@@ -206,6 +208,8 @@ def test_admin_sees_toggle_button_on_profiles(mockdata, client, session):
             follow_redirects=True
         )
         assert 'test_user' in rv.data
+        # User email should appear
+        assert 'User Email' in rv.data
         # Admin should be able to see the Toggle button
         assert 'Toggle (Disable/Enable) User' in rv.data
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - Adds a user's email to the profile page only for administrators. This way we can email users.
 - Adds tests to check that we see the email if we are an admin but not if we are a regular user.

## Screenshots (if appropriate)

<img width="358" alt="screen shot 2017-05-06 at 4 54 23 pm" src="https://cloud.githubusercontent.com/assets/7832803/25776824/88290d7a-327e-11e7-99da-7e8b599287ea.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
