### PR TITLE
...email has been sent to you{ by email,}

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -57,7 +57,7 @@ def register():
         token = user.generate_confirmation_token()
         send_email(user.email, 'Confirm Your Account',
                    'auth/email/confirm', user=user, token=token)
-        flash('A confirmation email has been sent to you by email.')
+        flash('A confirmation email has been sent to you.')
         return redirect(url_for('auth.login'))
     return render_template('auth/register.html', form=form, jsloads=jsloads)
 
@@ -80,7 +80,7 @@ def resend_confirmation():
     token = current_user.generate_confirmation_token()
     send_email(current_user.email, 'Confirm Your Account',
                'auth/email/confirm', user=current_user, token=token)
-    flash('A new confirmation email has been sent to you by email.')
+    flash('A new confirmation email has been sent to you.')
     return redirect(url_for('main.index'))
 
 

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -389,7 +389,7 @@ def test_user_can_register_with_legit_credentials(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A confirmation email has been sent to you by email.' in rv.data
+        assert 'A confirmation email has been sent to you.' in rv.data
 
 
 def test_user_cannot_register_with_weak_password(mockdata, client, session):
@@ -404,7 +404,7 @@ def test_user_cannot_register_with_weak_password(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A confirmation email has been sent to you by email.' not in rv.data
+        assert 'A confirmation email has been sent to you.' not in rv.data
 
 
 def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
@@ -416,7 +416,7 @@ def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A new confirmation email has been sent to you by email.' in rv.data
+        assert 'A new confirmation email has been sent to you.' in rv.data
 
 
 def test_user_can_get_password_reset_token_sent(mockdata, client, session):


### PR DESCRIPTION
Fixes #259

## Status

Ready for review / in progress

## Description of Changes

Fixes #259: 'Redundant phrasing: "email has been sent to you by email"'


## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine **except for the ones that already fail in develop**
 
 [x] `flake8` checks pass
