### PR TITLE
Added autofocus to first input field of login, registration forms

### DIFF
--- a/OpenOversight/app/templates/auth/login.html
+++ b/OpenOversight/app/templates/auth/login.html
@@ -13,7 +13,7 @@
         {{ form.hidden_tag() }}
         {{ wtf.form_errors(form, hiddens="only") }}
 
-        {{ wtf.form_field(form.email) }}
+        {{ wtf.form_field(form.email, autofocus="autofocus") }}
         {{ wtf.form_field(form.password) }}
         {{ wtf.form_field(form.remember_me) }}
         {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}

--- a/OpenOversight/app/templates/auth/login.html
+++ b/OpenOversight/app/templates/auth/login.html
@@ -9,7 +9,15 @@
     <h1>Login</h1>
 </div>
 <div class="col-md-6">
-    {{ wtf.quick_form(form, button_map={'submit':'primary'}) }}
+    <form class="form" method="post" role="form">
+        {{ form.hidden_tag() }}
+        {{ wtf.form_errors(form, hiddens="only") }}
+
+        {{ wtf.form_field(form.email) }}
+        {{ wtf.form_field(form.password) }}
+        {{ wtf.form_field(form.remember_me) }}
+        {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
+    </form>
     <br>
     <p>Forgot your password? <a href="{{ url_for('auth.password_reset_request') }}">Click here to reset it</a>.</p>
     <p>New user? <a href="{{ url_for('auth.register') }}">Click here to register</a>.</p>

--- a/OpenOversight/app/templates/auth/register.html
+++ b/OpenOversight/app/templates/auth/register.html
@@ -13,7 +13,7 @@
         {{ form.hidden_tag() }}
         {{ wtf.form_errors(form, hiddens="only") }}
 
-        {{ wtf.form_field(form.email) }}
+        {{ wtf.form_field(form.email, autofocus="autofocus") }}
         {{ wtf.form_field(form.username) }}
         <div class="form-group {% if form.password.errors %}has-error{%endif%} required">
             <label class="control-label" for="password">Password</label>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #263 

Changes proposed in this pull request:

 - Changed login form to custom form (was `wtf.quick_form(form, ...)`) to prep for next change
 - Login and register forms now autofocus on their first form field


## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
