### PR TITLE
README.md: Added local vagrant dev account credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ vagrant ssh
 
 And open `http://localhost:3000` in your favorite browser!
 
+If you need to log in, use the auto-generated test account
+credentials:
+
+```
+Email: test@example.org
+Password: testtest
+```
+
 Please see `CONTRIB.md` for the full developer setup instructions.
 
 ## Deployment


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

README.md: Added local vagrant dev account credentials

Changes proposed in this pull request:

 - README.md: Added local vagrant dev account credentials


## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
