### PR TITLE
leaderboard.html: Added line breaks between user scores

### DIFF
--- a/OpenOversight/app/templates/leaderboard.html
+++ b/OpenOversight/app/templates/leaderboard.html
@@ -16,6 +16,7 @@
         <a href="{{ url_for( 'main.profile', username=sorter[0].username ) }}">
              {{ sorter[0].username }}</a>
         - {{ sorter[1] }}
+        <br />
       {% endfor %}
     </div>
   </div>
@@ -28,6 +29,7 @@
         <a href="{{ url_for( 'main.profile', username=tagger[0].username ) }}">
              {{ tagger[0].username }}</a>
         - {{ tagger[1] }}
+        <br />
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
Fixes #273

## Status

Ready for review

## Description of Changes

Fixes #273 

Changes proposed in this pull request:

 - Fixed leaderboard (users + scores were all on the same line)


## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
