### PR TITLE
defaults to not sure for better coverage of possible officers

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -50,11 +50,11 @@ class FindOfficerForm(Form):
     dept = SelectField('dept', default='ChicagoPD', choices=DEPT_CHOICES,
                        validators=[DataRequired(),
                                    AnyOf(allowed_values(DEPT_CHOICES))])
-    rank = SelectField('rank', default='COMMANDER', choices=RANK_CHOICES,
+    rank = SelectField('rank', default='Not Sure', choices=RANK_CHOICES,
                        validators=[AnyOf(allowed_values(RANK_CHOICES))])
-    race = SelectField('race', default='WHITE', choices=RACE_CHOICES,
+    race = SelectField('race', default='Not Sure', choices=RACE_CHOICES,
                        validators=[AnyOf(allowed_values(RACE_CHOICES))])
-    gender = SelectField('gender', default='M', choices=GENDER_CHOICES,
+    gender = SelectField('gender', default='Not Sure', choices=GENDER_CHOICES,
                          validators=[AnyOf(allowed_values(GENDER_CHOICES))])
     min_age = IntegerField('min_age', default=16, validators=[
         NumberRange(min=16, max=100)


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #274 .

Changes proposed in this pull request:

 - By default, we should offer the widest possible set of officers (not sure) for all categories.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [X] I have rebased my changes on current `develop`
 
 [X]  pytests pass in the development environment on my local machine
 
 [X] `flake8` checks pass
