### PR TITLE
Accept case insensitive filenames for uploads

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -33,7 +33,7 @@ def add_new_assignment(officer_id, form):
 
 def allowed_file(filename):
     return '.' in filename and \
-           filename.rsplit('.', 1)[1] in current_app.config['ALLOWED_EXTENSIONS']
+           filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']
 
 
 def get_random_image(image_query):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -80,6 +80,10 @@ def test_s3_url(mockdata):
     assert 'te/st' in url
 
 
+def test_user_can_submit_allowed_file(mockdata):
+    for file_to_submit in ['valid_photo.png', 'valid_photo.jpg', 'valid.photo.jpg', 'valid_photo.PNG', 'valid_photo.JPG']: 
+        assert OpenOversight.app.utils.allowed_file(file_to_submit) is True
+
 def test_user_cannot_submit_malicious_file(mockdata):
     file_to_submit = 'passwd'
     assert OpenOversight.app.utils.allowed_file(file_to_submit) is False

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -81,8 +81,9 @@ def test_s3_url(mockdata):
 
 
 def test_user_can_submit_allowed_file(mockdata):
-    for file_to_submit in ['valid_photo.png', 'valid_photo.jpg', 'valid.photo.jpg', 'valid_photo.PNG', 'valid_photo.JPG']: 
+    for file_to_submit in ['valid_photo.png', 'valid_photo.jpg', 'valid.photo.jpg', 'valid_photo.PNG', 'valid_photo.JPG']:
         assert OpenOversight.app.utils.allowed_file(file_to_submit) is True
+
 
 def test_user_cannot_submit_malicious_file(mockdata):
     file_to_submit = 'passwd'

--- a/vagrant/puppet/manifests/default.pp
+++ b/vagrant/puppet/manifests/default.pp
@@ -16,7 +16,7 @@
   }
   $development = true
 
-  $geckodriver_version = 'v0.13.0'
+  $geckodriver_version = 'v0.17.0'
   $geckodriver_url = "https://github.com/mozilla/geckodriver/releases/download/${geckodriver_version}/geckodriver-${geckodriver_version}-linux64.tar.gz"
 
   $virtualenv = "/home/${system_user}/oovirtenv"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes an issue reported on our Slack where files with capitalized extensions were incorrectly rejected by the backend.

Also updates the version of gecko-webdriver installed by the puppet provisioner, since the previous was old enough to 404.

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
