### PR TITLE
renames about to FAQ

### DIFF
--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div class="container theme-showcase" role="main">
-<h1>About OpenOversight</h1>
+<h1>Frequently Asked Questions</h1>
 <p>OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police accountability using public and crowdsourced data. We maintain a database of police officers and provide a digital gallery that allows the public to identify the name and badge number of a police officer they would like to file a complaint about.</p>
 <p><a href="/find" class="btn btn-info" id="try-it">Try it</a></p>
 

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -52,7 +52,7 @@
             {% if current_user and current_user.is_authenticated %}
               <li><a href="/leaderboard">Leaderboard</a></li>
             {% endif %}
-            <li><a href="/about">About</a></li>
+            <li><a href="/about">FAQ</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             {% if current_user and current_user.is_authenticated %}


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes  `Replace confusing "About" page with a "FAQ"` in #252 

Changes proposed in this pull request:

 - Rename "About" to "FAQ"
 - Does not change the `/about/` route

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [Y] I have rebased my changes on current `develop`
 
 [Y] pytests pass in the development environment on my local machine
 
 [Y] `flake8` checks pass

```
(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ pytest
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.6, pytest-3.0.3, py-1.4.34, pluggy-0.4.0
rootdir: /vagrant, inifile: 
plugins: pep8-1.0.6, cov-2.4.0
collected 99 items 

tests/test_functional.py ...
tests/test_models.py ...................
tests/test_routes.py .................................................................
tests/test_utils.py ............

======================================================== 99 passed in 186.92 seconds ========================================================
(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ 
```