### PR TITLE
Initial multi department support

### DIFF
--- a/OpenOversight/app/db_repository/versions/003_migration.py
+++ b/OpenOversight/app/db_repository/versions/003_migration.py
@@ -1,0 +1,27 @@
+from sqlalchemy import *
+from migrate import *
+
+
+from migrate.changeset import schema
+pre_meta = MetaData()
+post_meta = MetaData()
+departments = Table('departments', post_meta,
+    Column('id', Integer, primary_key=True, nullable=False),
+    Column('name', String(length=255), index=True, nullable=False),
+    Column('short_name', String(length=100), nullable=False),
+)
+
+
+def upgrade(migrate_engine):
+    # Upgrade operations go here. Don't create your own engine; bind
+    # migrate_engine to your metadata
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['departments'].create()
+
+
+def downgrade(migrate_engine):
+    # Operations to reverse the above upgrade go here.
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['departments'].drop()

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -105,10 +105,10 @@ class AssignmentForm(Form):
 class DepartmentForm(Form):
     name = StringField(
         'Full name of police department, e.g. Chicago Police Department',
-        default='', validators=[Regexp('\w*'), Length(max=500), DataRequired()]
+        default='', validators=[Regexp('\w*'), Length(max=255), DataRequired()]
     )
     short_name = StringField(
         'Shortened acronym for police department, e.g. CPD',
-        default='', validators=[Regexp('\w*'), Length(max=10), DataRequired()]
+        default='', validators=[Regexp('\w*'), Length(max=100), DataRequired()]
     )
     submit = SubmitField(label='Add')

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -100,3 +100,15 @@ class AssignmentForm(Form):
     unit = QuerySelectField('unit', validators=[Optional()],
                             query_factory=unit_choices)
     star_date = DateField('star_date', validators=[Optional()])
+
+
+class DepartmentForm(Form):
+    name = StringField(
+        'Full name of police department, e.g. Chicago Police Department',
+        default='', validators=[Regexp('\w*'), Length(max=500), DataRequired()]
+    )
+    short_name = StringField(
+        'Shortened acronym for police department, e.g. CPD',
+        default='', validators=[Regexp('\w*'), Length(max=10), DataRequired()]
+    )
+    submit = SubmitField(label='Add')

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -204,14 +204,15 @@ def add_department():
     form = DepartmentForm()
     if form.validate_on_submit():
         departments = [x[0] for x in db.session.query(Department.name).all()]
-        department = Department(name=form.name.data,
-                                short_name=form.short_name.data)
-        db.session.add(department)
-        if department.name not in departments:
+
+        if form.name.data not in departments:
+            department = Department(name=form.name.data,
+                                    short_name=form.short_name.data)
+            db.session.add(department)
             db.session.commit()
             flash('New department {} added to OpenOversight'.format(department.name))
         else:
-            flash('Department {} already exists'.format(department.name))
+            flash('Department {} already exists'.format(form.name.data))
         return redirect(url_for('main.department_overview'))
     else:
         return render_template('add_department.html', form=form)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -19,8 +19,8 @@ from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
                      allowed_file, add_new_assignment)
 from .forms import (FindOfficerForm, FindOfficerIDForm,
-                    FaceTag, AssignmentForm)
-from ..models import db, Image, User, Face, Officer, Assignment
+                    FaceTag, AssignmentForm, DepartmentForm)
+from ..models import db, Image, User, Face, Officer, Assignment, Department
 
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0o077)
@@ -189,6 +189,32 @@ def classify_submission(image_id, contains_cops):
         flash('Unknown error occurred')
     return redirect(redirect_url())
     # return redirect(url_for('main.display_submission', image_id=image_id))
+
+
+@main.route('/departments')
+def department_overview():
+    departments = Department.query.all()
+    return render_template('departments.html', departments=departments)
+
+
+@main.route('/department/new', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def add_department():
+    form = DepartmentForm()
+    if form.validate_on_submit():
+        departments = [x[0] for x in db.session.query(Department.name).all()]
+        department = Department(name=form.name.data,
+                                short_name=form.short_name.data)
+        db.session.add(department)
+        if department.name not in departments:
+            db.session.commit()
+            flash('New department {} added to OpenOversight'.format(department.name))
+        else:
+            flash('Department {} already exists'.format(department.name))
+        return redirect(url_for('main.department_overview'))
+    else:
+        return render_template('add_department.html', form=form)
 
 
 @main.route('/tag/delete/<int:tag_id>', methods=['POST'])

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -12,7 +12,8 @@ db = SQLAlchemy()
 class Department(db.Model):
     __tablename__ = 'departments'
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(255), index=True)
+    name = db.Column(db.String(255), index=True, unique=True, nullable=False)
+    short_name = db.Column(db.String(100), unique=False, nullable=False)
 
     def __repr__(self):
         return '<Department ID {}: {}>'.format(self.id, self.name)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -9,6 +9,15 @@ from . import login_manager
 db = SQLAlchemy()
 
 
+class Department(db.Model):
+    __tablename__ = 'departments'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), index=True)
+
+    def __repr__(self):
+        return '<Department ID {}: {}>'.format(self.id, self.name)
+
+
 class Officer(db.Model):
     __tablename__ = 'officers'
 

--- a/OpenOversight/app/templates/add_department.html
+++ b/OpenOversight/app/templates/add_department.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+{% block title %}OpenOversight Admin - Add Department{% endblock %}
+
+{% block content %}
+<div class="container theme-showcase" role="main">
+
+<div class="page-header">
+    <h1>Add Department</h1>
+</div>
+<div class="col-md-6">
+    <form class="form" method="post" role="form">
+        {{ form.hidden_tag() }}
+        {{ wtf.form_errors(form, hiddens="only") }}
+
+        {{ wtf.form_field(form.name, autofocus="autofocus") }}
+        {{ wtf.form_field(form.short_name) }}
+        {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
+    </form>
+    <br>
+</div>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -55,6 +55,9 @@
             <li><a href="/about">About</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
+            {% if current_user.is_administrator %}
+            <li><a href="{{ url_for('main.department_overview') }}">Departments</a></li>
+            {% endif %}
             {% if current_user and current_user.is_authenticated %}
             <li><a href="{{ url_for('main.profile', username=current_user.username) }}">Profile</a></li>
             <li class="dropdown">

--- a/OpenOversight/app/templates/departments.html
+++ b/OpenOversight/app/templates/departments.html
@@ -15,11 +15,13 @@
 
     {% endfor %}
 
+    {% if current_user.is_administrator %}
     <a href="{{ url_for('main.add_department') }}"
           class="btn btn-primary" role="button">
         <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
         Add New Department
     </a>
+    {% endif %}
 
   </div>
 

--- a/OpenOversight/app/templates/departments.html
+++ b/OpenOversight/app/templates/departments.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+
+<div class="container" role="main">
+
+  <div class="text-center">
+    <h1><small>Departments</small></h1>
+  </div>
+
+  <div class="text-center frontpage-leads">
+
+    {% for department in departments %}
+
+    <h4><small>{{ department.name }} ({{department.short_name}})</small></h4>
+
+    {% endfor %}
+
+    <a href="{{ url_for('main.add_department') }}"
+          class="btn btn-primary" role="button">
+        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+        Add New Department
+    </a>
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -165,6 +165,11 @@ def mockdata(session, request):
     session.add_all(assignments)
     session.add_all(faces)
 
+    department = models.Department(name='Springfield Police Department',
+                                   short_name='SPD')
+    session.add(department)
+    session.commit()
+
     test_user = models.User(email='jen@example.org',
                             username='test_user',
                             password='dog',
@@ -196,6 +201,7 @@ def mockdata(session, request):
         models.Image.query.delete()
         models.Face.query.delete()
         models.Unit.query.delete()
+        models.Department.query.delete()
         session.commit()
         session.flush()
 

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -1,7 +1,11 @@
 from pytest import raises
 import time
 from OpenOversight.app.models import (Officer, Assignment, Face, Image, Unit,
-                                      User, db)
+                                      User, db, Department)
+
+def test_department_repr(mockdata):
+    department = Department.query.first()
+    assert department.__repr__() == '<Department ID {}: {}>'.format(department.id, department.name)
 
 
 def test_officer_repr(mockdata):

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -3,6 +3,7 @@ import time
 from OpenOversight.app.models import (Officer, Assignment, Face, Image, Unit,
                                       User, db, Department)
 
+
 def test_department_repr(mockdata):
     department = Department.query.first()
     assert department.__repr__() == '<Department ID {}: {}>'.format(department.id, department.name)

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -10,7 +10,7 @@ from OpenOversight.app.auth.forms import (LoginForm, RegistrationForm,
                                           ChangePasswordForm, PasswordResetForm,
                                           PasswordResetRequestForm,
                                           ChangeEmailForm)
-from OpenOversight.app.models import User, Face
+from OpenOversight.app.models import User, Face, Department
 
 
 @pytest.mark.parametrize("route", [
@@ -625,6 +625,11 @@ def test_admin_can_add_police_department(mockdata, client, session):
 
         assert 'New department' in rv.data
 
+        # Check the department was added to the database
+        department = Department.query.filter_by(
+            name='Test Police Department').one()
+        assert department.short_name == 'TPD'
+
 
 def test_admin_cannot_add_duplicate_police_department(mockdata, client,
                                                       session):
@@ -648,6 +653,12 @@ def test_admin_cannot_add_duplicate_police_department(mockdata, client,
         )
 
         assert 'already exists' in rv.data
+
+        # Check that only one department was added to the database
+        # one() method will throw exception if more than one department found
+        department = Department.query.filter_by(
+            name='Chicago Police Department').one()
+        assert department.short_name == 'CPD'
 
 
 def test_admin_can_see_department_list(mockdata, client, session):

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,7 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
   # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # within the machine from a port on the host machine.
    config.vm.network "forwarded_port", guest: 3000, host: 3000
 
   # Provider-specific configuration so you can fine-tune various

--- a/test_data.py
+++ b/test_data.py
@@ -103,6 +103,11 @@ def populate():
     db.session.add_all(test_images)
     db.session.commit()
 
+    department = models.Department(name='Springfield Police Department',
+                                   short_name='SPD')
+    db.session.add(department)
+    db.session.commit()
+
     officers = [generate_officer() for o in range(NUM_OFFICERS)]
     db.session.add_all(officers)
     db.session.commit()
@@ -137,6 +142,10 @@ def cleanup():
     faces = models.Face.query.all()
     for face in faces:
         db.session.delete(face)
+
+    departments = models.Department.query.all()
+    for dept in departments:
+        db.session.delete(dept)
 
     officers = models.Officer.query.all()
     for po in officers:

--- a/test_data.py
+++ b/test_data.py
@@ -120,6 +120,7 @@ def populate():
     test_user = models.User(email='test@example.org',
                             username='test_user',
                             password='testtest',
+                            is_administrator=True,
                             confirmed=True)
     db.session.add(test_user)
     db.session.commit()


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR adds first steps towards initial multi-department support (partially #296):

* Adds a 'departments' model to enable the web application to store which police departments the instance of OpenOversight supports. 

* Adds a new page (`/departments`) to list and manage basic data about each new police department. We can extend this to store the ranks for each department and any other department-specific information.

* Adds a new admin-only form to add a new department (`/department/new`)

## Multi-City Plan

1. After this is deployed, I will go into the admin panel and add "Chicago Police Department" as the first department. 
2. In a followup PR I will further decouple the code from Chicago (e.g. once step 1 is done then I can remove the hardcoded "Chicago Police Department" from all templates) and modify the other models (e.g. officers, units, etc.) to foreign key them to this first department. 

## Testing

Especially because this includes a migration, during review one should test this before merging it, so you should do something like this:

1. Provision development VM on 8a272dcccd2895be9cd90f6f3fe1de1262372429 (that commit makes the test user an admin)
2. `vagrant ssh`
3. `source ~/oovirtenv/bin/activate`
4. From your host OS: `git checkout multi-department-support`
5. Back in the VM: `cd /vagrant/OpenOversight`
7. `python manage.py migrate`
8. `python manage.py runserver`
9. Verify the functionality claimed in this PR is accurate, and recall that the test account credentials are `test@example.org` with password `testtest`.

## Screenshots

![screen shot 2017-09-10 at 1 24 45 am](https://user-images.githubusercontent.com/7832803/30247353-68ea2c08-95c7-11e7-81d6-35f6aa4a0235.png)

## Tests and linting
 
 - [x] I have rebased my changes on current `develop`
 
 - [x] pytests pass in the development environment on my local machine
 
 - [x] `flake8` checks pass
