### PR TITLE
Add multi-department support for photo submission

### DIFF
--- a/OpenOversight/app/db_repository/versions/004_migration.py
+++ b/OpenOversight/app/db_repository/versions/004_migration.py
@@ -1,0 +1,35 @@
+from sqlalchemy import *
+from migrate import *
+
+
+from migrate.changeset import schema
+pre_meta = MetaData()
+post_meta = MetaData()
+
+
+raw_images = Table('raw_images', post_meta,
+    Column('id', Integer, primary_key=True, nullable=False),
+    Column('filepath', String(length=255)),
+    Column('hash_img', String(length=120)),
+    Column('date_image_inserted', DateTime),
+    Column('date_image_taken', DateTime),
+    Column('contains_cops', Boolean),
+    Column('user_id', Integer),
+    Column('is_tagged', Boolean, default=ColumnDefault(False)),
+    Column('department_id', Integer),
+)
+
+
+def upgrade(migrate_engine):
+    # Upgrade operations go here. Don't create your own engine; bind
+    # migrate_engine to your metadata
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['raw_images'].columns['department_id'].create()
+
+
+def downgrade(migrate_engine):
+    # Operations to reverse the above upgrade go here.
+    pre_meta.bind = migrate_engine
+    post_meta.bind = migrate_engine
+    post_meta.tables['raw_images'].columns['department_id'].drop()

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -106,6 +106,8 @@ class Image(db.Model):
     user = db.relationship('User', backref='raw_images')
     is_tagged = db.Column(db.Boolean, default=False, unique=False, nullable=True)
 
+    department_id = db.Column(db.Integer)
+
     def __repr__(self):
         return '<Image ID {}: {}>'.format(self.id, self.filepath)
 

--- a/OpenOversight/app/templates/submit_department.html
+++ b/OpenOversight/app/templates/submit_department.html
@@ -4,19 +4,20 @@
 <link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
 
 <div class="container theme-showcase" role="main">
+
    <div class="page-header">
         <h1>Submit Images <small>containing faces/badge numbers of uniformed police officers</small></h1>
    </div>
 
-  <h3>Drop images here to submit</h3>
+  <h3>Drop images here to submit photos of officers in {{ department.name }}</h3>
 
-  <form action="/upload" class="dropzone" id="my-cop-dropzone">
+  <form action="/upload/department/{{ department.id }}" class="dropzone" id="my-cop-dropzone">
   </form>
 
   <script>
   $(document).ready(function(){
     Dropzone.options.myCopDropzone = {
-      url: "/upload",
+      url: "/upload/department/{{ department.id }}",
       method: "POST",
       uploadMultiple: false,
       parallelUploads: 50,
@@ -31,6 +32,7 @@
 
   });
   </script>
+
 </div>
 
 <div class="container">
@@ -41,6 +43,5 @@
 
 <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
-
 
 {% endblock %}

--- a/OpenOversight/app/templates/submit_deptselect.html
+++ b/OpenOversight/app/templates/submit_deptselect.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+
+<link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
+
+<div class="container theme-showcase" role="main">
+
+<div class="text-center frontpage-leads">
+  <h1><small>Submit images of officers in action in: </small></h1>
+  {% for department in departments %}
+  <p>
+  <a href="/submit/department/{{ department.id }}" class="btn btn-lg btn-primary">
+      <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
+      {{ department.name }}</a>
+  </p>
+  {% endfor %}
+</div>
+
+</div>
+
+{% endblock %}

--- a/OpenOversight/manage.py
+++ b/OpenOversight/manage.py
@@ -99,5 +99,15 @@ def make_admin_user():
                                                                   email))
 
 
+@manager.command
+def link_images_to_department():
+    # Link existing images to first department
+    from app.models import Image, db
+    images = Image.query.all()
+    for image in images:
+        image.department_id = 1
+    db.session.commit()
+
+
 if __name__ == "__main__":
     manager.run()

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -142,10 +142,14 @@ def mockdata(session, request):
     SEED = current_app.config['SEED']
     random.seed(SEED)
 
-    image1 = models.Image(filepath='static/images/test_cop1.png')
-    image2 = models.Image(filepath='static/images/test_cop2.png')
-    image3 = models.Image(filepath='static/images/test_cop3.png')
-    image4 = models.Image(filepath='static/images/test_cop4.png')
+    image1 = models.Image(filepath='static/images/test_cop1.png',
+                          department_id=1)
+    image2 = models.Image(filepath='static/images/test_cop2.png',
+                          department_id=1)
+    image3 = models.Image(filepath='static/images/test_cop3.png',
+                          department_id=1)
+    image4 = models.Image(filepath='static/images/test_cop4.png',
+                          department_id=1)
 
     unit1 = models.Unit(descrip="test")
 

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -21,6 +21,7 @@ from OpenOversight.app.models import User, Face, Department
     ('/tagger_find'),
     ('/privacy'),
     ('/submit'),
+    ('/submit/department/1'),
     ('/label'),
     ('/departments'),
     ('/officer/3'),
@@ -671,3 +672,16 @@ def test_admin_can_see_department_list(mockdata, client, session):
         )
 
         assert 'Departments' in rv.data
+
+
+def test_expected_dept_appears_in_submission_dept_selection(mockdata, client,
+                                                            session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.get(
+            url_for('main.submit_data'),
+            follow_redirects=True
+        )
+
+        assert 'Springfield Police Department' in rv.data

--- a/test_data.py
+++ b/test_data.py
@@ -93,11 +93,16 @@ def populate():
     """ Populate database with test data"""
 
     # Add images from Springfield Police Department
-    image1 = models.Image(filepath='static/images/test_cop1.png')
-    image2 = models.Image(filepath='static/images/test_cop2.png')
-    image3 = models.Image(filepath='static/images/test_cop3.png')
-    image4 = models.Image(filepath='static/images/test_cop4.png')
-    image5 = models.Image(filepath='static/images/test_cop5.jpg')
+    image1 = models.Image(filepath='static/images/test_cop1.png',
+                          department_id=1)
+    image2 = models.Image(filepath='static/images/test_cop2.png',
+                          department_id=1)
+    image3 = models.Image(filepath='static/images/test_cop3.png',
+                          department_id=1)
+    image4 = models.Image(filepath='static/images/test_cop4.png',
+                          department_id=1)
+    image5 = models.Image(filepath='static/images/test_cop5.jpg',
+                          department_id=1)
 
     test_images = [image1, image2, image3, image4, image5]
     db.session.add_all(test_images)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR extends initial multi-department support:

* Links existing images to the first department (Chicago in the case of LPL's instance). 
* Adds a first step in the photo submission flow for the user to indicate _which department_ the photos are for. 

![lpl_multi_submission](https://user-images.githubusercontent.com/7832803/30577844-b1d68f24-9cc5-11e7-83e0-d0c95735b767.gif)

# Testing

1. Checkout base PR:

```
git checkout multi-dept-submission
```
2. Provision development VM, and migrate the database: 

```
vagrant up
vagrant ssh
source ~/oovirtenv/bin/activate
cd /vagrant/OpenOversight
python manage.py migrate
```

No errors should appear.

3. Link existing images to the first department:

```
python manage.py link_images_to_department 
```

If you want to verify that images are linked to the right department, you can always do the following in `python manage.py shell`:

```
>>> from app.models import Image
>>> Image.query.first().department_id
1
```

4. Now add a few departments via the "Departments" menu and then go to "Submit Photos" to select a department and submit some test photos (note this does not work in a development environment because a S3 bucket needs to be hooked up, so you'll either need to hook up S3 to test or just run this on staging). See the gif for how to do this.

5. We do _not_ have unit test coverage of the `/upload` route, so to verify the proper metadata was added in the database you can use `python manage.py shell`, for example:

```
>>> from app.models import Image
>>> Image.query.all()
[<Image ID 1: static/images/test_cop1.png>, <Image ID 2: static/images/test_cop2.png>, <Image ID 3: static/images/test_cop3.png>, <Image ID 4: static/images/test_cop4.png>, <Image ID 5: static/images/test_cop5.jpg>, <Image ID 6: https://s3-us-west-2.amazonaws.com/openoversight/c2/ff41871891265935d87fe8cf701a010a863d16244f0dc30d387300292d13a5.jpg>, <Image ID 7: https://s3-us-west-2.amazonaws.com/openoversight/1e/3b5be1c4912dcfb5e6ab47e74075e62d3187b023e54c9ba25a3ee060cdf2f2.jpg>, <Image ID 8: https://s3-us-west-2.amazonaws.com/openoversight/b7/d5d2a2cf705e664af0d08846b2de06a00a45f8e79c0686a4c192f257322848.jpg>, <Image ID 9: https://s3-us-west-2.amazonaws.com/openoversight/d9/955079ab09d4a5ad3801ab53f5d9efc36291026e0c3ba3699dc89f824f8883.png>]
>>> Image.query.all()[7].department_id
2
```

Since I selected Berkeley (which has `department_id = 2`), the result here matches my expectation.

## Tests and linting
 
 - [x] I have rebased my changes on current `develop`
 
 - [x] pytests pass in the development environment on my local machine
 
 - [x] `flake8` checks pass
