### PR TITLE
Fix vagrant provisioning to let gunicorn write oo logs (#299)

### DIFF
--- a/vagrant/puppet/manifests/default.pp
+++ b/vagrant/puppet/manifests/default.pp
@@ -112,8 +112,9 @@
   file {'/tmp/openoversight.log':
     ensure  => present,
     owner   => $system_user,
-    group   => $system_user,
-    mode    => '0644',
+    group   => "www-data",
+    mode    => '0664',
+    require => Python::Virtualenv[$virtualenv],
   }
 
   exec{'/usr/bin/apt-get update': }


### PR DESCRIPTION
Gunicorn fails to start up on first vagrant provision because it cannot
write to /tmp/openoversight.log, because gunicorn starts up as www-data
instead of the vagrant user:
```python
root@vagrant-ubuntu-trusty-64:~# cat /etc/gunicorn.d/oo
CONFIG = {
  'mode': 'wsgi',
  'environment': {
    'PYTHONPATH': '/home/vagrant/oovirtenv'
  },
  'working_dir': '/vagrant/OpenOversight',
  'user': 'www-data',
  'group': 'www-data',
  'python': '/home/vagrant/oovirtenv/bin/python',
  'args': (
    '--bind=0.0.0.0:3000',
    '--workers=3',
    '--timeout=30',

    '--log-level=error',
    'app:app',
  ),
}
```
As specced, it doesn't look like there's a hard-coded knob for user/group
gunicorn runs as: https://github.com/stankevich/puppet-python#pythongunicorn
So we can either change the template (ew) or change the permissions on
/tmp/openoversight.log to be rw for both user vagrant and group www-data.

This change does the latter, in keeping with the principle "make the smallest
change that makes things work".

## Status

Ready for review

## Description of Changes

Fixes #299.

Changes proposed in this pull request:

See above.

## Notes for Deployment

No changes to production deployment; `vagrant provision` will get you back up and running locally.

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
