### PR TITLE
Add multi department volunteer image classification support

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -63,21 +63,24 @@ def get_ooid():
 
 @main.route('/label', methods=['GET', 'POST'])
 def get_started_labeling():
-    return render_template('label_data.html')
+    departments = Department.query.all()
+    return render_template('label_data.html', departments=departments)
 
 
-@main.route('/sort', methods=['GET', 'POST'])
+@main.route('/sort/department/<int:department_id>', methods=['GET', 'POST'])
 @login_required
-def sort_images():
+def sort_images(department_id):
     # Select a random unsorted image from the database
-    image_query = Image.query.filter_by(contains_cops=None)
+    image_query = Image.query.filter_by(contains_cops=None) \
+                             .filter_by(department_id=department_id)
     image = get_random_image(image_query)
 
     if image:
         proper_path = serve_image(image.filepath)
     else:
         proper_path = None
-    return render_template('sort.html', image=image, path=proper_path)
+    return render_template('sort.html', image=image, path=proper_path,
+                           department_id=department_id)
 
 
 @main.route('/tutorial')

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -10,15 +10,18 @@
     </div>
 
     <div class="text-center frontpage-leads">
-      <p>
-        <a class="btn btn-lg btn-primary" href="{{ url_for('main.sort_images') }}">
-          <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
-          Image classification
-        </a>
-      </p>
+      <h2><small>Image classification</small></h2>
       <p>
         Sort submitted images into those with and without officers.
       </p>
+      {% for department in departments %}
+      <p>
+        <a class="btn btn-lg btn-primary" href="{{ url_for('main.sort_images', department_id=department.id) }}">
+          <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
+          {{ department.name }}
+        </a>
+      </p>
+      {% endfor %}
     </div>
 
     <div class="text-center frontpage-leads">

--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -44,7 +44,7 @@ $(document).bind('keydown', 's', function(){
           </form>
         </div>
         <div class="col-sm-4 text-center">
-          <a href="{{ url_for('main.sort_images') }}" id="answer-skip" class="btn btn-lg btn-primary" role="button">
+          <a href="{{ url_for('main.sort_images', department_id=department_id) }}" id="answer-skip" class="btn btn-lg btn-primary" role="button">
             <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> <u>S</u>kip</a>
         </div>
         <div class="col-sm-4 text-center">

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -39,7 +39,7 @@ def test_routes_ok(route, client, mockdata):
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route", [
     ('/auth/unconfirmed'),
-    ('/sort'),
+    ('/sort/department/1'),
     ('/cop_face'),
     ('/image/1'),
     ('/image/tagged/1'),
@@ -181,7 +181,7 @@ def test_logged_in_user_can_access_sort_form(mockdata, client, session):
         login_user(client)
 
         rv = client.get(
-            url_for('main.sort_images'),
+            url_for('main.sort_images', department_id=1),
             follow_redirects=True
         )
         assert 'Do you see police officers in the photo' in rv.data


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #309, enables volunteers to classify images from a particular police department

## Notes for Deployment

Straightforward, no migrations needed

## Screenshots (if appropriate)

<img width="603" alt="screen shot 2017-11-07 at 7 26 19 pm" src="https://user-images.githubusercontent.com/7832803/32530187-8e3ddbb4-c3f1-11e7-9c6e-a3749c00de05.png">


## Tests and linting
 
 - [x] I have rebased my changes on current `develop`
 
 - [x] pytests pass in the development environment on my local machine
 
 - [x] `flake8` checks pass
