### PR TITLE
322 revamp cont

### DIFF
--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -176,6 +176,7 @@ body {
 
 .subhero {
     color: #333;
+    font-size: 18px;
     font-family: Courier, sans-serif;
 }
 
@@ -301,11 +302,26 @@ body {
     display: flex;
 }
 
+.bordered-box {
+    border: 0 solid #999999;
+    border-right-width: 1px;
+}
+
 @media (max-width: 750px) {
     .display-flex {
         flex-wrap: wrap;
         justify-content: center;
     }
+
+    .bordered-box {
+        border-right-width: 0;
+        border-bottom-width: 1px;
+    }
+}
+
+.vertical-padding {
+    padding-left: 50px;
+    padding-right: 50px;
 }
 
 .horizontal-padding {

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -168,6 +168,13 @@ body {
      padding: 150px;
  }
 
+.hero-section-no-sub {
+    /*TODO: get background image- using color as standin for now*/
+    background-color: #bbbbbb;
+    text-align: center;
+    padding: 110px;
+}
+
 .hero {
     color:white;
     font-size:40px;
@@ -201,7 +208,7 @@ body {
 
 .hr-banner p {
     text-align: left;
-    font-size: 20px;
+    font-size: 18px;
 }
 
  h1 small {
@@ -294,6 +301,10 @@ body {
     background-color: #dce1e5;
 }
 
+.bg-light-blue {
+    background-color: #e8f0f9;
+}
+
 .bg-white {
     background-color: #ffffff;
 }
@@ -346,6 +357,18 @@ body {
 .sink-row {
     position: relative;
     margin-top: -70px;
+}
+
+.font-weight-300 {
+    font-weight: 300;
+}
+
+.i {
+    font-style: italic;
+}
+
+.pb-50 {
+    padding-bottom: 50px;
 }
 
 .pb-90 {

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -313,7 +313,6 @@ body {
 
 .col-half-border {
     padding: 60px;
-    text-align: left;
     border: 1px solid #d3d3d3;
     margin: 12px;
 }
@@ -321,7 +320,6 @@ body {
 .col-half-no-border {
     height: inherit;
     padding: 70px 120px;
-    text-align: left;
     width: 100%;
 }
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -168,10 +168,7 @@ body {
      padding: 150px;
  }
 
-.hero-section-no-sub {
-    /*TODO: get background image- using color as standin for now*/
-    background-color: #bbbbbb;
-    text-align: center;
+.hero-section.no-sub {
     padding: 110px;
 }
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -75,6 +75,12 @@ body {
      width: auto;
  }
 
+ #navbar li a:hover {
+     border: 0 solid black;
+     border-bottom-width: 2px;
+     border-radius: 0;
+ }
+
  .glyphicon {
      font-size: 30px;
  }

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -174,6 +174,16 @@ body {
     text-shadow: 1px 1px 1px #999;
 }
 
+@media (max-width: 550px) {
+    .hero {
+        font-size: 28px;
+    }
+    .hero-section {
+        padding-left: 50px;
+        padding-right: 50px;
+    }
+}
+
 .subhero {
     color: #333;
     font-size: 18px;

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -182,13 +182,17 @@ body {
 
  .hr-banner {
      padding: 90px;
-     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
      font-weight: 300;
      background-color: #333333;
      color: white;
      text-align: center;
      font-size: 28px;
  }
+
+.hr-banner p {
+    text-align: left;
+    font-size: 20px;
+}
 
  h1 small {
      color: #333333;

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -251,6 +251,16 @@ body {
     color: white;
 }
 
+.btn-unstyled {
+    padding: 0;
+    color: #666666;
+}
+
+.btn-unstyled:hover {
+    color: #333333;
+    text-decoration: none;
+}
+
 .control-label {
     text-transform: uppercase;
     color: #555555;
@@ -298,8 +308,9 @@ body {
     }
 }
 
-.padded-row {
-    padding: 25px 50px;
+.horizontal-padding {
+    padding-top: 25px;
+    padding-bottom: 25px;
 }
 
 .sink-row {

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -218,6 +218,11 @@ body {
      margin: 20px auto;
  }
 
+ .lead.margin-less {
+     margin-bottom: 0;
+     margin-top: 10px;
+ }
+
  .btn {
      color: #555555;
  }

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -19,18 +19,18 @@
 
   <div class="row font-weight-300 text-center">
     <div class="col-lg-4">
-      <i class="fa fa-institution fa-2x"></i>
+      <span class="fa fa-institution fa-2x"></span>
       <p>This project is a direct response to the failure of leaders in local governments to implement systems that
         effectively and safely allow the public to identify and report problematic police officers.
       </p>
     </div>
     <div class="col-lg-4">
-      <i class="fa fa-map-marker fa-2x"></i><p>
+      <span class="fa fa-map-marker fa-2x"></span><p>
         It is the first project of its kind in the United States, and was first implemented in Chicago in October 2016.
       In fall 2017, OpenOversight launched in the East Bay of the San Francisco Bay Area.</p>
     </div>
     <div class="col-lg-4">
-      <i class="fa fa-github fa-2x"></i><p>
+      <span class="fa fa-github fa-2x"></span><p>
       OpenOversight is released as free and open source software so others can launch similar police accountability
         projects in their own cities. The software is available for download and collaborative development on
       <a href="https://github.com/lucyparsons/OpenOversight">GitHub</a>.</p>

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -1,30 +1,58 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="container theme-showcase" role="main">
-<h1>About OpenOversight</h1>
-<p>OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police accountability using public and crowdsourced data. We maintain databases of police officers in several cities, providing digital galleries that make identifying police officers easier for the public, including for the purpose of complaints.</p>
-<p><a href="/find" class="btn btn-info" id="try-it">Try it</a></p>
+<div class="" role="main">
+  <div class="hero-section">
+    <div class="hero">About OpenOversight</div>
+    <div class="subhero">OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police
+      accountability using public and crowdsourced data. We maintain databases of police officers in several cities,
+      providing digital galleries that make identifying police officers easier for the public, including for the purpose
+      of complaints.</div>
+  </div>
+  <div class="vertical-padding horizontal-padding">
+  <div class="text-center"><a href="/find" class="btn btn-lg btn-info" id="try-it">Try it</a></div>
 
-<p>This project is a direct response to the failure of leaders in local governments to implement systems that effectively and safely allow the public to identify and report problem police officers. It is the first project of its kind in the United States, and was first implemented in Chicago in October 2016. In fall 2017, OpenOversight launched in the East Bay of the San Francisco Bay Area.</p>
+<p>This project is a direct response to the failure of leaders in local governments to implement systems that
+  effectively and safely allow the public to identify and report problem police officers. It is the first project
+  of its kind in the United States, and was first implemented in Chicago in October 2016. In fall 2017, OpenOversight
+  launched in the East Bay of the San Francisco Bay Area.</p>
 
-<p>OpenOversight is released as free and open source software so others can launch similar police accountability projects in their own cities. The software is available for download and collaborative development on <a href="https://github.com/lucyparsons/OpenOversight">GitHub</a>.</p>
-
-
-<h2>Legal <small>A note to Illinois law enforcement</h2>
+<p>OpenOversight is released as free and open source software so others can launch similar police accountability
+  projects in their own cities. The software is available for download and collaborative development on
+  <a href="https://github.com/lucyparsons/OpenOversight">GitHub</a>.</p>
+</div>
+  <div class="row display-flex vertical-padding horizontal-padding">
+    <div class="col-lg-6 col-half-border bg-white">
+      <h2>Legal</h2> <div class="text-gray-lighter">A note to Illinois law enforcement</div>
 <p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric Information Privacy Act.
 Requests or questions regarding this project from those affiliated with law enforcement must be directed to our legal representation at <a href="mailto:legal@lucyparsonslabs.com">legal@lucyparsonslabs.com</a>.</p>
-
+    </div>
+    <div class="col-lg-6 col-half-border bg-white">
 <h2>Media</h2>
 <p>For media inquiries about OpenOversight, please email <a href="mailto:media@lucyparsonslabs.com">media@lucyparsonslabs.com</a>. For general inquiries about the project, please contact <a href="mailto:openoversight@lucyparsonslabs.com">openoversight@lucyparsonslabs.com</a>. For Chicago specific questions, please use <a href="mailto:chicagooversight@lucyparsonslabs.com">chicagooversight@lucyparsonslabs.com</a> and for East Bay questions, please use <a href="bayareaoversight@lucyparsonslabs.com">bayareaoversight@lucyparsonslabs.com</a>.
+  </div>
+  </div>
 
-<h2>Press Release</h2>
+<div class="hr-banner">
+  <h2>Press Release</h2>
+<p>In support of demands for greater police accountability, Illinois nonprofit The Lucy Parsons Labs launched
+  OpenOversight, an interactive web tool and accountability platform that makes it easier for the public to identify
+  police officers, including for the purpose of complains.  We rely on crowdsourced and public data to build a database
+  of police officers in a city, allowing the public to filter through the dataset to find the name and badge number of
+  the offending officer.</p>
 
-<p>In support of demands for greater police accountability, Illinois nonprofit The Lucy Parsons Labs launched OpenOversight, an interactive web tool and accountability platform that makes it easier for the public to identify police officers, including for the purpose of complains.  We rely on crowdsourced and public data to build a database of police officers in a city, allowing the public to filter through the dataset to find the name and badge number of the offending officer.</p>
-
-<p>Using OpenOversight, members of the public can search for the names and badge numbers of police with whome they have negative interactions using the officer's estimated age, race and gender. Using this information, the OpenOversight web application returns a digital gallery of potential matches and, when possible, includes pictures of officers in uniform to assist in identification. "The deck is stacked against people harmed by police," says Jennifer Helsby, CTO of the Lucy Parsons Labs and lead developer on the OpenOversight project. "Police are almost never held accountable for misconduct or crimes they commit. To file a misconduct complaint, the burden is on the public to provide as much detailed data about the officer as possible. OpenOversight aims to empower citizens with tools that make it easier to identify officers and hold them accountable."
-
+<p>Using OpenOversight, members of the public can search for the names and badge numbers of police with whome they
+  have negative interactions using the officer's estimated age, race and gender. Using this information, the
+  OpenOversight web application returns a digital gallery of potential matches and, when possible, includes pictures
+  of officers in uniform to assist in identification. "The deck is stacked against people harmed by police," says
+  Jennifer Helsby, CTO of the Lucy Parsons Labs and lead developer on the OpenOversight project. "Police are almost
+  never held accountable for misconduct or crimes they commit. To file a misconduct complaint, the burden is on the
+  public to provide as much detailed data about the officer as possible. OpenOversight aims to empower citizens with
+  tools that make it easier to identify officers and hold them accountable."
 </p>
+
+</div>
+  <div class="vertical-padding horizontal-padding">
 <h4>Facts and Figures about Chicago Police Department:</h4>
 <ul>
   <li>To file a police complaint in Chicago, a member of the public needs to know as much <a href="http://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:5406784243929236">detailed data</a> about the officer as possible. Based on complaints data from the <a href="http://invisible.institute/">Invisible Institute</a>, from March 2011 - March 2015, 28% of complaints (4,000 total complaints) were immediately dropped due to no officer identification.  <a href="http://cpdp.co/data/D8or5A/only-20525-28595-have-id-for-the-accused-officer">Source: Citizen Police Data Project</a></li>
@@ -33,6 +61,7 @@ Requests or questions regarding this project from those affiliated with law enfo
   <li>Chicago spent over $500 million from 2004 to 2014 on settlements, legal fees and other costs related to complaints against police officers.  <a href="http://www.bettergov.org/news/beyond-burge">Source: Better Government Association</a></li>
   <li>In 2015, there was no discipline in more than 99 percent of the thousands of misconduct complaints against Chicago police officers. <a href="https://www.nytimes.com/2015/11/19/us/few-complaints-against-chicago-police-result-in-discipline-data-shows.html?mcubz=0">Source: New York Times</a></li>
 </ul>
+  </div>
 
 </div>
 

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -17,7 +17,7 @@
     Try it
   </a></div>
 
-  <div class="row font-weight-300 text-center display-flex pb-50">
+  <div class="row font-weight-300 text-center display-flex">
     <div class="col-lg-4 col-half-border">
       <span class="fa fa-institution fa-2x"></span >
       <p>This project is a direct response to the failure of leaders in local governments to implement systems that
@@ -38,7 +38,7 @@
     </div>
   </div>
 </div>
-<div class="row display-flex">
+<div class="row display-flex  horizontal-padding vertical-padding pb-50">
   <div class="col-lg-6 col-half-no-border bg-light-blue">
     <h2>Legal</h2> <i>A note to Illinois law enforcement</i>
     <p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -1,67 +1,134 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="" role="main">
-  <div class="hero-section">
-    <div class="hero">About OpenOversight</div>
-    <div class="subhero">OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police
-      accountability using public and crowdsourced data. We maintain databases of police officers in several cities,
-      providing digital galleries that make identifying police officers easier for the public, including for the purpose
-      of complaints.</div>
-  </div>
-  <div class="vertical-padding horizontal-padding">
-  <div class="text-center"><a href="/find" class="btn btn-lg btn-info" id="try-it">Try it</a></div>
-
-<p>This project is a direct response to the failure of leaders in local governments to implement systems that
-  effectively and safely allow the public to identify and report problem police officers. It is the first project
-  of its kind in the United States, and was first implemented in Chicago in October 2016. In fall 2017, OpenOversight
-  launched in the East Bay of the San Francisco Bay Area.</p>
-
-<p>OpenOversight is released as free and open source software so others can launch similar police accountability
-  projects in their own cities. The software is available for download and collaborative development on
-  <a href="https://github.com/lucyparsons/OpenOversight">GitHub</a>.</p>
+<div role="main">
+<div class="hero-section-no-sub">
+  <div class="hero">About OpenOversight</div>
 </div>
-  <div class="row display-flex vertical-padding horizontal-padding">
-    <div class="col-lg-6 col-half-border bg-white">
-      <h2>Legal</h2> <div class="text-gray-lighter">A note to Illinois law enforcement</div>
-<p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric Information Privacy Act.
-Requests or questions regarding this project from those affiliated with law enforcement must be directed to our legal representation at <a href="mailto:legal@lucyparsonslabs.com">legal@lucyparsonslabs.com</a>.</p>
+<div class="vertical-padding horizontal-padding">
+  <p class="lead"><small>
+    OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police
+    accountability using public and crowdsourced data. We maintain databases of police officers in several cities,
+    providing digital galleries that make identifying police officers easier for the public, including for the purpose
+    of complaints.
+  </small></p>
+
+  <div class="text-center pb-50"><a href="/find" class="btn btn-lg btn-info" id="try-it">
+    Try it
+  </a></div>
+
+  <div class="row font-weight-300 text-center">
+    <div class="col-lg-4">
+      <i class="fa fa-institution fa-2x"></i>
+      <p>This project is a direct response to the failure of leaders in local governments to implement systems that
+        effectively and safely allow the public to identify and report problematic police officers.
+      </p>
     </div>
-    <div class="col-lg-6 col-half-border bg-white">
-<h2>Media</h2>
-<p>For media inquiries about OpenOversight, please email <a href="mailto:media@lucyparsonslabs.com">media@lucyparsonslabs.com</a>. For general inquiries about the project, please contact <a href="mailto:openoversight@lucyparsonslabs.com">openoversight@lucyparsonslabs.com</a>. For Chicago specific questions, please use <a href="mailto:chicagooversight@lucyparsonslabs.com">chicagooversight@lucyparsonslabs.com</a> and for East Bay questions, please use <a href="bayareaoversight@lucyparsonslabs.com">bayareaoversight@lucyparsonslabs.com</a>.
+    <div class="col-lg-4">
+      <i class="fa fa-map-marker fa-2x"></i><p>
+        It is the first project of its kind in the United States, and was first implemented in Chicago in October 2016.
+      In fall 2017, OpenOversight launched in the East Bay of the San Francisco Bay Area.</p>
+    </div>
+    <div class="col-lg-4">
+      <i class="fa fa-github fa-2x"></i><p>
+      OpenOversight is released as free and open source software so others can launch similar police accountability
+        projects in their own cities. The software is available for download and collaborative development on
+      <a href="https://github.com/lucyparsons/OpenOversight">GitHub</a>.</p>
+
+    </div>
   </div>
-  </div>
-
-<div class="hr-banner">
-  <h2>Press Release</h2>
-<p>In support of demands for greater police accountability, Illinois nonprofit The Lucy Parsons Labs launched
-  OpenOversight, an interactive web tool and accountability platform that makes it easier for the public to identify
-  police officers, including for the purpose of complains.  We rely on crowdsourced and public data to build a database
-  of police officers in a city, allowing the public to filter through the dataset to find the name and badge number of
-  the offending officer.</p>
-
-<p>Using OpenOversight, members of the public can search for the names and badge numbers of police with whome they
-  have negative interactions using the officer's estimated age, race and gender. Using this information, the
-  OpenOversight web application returns a digital gallery of potential matches and, when possible, includes pictures
-  of officers in uniform to assist in identification. "The deck is stacked against people harmed by police," says
-  Jennifer Helsby, CTO of the Lucy Parsons Labs and lead developer on the OpenOversight project. "Police are almost
-  never held accountable for misconduct or crimes they commit. To file a misconduct complaint, the burden is on the
-  public to provide as much detailed data about the officer as possible. OpenOversight aims to empower citizens with
-  tools that make it easier to identify officers and hold them accountable."
-</p>
-
 </div>
-  <div class="vertical-padding horizontal-padding">
-<h4>Facts and Figures about Chicago Police Department:</h4>
-<ul>
-  <li>To file a police complaint in Chicago, a member of the public needs to know as much <a href="http://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:5406784243929236">detailed data</a> about the officer as possible. Based on complaints data from the <a href="http://invisible.institute/">Invisible Institute</a>, from March 2011 - March 2015, 28% of complaints (4,000 total complaints) were immediately dropped due to no officer identification.  <a href="http://cpdp.co/data/D8or5A/only-20525-28595-have-id-for-the-accused-officer">Source: Citizen Police Data Project</a></li>
-  <li>All complaints against officers must be supported by a sworn affidavit. False complaints can result in perjury charges, a Class 3 felony.  <a href="https://web.archive.org/web/20160829203856/http://home.chicagopolice.org/inside-the-cpd/internal-affairs-division/the-complaint/">Source: Chicago Police</a></li>
-  <li>Less than 2% of the 28,567 complaints filed against the Chicago police department from March 2011 to September 2015 resulted in discipline. Most officers who do face discipline are suspended for a week or less.  <a href="http://cpdb.co/data/D1zdwL/citizens-police-data-project">Source: Citizens Police Data Project</a></li>
-  <li>Chicago spent over $500 million from 2004 to 2014 on settlements, legal fees and other costs related to complaints against police officers.  <a href="http://www.bettergov.org/news/beyond-burge">Source: Better Government Association</a></li>
-  <li>In 2015, there was no discipline in more than 99 percent of the thousands of misconduct complaints against Chicago police officers. <a href="https://www.nytimes.com/2015/11/19/us/few-complaints-against-chicago-police-result-in-discipline-data-shows.html?mcubz=0">Source: New York Times</a></li>
-</ul>
+<div class="row display-flex vertical-padding horizontal-padding pb-50">
+  <div class="col-lg-6 col-half-border bg-light-blue">
+    <h2>Legal</h2> <i>A note to Illinois law enforcement</i>
+    <p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric
+      Information Privacy Act.
+      Requests or questions regarding this project from those affiliated with law enforcement must be directed to our
+      legal representation at <a href="mailto:legal@lucyparsonslabs.com">legal@lucyparsonslabs.com</a>.</p>
   </div>
+  <div class="col-lg-6 col-half-border bg-light-gray">
+    <h2>Media</h2>
+    <p>For media inquiries about OpenOversight, please email <a href="mailto:media@lucyparsonslabs.com">media@lucyparsonslabs.com</a>.
+      For general inquiries about the project, please contact <a href="mailto:openoversight@lucyparsonslabs.com">openoversight@lucyparsonslabs.com</a>.
+      For Chicago specific questions, please use <a href="mailto:chicagooversight@lucyparsonslabs.com">chicagooversight@lucyparsonslabs.com</a>
+      and for East Bay questions, please use <a href="bayareaoversight@lucyparsonslabs.com">bayareaoversight@lucyparsonslabs.com</a>.
+  </div>
+</div>
+
+<div class="pb-50"><div class="hr-banner">
+    <h2>Press Release</h2>
+    <p>In support of demands for greater police accountability, Illinois nonprofit The Lucy Parsons Labs launched
+      OpenOversight, an interactive web tool and accountability platform that makes it easier for the public to identify
+      police officers, including for the purpose of complains. We rely on crowdsourced and public data to build a
+      database
+      of police officers in a city, allowing the public to filter through the dataset to find the name and badge number
+      of
+      the offending officer.</p>
+
+    <p>Using OpenOversight, members of the public can search for the names and badge numbers of police with whom they
+      have negative interactions using the officer's estimated age, race and gender. Using this information, the
+      OpenOversight web application returns a digital gallery of potential matches and, when possible, includes pictures
+      of officers in uniform to assist in identification. "The deck is stacked against people harmed by police," says
+      Jennifer Helsby, CTO of the Lucy Parsons Labs and lead developer on the OpenOversight project. "Police are almost
+      never held accountable for misconduct or crimes they commit. To file a misconduct complaint, the burden is on the
+      public to provide as much detailed data about the officer as possible. OpenOversight aims to empower citizens with
+      tools that make it easier to identify officers and hold them accountable."
+    </p>
+  </div>
+</div>
+
+<div class="horizontal-padding vertical-padding">
+  <div class="text-center">
+    <h2>Facts and Figures about the Chicago Police Department</h2>
+  </div>
+  <div class="row display-flex">
+    <div class="col-lg-7 col-half-border bg-white">
+        To file a police complaint in Chicago, a member of the public needs
+        to know as much
+        <a href="http://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:5406784243929236">detailed data</a>
+        about the officer as possible. Based on complaints data from the <a href="http://invisible.institute/">Invisible
+        Institute</a>, from March 2011 - March 2015, 28% of complaints (4,000 total complaints) were immediately
+        dropped due to no officer identification.
+      <p class="text-right i">
+        <a href="http://cpdp.co/data/D8or5A/only-20525-28595-have-id-for-the-accused-officer">
+          Source: Citizen Police Data Project
+        </a>
+      </p></div>
+    <div class="col-lg-5 col-half-border bg-white">
+        Less than 2% of the 28,567 complaints filed against the Chicago
+        police department from March 2011 to September 2015 resulted in discipline. Most officers who do face
+        discipline
+        are suspended for a week or less.
+      <p class="text-right i">
+        <a href="http://cpdb.co/data/D1zdwL/citizens-police-data-project">
+          Source: Citizens Police Data Project
+        </a>
+      </p>
+    </div>
+  </div>
+  <div class="row display-flex">
+    <div class="col-lg-4 col-half-border bg-white">
+        All complaints against officers must be supported by a sworn affidavit. False complaints can result in
+        perjury charges, a Class 3 felony.
+      <p class="text-right i">
+        <a href="https://web.archive.org/web/20160829203856/http://home.chicagopolice.org/inside-the-cpd/internal-affairs-division/the-complaint/">
+          Source: Chicago Police
+        </a>
+      </p></div>
+    <div class="col-lg-4 col-half-border bg-white">
+      Chicago spent over $500 million from 2004 to 2014 on settlements,
+      legal fees and other costs related to complaints against police officers.
+      <p class="text-right i"><a href="http://www.bettergov.org/news/beyond-burge">
+          Source: Better Government Association
+        </a></p></div>
+    <div class="col-lg-4 col-half-border bg-white">
+      In 2015, there was no discipline in more than 99 percent of the
+      thousands of misconduct complaints against Chicago police officers.
+      <p class="text-right i"><a href="https://www.nytimes.com/2015/11/19/us/few-complaints-against-chicago-police-result-in-discipline-data-shows.html?mcubz=0">
+        Source: New York Times
+        </a></p></div>
+  </div>
+</div>
 
 </div>
 

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -13,23 +13,23 @@
     of complaints.
   </small></p>
 
-  <div class="text-center pb-90"><a href="/find" class="btn btn-lg btn-info" id="try-it">
+  <div class="text-center pb-50"><a href="/find" class="btn btn-lg btn-info" id="try-it">
     Try it
   </a></div>
 
-  <div class="row font-weight-300 text-center">
-    <div class="col-lg-4">
-      <span class="fa fa-institution fa-2x"></span>
+  <div class="row font-weight-300 text-center display-flex pb-50">
+    <div class="col-lg-4 col-half-border">
+      <span class="fa fa-institution fa-2x"></span >
       <p>This project is a direct response to the failure of leaders in local governments to implement systems that
         effectively and safely allow the public to identify and report problematic police officers.
       </p>
     </div>
-    <div class="col-lg-4">
+    <div class="col-lg-4 col-half-border">
       <span class="fa fa-map-marker fa-2x"></span><p>
         It is the first project of its kind in the United States, and was first implemented in Chicago in October 2016.
       In fall 2017, OpenOversight launched in the East Bay of the San Francisco Bay Area.</p>
     </div>
-    <div class="col-lg-4">
+    <div class="col-lg-4 col-half-border">
       <span class="fa fa-github fa-2x"></span><p>
       OpenOversight is released as free and open source software so others can launch similar police accountability
         projects in their own cities. The software is available for download and collaborative development on
@@ -38,15 +38,15 @@
     </div>
   </div>
 </div>
-<div class="row display-flex vertical-padding horizontal-padding pb-50">
-  <div class="col-lg-6 col-half-border bg-light-blue">
+<div class="row display-flex">
+  <div class="col-lg-6 col-half-no-border bg-light-blue">
     <h2>Legal</h2> <i>A note to Illinois law enforcement</i>
     <p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric
       Information Privacy Act.
       Requests or questions regarding this project from those affiliated with law enforcement must be directed to our
       legal representation at <a href="mailto:legal@lucyparsonslabs.com">legal@lucyparsonslabs.com</a>.</p>
   </div>
-  <div class="col-lg-6 col-half-border bg-light-gray">
+  <div class="col-lg-6 col-half-no-border bg-blue-gray">
     <h2>Media</h2>
     <p>For media inquiries about OpenOversight, please email <a href="mailto:media@lucyparsonslabs.com">media@lucyparsonslabs.com</a>.
       For general inquiries about the project, please contact <a href="mailto:openoversight@lucyparsonslabs.com">openoversight@lucyparsonslabs.com</a>.
@@ -81,7 +81,7 @@
   <div class="text-center">
     <h2>Facts and Figures about the Chicago Police Department</h2>
   </div>
-  <div class="row display-flex font-weight-300">
+  <div class="row display-flex font-weight-300 text-left">
     <div class="col-lg-7 col-half-border bg-white">
         To file a police complaint in Chicago, a member of the public needs
         to know as much

--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -2,10 +2,10 @@
 {% block content %}
 
 <div role="main">
-<div class="hero-section-no-sub">
+<div class="hero-section no-sub">
   <div class="hero">About OpenOversight</div>
 </div>
-<div class="vertical-padding horizontal-padding">
+<div class="vertical-padding">
   <p class="lead"><small>
     OpenOversight is a <a href="https://lucyparsonslabs.com">Lucy Parsons Labs</a> project to improve police
     accountability using public and crowdsourced data. We maintain databases of police officers in several cities,
@@ -13,7 +13,7 @@
     of complaints.
   </small></p>
 
-  <div class="text-center pb-50"><a href="/find" class="btn btn-lg btn-info" id="try-it">
+  <div class="text-center pb-90"><a href="/find" class="btn btn-lg btn-info" id="try-it">
     Try it
   </a></div>
 
@@ -81,7 +81,7 @@
   <div class="text-center">
     <h2>Facts and Figures about the Chicago Police Department</h2>
   </div>
-  <div class="row display-flex">
+  <div class="row display-flex font-weight-300">
     <div class="col-lg-7 col-half-border bg-white">
         To file a police complaint in Chicago, a member of the public needs
         to know as much
@@ -106,7 +106,7 @@
       </p>
     </div>
   </div>
-  <div class="row display-flex">
+  <div class="row display-flex font-weight-300">
     <div class="col-lg-4 col-half-border bg-white">
         All complaints against officers must be supported by a sworn affidavit. False complaints can result in
         perjury charges, a Class 3 felony.

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -92,19 +92,39 @@
 
     <footer class="footer">
       <hr>
-      <div class="container text-muted">
-        <div class="text-center center-block">
-          <a href="https://www.facebook.com/lucyparsonslabs"><i class="fa fa-facebook-square fa-3x social"></i></a>
-          <a href="https://twitter.com/lucyparsonslabs"><i class="fa fa-twitter-square fa-3x social"></i></a>
-          <a href="https://github.com/lucyparsons/openoversight"><i class="fa fa-github fa-3x social"></i></a>
-          <a href="mailto:info@lucyparsonslabs.com"><i class="fa fa-envelope-square fa-3x social"></i></a>
+      <div class="row text-center horizontal-padding">
+
+        <div class="col-lg-4">
+          <h5>OpenOversight</h5>
+          <p>
+            A product of Lucy Parsons Labs in Chicago, IL. <br>
+            <a href="https://lucyparsonslabs.com/" target="_blank" class="btn-unstyled">Lucy Parsons Labs</a><br>
+            <a href="https://lucyparsonslabs.com/securedrop/" target="_blank" class="btn-unstyled">SecureDrop</a>
+          </p>
         </div>
-      </div>
-      <div class="container text-muted">
-        <div class="text-center center-block">
-          <a href="/privacy" class="btn">Privacy Policy</a>
+
+        <div class="col-lg-4">
+          <h5>Contact</h5>
+          <p>
+            <a href="https://www.facebook.com/lucyparsonslabs"><i class="fa fa-facebook-square fa-3x social"></i></a>
+            <a href="https://twitter.com/lucyparsonslabs"><i class="fa fa-twitter-square fa-3x social"></i></a>
+            <a href="https://github.com/lucyparsons/openoversight"><i class="fa fa-github fa-3x social"></i></a>
+            <a href="mailto:info@lucyparsonslabs.com"><i class="fa fa-envelope-square fa-3x social"></i></a><br>
+            <a href="/privacy" class="btn">Privacy Policy</a>
+          </p>
         </div>
+        <div class="col-lg-4">
+          <h5>Navigation</h5>
+          <p>
+            <a href="{{ url_for('main.get_officer') }}" class="btn-unstyled">Find an Officer</a><br>
+            <a href="{{ url_for('main.submit_data') }}" class="btn-unstyled">Submit Images</a><br>
+            <a href="{{ url_for('main.get_started_labeling') }}" class="btn-unstyled">Volunteer</a><br>
+            <a href="{{ url_for('main.about_oo') }}" class="btn-unstyled">About</a><br>
+          </p>
+        </div>
+
       </div>
+
     </footer>
 
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -96,7 +96,7 @@
 
         <div class="col-lg-4">
           <h5>OpenOversight</h5>
-          <p>
+          <p class="font-weight-300">
             A product of Lucy Parsons Labs in Chicago, IL. <br>
             <a href="https://lucyparsonslabs.com/" target="_blank" class="btn-unstyled">Lucy Parsons Labs</a><br>
             <a href="https://lucyparsonslabs.com/securedrop/" target="_blank" class="btn-unstyled">SecureDrop</a>
@@ -115,7 +115,7 @@
         </div>
         <div class="col-lg-4">
           <h5>Navigation</h5>
-          <p>
+          <p class="font-weight-300">
             <a href="{{ url_for('main.get_officer') }}" class="btn-unstyled">Find an Officer</a><br>
             <a href="{{ url_for('main.submit_data') }}" class="btn-unstyled">Submit Images</a><br>
             <a href="{{ url_for('main.get_started_labeling') }}" class="btn-unstyled">Volunteer</a><br>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -9,7 +9,7 @@
             <div class="subhero">OpenOversight: The first public, searchable database of CPD officers.</div>
         </div>
 
-        <div class="row display-flex padded-row sink-row">
+        <div class="row display-flex vertical-padding horizontal-padding sink-row">
             <div class="col-lg-6 col-half-border bg-white">
                 <h1>
                     <small>Find a Police Officer</small>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -9,7 +9,7 @@
             <div class="subhero">OpenOversight: The first public, searchable database of CPD officers.</div>
         </div>
 
-        <div class="row display-flex vertical-padding horizontal-padding sink-row">
+        <div class="row display-flex vertical-padding horizontal-padding sink-row text-left">
             <div class="col-lg-6 col-half-border bg-white">
                 <h1>
                     <small>Find a Police Officer</small>
@@ -47,7 +47,7 @@
     </div>
 
     <div class="row display-flex">
-        <div class="col-lg-6 bg-light-gray col-half-no-border">
+        <div class="col-lg-6 bg-light-gray col-half-no-border text-left">
             <h1>
                 <small>Volunteer</small>
             </h1>
@@ -59,7 +59,7 @@
                 Put me to work
             </a>
         </div>
-        <div class="col-lg-6 bg-blue-gray col-half-no-border">
+        <div class="col-lg-6 bg-blue-gray col-half-no-border text-left">
             <h1>
                 <small>Donate</small>
             </h1>

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <div role="main">
-    <div class="hero-section-no-sub">
+    <div class="hero-section no-sub">
         <div class="hero">Find an Officer </div>
     </div>
 </div>

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -2,18 +2,22 @@
 {% block content %}
 
 <div role="main">
-    <div class="hero-section">
+    <div class="hero-section-no-sub">
         <div class="hero">Find an Officer </div>
-        <div class="subhero">Use this form to generate a gallery of police officers.</div>
     </div>
 </div>
 
 <div class="container" role="main">
-    <p class="lead horizontal-padding">
-        Fill in the information you know about a police officer you interacted with. Don't worry if you don't know or
-        have answers to every question. OpenOversight takes what you provide and generates a digital gallery of Chicago
-        police officers who may be a match.
-    </p>
+    <div class="horizontal-padding">
+        <div class="lead text-center">
+            Use this form to generate a gallery of police officers.
+        </div>
+        <p class="font-weight-300">
+            Fill in the information you know about a police officer you interacted with. Don't worry if you don't know or
+            have answers to every question. OpenOversight takes what you provide and generates a digital gallery of Chicago
+            police officers who may be a match.
+        </p>
+    </div>
   <form action="{{ url_for('main.get_officer') }}" method="post" class="form">
   {{ form.hidden_tag() }}
 	  <div class="row form-group">

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -1,12 +1,19 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="container page-header" role="main">
-   <h1 id="page-title">Find an Officer <small>Use this form to generate a gallery of police officers</small></h1>
-   <p>Fill in the information you know about a police officer you interacted with. Don't worry if you don't know or have answers to every question. OpenOversight takes what you provide and generates a digital gallery of Chicago police officers who may be a match. </p>
+<div role="main">
+    <div class="hero-section">
+        <div class="hero">Find an Officer </div>
+        <div class="subhero">Use this form to generate a gallery of police officers.</div>
+    </div>
 </div>
 
 <div class="container" role="main">
+    <p class="lead horizontal-padding">
+        Fill in the information you know about a police officer you interacted with. Don't worry if you don't know or
+        have answers to every question. OpenOversight takes what you provide and generates a digital gallery of Chicago
+        police officers who may be a match.
+    </p>
   <form action="{{ url_for('main.get_officer') }}" method="post" class="form">
   {{ form.hidden_tag() }}
 	  <div class="row form-group">

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -76,7 +76,7 @@
                 How you can help
             </h2>
             <div class="row pb-50">
-                <div class="col-lg-4">
+                <div class="col-lg-4 horizontal-padding">
                     <span class="fa fa-picture-o fa-2x"></span>
                     <p class="lead margin-less">
                         Sort Images
@@ -85,7 +85,7 @@
                         Sort submitted images into those with and without officers.
                     </div>
                 </div>
-                <div class="col-lg-4">
+                <div class="col-lg-4 horizontal-padding"">
                     <span class="fa fa-users fa-2x"></span>
                     <p class="lead margin-less">
                         Identify Officers
@@ -94,7 +94,7 @@
                         Have a photo containing faces and/or badge numbers of uniformed police officers?
                     </div>
                 </div>
-                <div class="col-lg-4">
+                <div class="col-lg-4 horizontal-padding"">
                     <span class="fa fa-envelope fa-2x"></span>
                     <p class="lead margin-less">
                         Contact Us

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -63,14 +63,12 @@
 <div role="main">
     <div class="text-center">
         <div class="hero-section">
-            <div class="text-left">
             <div class="hero">
                 Volunteer
             </div>
             <div class="subhero">
                 Help OpenOversight create transparency with the first public, searchable
                 database of CPD officers.
-            </div>
             </div>
         </div>
         <div class="container">
@@ -104,38 +102,38 @@
                     </small>
                 </div>
             </div>
+        </div>
 
-            <div class="row display-flex">
-                <div class="col-lg-6 col-half-no-border bg-blue-gray">
-                    <div class="text-center">
-                        <h1>
-                            <small>Log In</small>
-                        </h1>
-                    </div>
-                    <div>
-                        <form class="form" method="post" role="form">
-                            {{ form.hidden_tag() }}
-                            {{ wtf.form_errors(form, hiddens="only") }}
-
-                            {{ wtf.form_field(form.email) }}
-                            {{ wtf.form_field(form.password) }}
-                            <div class="text-center">
-                                {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'secondary btn-lg'}) }}
-                                {% if error %}
-                                    {{ error }}
-                                {% endif %}
-                            </div>
-                        </form>
-                    </div>
-                    <div class="text-center">
-                        <a href="{{ url_for('auth.password_reset_request') }}">Forgot Password</a>
-                    </div>
+        <div class="row display-flex vertical-padding">
+            <div class="col-lg-6 col-half-no-border bg-blue-gray bordered-box">
+                <div class="text-center">
+                    <h1>
+                        <small>Log In</small>
+                    </h1>
                 </div>
-                <div class="col-lg-6 col-half-no-border bg-blue-gray">
-                    <div class="text-center">
-                        <h1>
-                            <small>Interested in volunteering?</small>
-                        </h1>
+                    <form class="form" method="post" role="form">
+                        {{ form.hidden_tag() }}
+                        {{ wtf.form_errors(form, hiddens="only") }}
+
+                        {{ wtf.form_field(form.email) }}
+                        {{ wtf.form_field(form.password) }}
+                        <div class="text-center">
+                            {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'secondary btn-lg'}) }}
+                            {% if error %}
+                                {{ error }}
+                            {% endif %}
+                        </div>
+                    </form>
+                <p class="text-center">
+                    <a href="{{ url_for('auth.password_reset_request') }}">Forgot Password</a>
+                </p>
+            </div>
+            <div class="col-lg-6 col-half-no-border bg-blue-gray">
+                <div class="text-center">
+                    <h1>
+                        <small>Interested in volunteering?</small>
+                    </h1>
+                    <div class="horizontal-padding">
                         <a class="btn btn-lg btn-info" href="{{ url_for('auth.register') }}">
                             Sign Up
                         </a>

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -71,36 +71,37 @@
                 database of CPD officers.
             </div>
         </div>
-        <div class="container">
+        <div class="container horizontal-padding">
             <h2 class="horizontal-padding font-weight-300">
                 How you can help
             </h2>
             <div class="row pb-50">
                 <div class="col-lg-4">
                     <span class="fa fa-picture-o fa-2x"></span>
-                    <p class="lead">
+                    <p class="lead margin-less">
                         Sort Images
-                    </p><p class="font-weight-300">
+                    </p>
+                    <div class="font-weight-300">
                         Sort submitted images into those with and without officers.
-                </p>
+                    </div>
                 </div>
                 <div class="col-lg-4">
                     <span class="fa fa-users fa-2x"></span>
-                    <p class="lead">
+                    <p class="lead margin-less">
                         Identify Officers
                     </p>
-                    <p class="font-weight-300">
+                    <div class="font-weight-300">
                         Have a photo containing faces and/or badge numbers of uniformed police officers?
-                    </p>
+                    </div>
                 </div>
                 <div class="col-lg-4">
                     <span class="fa fa-envelope fa-2x"></span>
-                    <p class="lead">
+                    <p class="lead margin-less">
                         Contact Us
                     </p>
-                    <p class="font-weight-300">
+                    <div class="font-weight-300">
                         Reach out with any questions, concerns, or ways you'd like to get involved.
-                    </p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -72,34 +72,35 @@
             </div>
         </div>
         <div class="container">
-            <h2>
-                <small>How you can help</small>
+            <h2 class="horizontal-padding font-weight-300">
+                How you can help
             </h2>
-            <div class="row pb-90">
+            <div class="row pb-50">
                 <div class="col-lg-4">
-                    <h1>
-                        <small>Sort Images</small>
-                    </h1>
-                    <small>
+                    <i class="fa fa-picture-o fa-2x"></i>
+                    <p class="lead">
+                        Sort Images
+                    </p><p class="font-weight-300">
                         Sort submitted images into those with and without officers.
-                    </small>
+                </p>
                 </div>
                 <div class="col-lg-4">
-                    <h1>
-                        <small>Identify Officers</small>
-                    </h1>
-                    <small>
+                    <i class="fa fa-users fa-2x"></i>
+                    <p class="lead">
+                        Identify Officers
+                    </p>
+                    <p class="font-weight-300">
                         Have a photo containing faces and/or badge numbers of uniformed police officers?
-                    </small>
+                    </p>
                 </div>
                 <div class="col-lg-4">
-                    <h1>
-                        <small>Contact Us</small>
-                    </h1>
-                    <!--TODO need copy-->
-                    <small>
+                    <i class="fa fa-envelope fa-2x"></i>
+                    <p class="lead">
+                        Contact Us
+                    </p>
+                    <p class="font-weight-300">
                         Reach out with any questions, concerns, or ways you'd like to get involved.
-                    </small>
+                    </p>
                 </div>
             </div>
         </div>

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -77,7 +77,7 @@
             </h2>
             <div class="row pb-50">
                 <div class="col-lg-4">
-                    <i class="fa fa-picture-o fa-2x"></i>
+                    <span class="fa fa-picture-o fa-2x"></span>
                     <p class="lead">
                         Sort Images
                     </p><p class="font-weight-300">
@@ -85,7 +85,7 @@
                 </p>
                 </div>
                 <div class="col-lg-4">
-                    <i class="fa fa-users fa-2x"></i>
+                    <span class="fa fa-users fa-2x"></span>
                     <p class="lead">
                         Identify Officers
                     </p>
@@ -94,7 +94,7 @@
                     </p>
                 </div>
                 <div class="col-lg-4">
-                    <i class="fa fa-envelope fa-2x"></i>
+                    <span class="fa fa-envelope fa-2x"></span>
                     <p class="lead">
                         Contact Us
                     </p>

--- a/OpenOversight/app/templates/submit_deptselect.html
+++ b/OpenOversight/app/templates/submit_deptselect.html
@@ -10,7 +10,7 @@
   {% for department in departments %}
   <p>
   <a href="/submit/department/{{ department.id }}" class="btn btn-lg btn-primary">
-      <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
+      <span class="fa fa-upload" aria-hidden="true"></span>
       {{ department.name }}</a>
   </p>
   {% endfor %}


### PR DESCRIPTION
## Status
Ready for review- frontend work continued; styling changes only // no copy changes
Could definitely use design feedback on the about page if people have opinions!

## Description of Changes
Adds on to #332 .
Also kinda touches on #292 ? could add in a little icon or something too if securedrop should be called out more

Changes proposed in this pull request:
 - Redesign of 'about' page
 - Adds footer content
 - Minor adjustments to 'find' and 'volunteer' pages
 - Responsive fix for homepage header
 - Minor styling changes to nav

## Screenshots
About + footer additions: 
![image](https://user-images.githubusercontent.com/9063936/34194246-6b6c5758-e51d-11e7-8526-ec573bdb22ac.png)

Volunteer:
<img width="1493" alt="screen shot 2017-12-19 at 11 01 07 pm" src="https://user-images.githubusercontent.com/9063936/34192188-1a810a2e-e512-11e7-93db-ab7f1f5dd093.png">

Find an officer:
<img width="1447" alt="screen shot 2017-12-19 at 10 30 57 pm" src="https://user-images.githubusercontent.com/9063936/34191422-7d9f79f2-e50c-11e7-8c96-652c97c936b2.png">

## Tests and linting
 - [x] I have rebased my changes on current `develop`
 - [x] pytests pass in the development environment on my local machine
 - [x] `flake8` checks pass
