### PR TITLE
Enable admins to edit existing officer information

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -139,6 +139,27 @@ class AddOfficerForm(Form):
     submit = SubmitField(label='Add')
 
 
+class BasicOfficerForm(Form):
+    first_name = StringField('First name',
+                             validators=[Regexp('\w*'), Length(max=50),
+                                         Optional()])
+    last_name = StringField('Last name',
+                            validators=[Regexp('\w*'), Length(max=50),
+                                        DataRequired()])
+    middle_initial = StringField('Middle initial',
+                                 validators=[Regexp('\w*'), Length(max=50),
+                                             Optional()])
+    race = SelectField('Race', choices=RACE_CHOICES,
+                       validators=[AnyOf(allowed_values(RACE_CHOICES))])
+    gender = SelectField('Gender', choices=GENDER_CHOICES,
+                         validators=[AnyOf(allowed_values(GENDER_CHOICES))])
+    employment_date = DateField('Employment Date', validators=[Optional()])
+    birth_year = IntegerField('Birth Year', validators=[Optional()])
+    department = QuerySelectField('Department', validators=[Optional()],
+                                  query_factory=dept_choices, get_label='name')
+    submit = SubmitField(label='Update')
+
+
 class AddUnitForm(Form):
     descrip = StringField('Unit name or description', default='', validators=[
         Regexp('\w*'), Length(max=120), DataRequired()])

--- a/OpenOversight/app/templates/edit_officer.html
+++ b/OpenOversight/app/templates/edit_officer.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+{% block title %}OpenOversight Admin - Edit Officer{% endblock %}
+
+{% block content %}
+<div class="container theme-showcase" role="main">
+
+<div class="page-header">
+    <h1>Edit Officer</h1>
+</div>
+<div class="col-md-6">
+    <form class="form" method="post" role="form">
+        {{ form.hidden_tag() }}
+        {{ wtf.form_errors(form, hiddens="only") }}
+        {{ wtf.form_field(form.first_name, autofocus="autofocus") }}
+        {{ wtf.form_field(form.middle_initial) }}
+        {{ wtf.form_field(form.last_name) }}
+        {{ wtf.form_field(form.race) }}
+        {{ wtf.form_field(form.gender) }}
+        {{ wtf.form_field(form.employment_date) }}
+        {{ wtf.form_field(form.birth_year) }}
+        {{ wtf.form_field(form.department) }}
+        {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
+    </form>
+    <br>
+</div>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -20,7 +20,13 @@
     <div class="col-sm-6 col-md-4">
       <div class="thumbnail">
         <div class="caption">
-          <h3>General Information</h3>
+          <h3>General Information
+            {% if current_user.is_administrator %}
+            <a href="{{ url_for('main.edit_officer', officer_id=officer.id) }}">
+              <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+            </a>
+            {% endif %}
+          </h3>
           <table class="table table-hover">
             <tbody>
               <tr>

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -20,7 +20,6 @@ def dept_choices():
 
 def add_new_assignment(officer_id, form):
     # Resign date should be null
-
     if form.unit.data:
         unit = form.unit.data.id
     else:
@@ -38,15 +37,57 @@ def add_new_assignment(officer_id, form):
 def edit_existing_assignment(assignment, form):
     assignment.star_no = form.star_no.data
     assignment.rank = form.rank.data
+
     if form.unit.data:
         officer_unit = form.unit.data.id
     else:
         officer_unit = None
+
     assignment.unit = officer_unit
     assignment.star_date = form.star_date.data
     db.session.add(assignment)
     db.session.commit()
     return assignment
+
+
+def add_officer_profile(form):
+    officer = Officer(first_name=form.first_name.data,
+                      last_name=form.last_name.data,
+                      middle_initial=form.middle_initial.data,
+                      race=form.race.data,
+                      gender=form.gender.data,
+                      birth_year=form.birth_year.data,
+                      employment_date=form.employment_date.data,
+                      department_id=form.department.data.id)
+    db.session.add(officer)
+
+    if form.unit.data:
+        officer_unit = form.unit.data.id
+    else:
+        officer_unit = None
+
+    assignment = Assignment(baseofficer=officer,
+                            star_no=form.star_no.data,
+                            rank=form.rank.data,
+                            unit=officer_unit,
+                            star_date=form.employment_date.data)
+    db.session.add(assignment)
+    db.session.commit()
+    return officer
+
+
+def edit_officer_profile(officer, form):
+    officer.first_name = form.first_name.data
+    officer.last_name = form.last_name.data
+    officer.middle_initial = form.middle_initial.data
+    officer.race = form.race.data
+    officer.gender = form.gender.data
+    officer.birth_year = form.birth_year.data
+    officer.employment_date = form.employment_date.data
+    officer.department_id = form.department.data.id
+    db.session.add(officer)
+    db.session.commit()
+    return officer
 
 
 def allowed_file(filename):

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -6,7 +6,8 @@ from urlparse import urlparse
 
 from OpenOversight.app.main.forms import (FindOfficerIDForm, AssignmentForm,
                                           FaceTag, DepartmentForm,
-                                          AddOfficerForm, AddUnitForm)
+                                          AddOfficerForm, AddUnitForm,
+                                          BasicOfficerForm)
 from OpenOversight.app.auth.forms import (LoginForm, RegistrationForm,
                                           ChangePasswordForm, PasswordResetForm,
                                           PasswordResetRequestForm,
@@ -732,6 +733,40 @@ def test_admin_can_add_new_officer(mockdata, client, session):
         assert officer.first_name == 'Test'
         assert officer.race == 'WHITE'
         assert officer.gender == 'M'
+
+
+def test_admin_can_edit_existing_officer(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        form = AddOfficerForm(first_name='Test',
+                              last_name='Testerinski',
+                              middle_initial='T',
+                              race='WHITE',
+                              gender='M',
+                              star_no=666,
+                              rank='COMMANDER',
+                              birth_year=1990)
+
+        rv = client.post(
+            url_for('main.add_officer'),
+            data=form.data,
+            follow_redirects=True
+        )
+
+        officer = Officer.query.filter_by(
+            last_name='Testerinski').one()
+
+        form = BasicOfficerForm(last_name='Changed')
+
+        rv = client.post(
+            url_for('main.edit_officer', officer_id=officer.id),
+            data=form.data,
+            follow_redirects=True
+        )
+
+        assert 'Changed' in rv.data
+        assert 'Testerinski' not in rv.data
 
 
 def test_admin_adds_officer_without_middle_initial(mockdata, client, session):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-Script
 Flask-Mail
 Flask-Migrate
 psycopg2>=2.6.2
-sqlalchemy
+sqlalchemy==1.1.15
 flask-sqlalchemy>=2.1
 flask-bootstrap
 gunicorn==17.5


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #330 

## Notes for Deployment

Nothin' fancy

## Screenshots (if appropriate)

Adds a wee pencil edit button next to table of officer info on their profile which takes the person to a officer edit form:

<img width="380" alt="screen shot 2017-12-23 at 1 32 38 pm" src="https://user-images.githubusercontent.com/7832803/34322960-6cfb679c-e7ea-11e7-80e7-40d5a9c6b15f.png">

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
