### PR TITLE
Enable admins to edit assignments data

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -93,12 +93,13 @@ class FaceTag(Form):
 
 
 class AssignmentForm(Form):
-    star_no = IntegerField('star_no')
-    rank = SelectField('rank', default='COMMANDER', choices=RANK_CHOICES,
+    star_no = StringField('Badge Number', default='', validators=[
+        Regexp('\w*'), Length(max=50)])
+    rank = SelectField('Rank', default='COMMANDER', choices=RANK_CHOICES,
                        validators=[AnyOf(allowed_values(RANK_CHOICES))])
-    unit = QuerySelectField('unit', validators=[Optional()],
+    unit = QuerySelectField('Unit', validators=[Optional()],
                             query_factory=unit_choices, get_label='descrip')
-    star_date = DateField('star_date', validators=[Optional()])
+    star_date = DateField('Assignment start date', validators=[Optional()])
 
 
 class DepartmentForm(Form):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -17,7 +17,7 @@ from . import main
 from .. import limiter
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
-                     allowed_file, add_new_assignment)
+                     allowed_file, add_new_assignment, edit_existing_assignment)
 from .forms import (FindOfficerForm, FindOfficerIDForm, AddUnitForm,
                     FaceTag, AssignmentForm, DepartmentForm, AddOfficerForm)
 from ..models import (db, Image, User, Face, Officer, Assignment, Department,
@@ -144,6 +144,20 @@ def officer_profile(officer_id):
                                 officer_id=officer_id), code=302)
     return render_template('officer.html', officer=officer, paths=face_paths,
                            assignments=assignments, form=form)
+
+
+@main.route('/officer/<int:officer_id>/assignment/<int:assignment_id>',
+            methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_assignment(officer_id, assignment_id):
+    assignment = Assignment.query.filter_by(id=assignment_id).one()
+    form = AssignmentForm(obj=assignment)
+    if form.validate_on_submit():
+        assignment = edit_existing_assignment(assignment, form)
+        flash('Edited officer assignment ID {}'.format(assignment.id))
+        return redirect(url_for('main.officer_profile', officer_id=officer_id))
+    return render_template('edit_assignment.html', form=form)
 
 
 @main.route('/user/toggle/<int:uid>', methods=['POST'])

--- a/OpenOversight/app/templates/edit_assignment.html
+++ b/OpenOversight/app/templates/edit_assignment.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+{% block title %}OpenOversight Admin - Edit Officer Assignment{% endblock %}
+
+{% block content %}
+<div class="container theme-showcase" role="main">
+
+<div class="page-header">
+    <h1>Edit Officer Assignment</h1>
+</div>
+<div class="col-md-6">
+    <form class="form" method="post" role="form">
+        {{ form.hidden_tag() }}
+        {{ wtf.form_errors(form, hiddens="only") }}
+        {{ wtf.form_field(form.star_no) }}
+        {{ wtf.form_field(form.rank) }}
+        {{ wtf.form_field(form.unit) }}
+        <h4><small><a href="{{ url_for( 'main.add_unit' )}}">Don't see your unit? Add one!</a></small></h4>
+        {{ wtf.form_field(form.star_date) }}
+        <input class="btn btn-primary btn-lg" type="submit" value="Edit" />
+    </form>
+    <br>
+</div>
+
+</div>
+{% endblock %}

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -65,6 +65,9 @@
                 <th><b>Badge No.</b></th>
                 <th><b>Unit</b></th>
                 <th><b>Assignment Date</b></th>
+                {% if current_user.is_administrator %}
+                <th><b>Edit</b></th>
+                {% endif %}
               </tr>
             <tbody>
               {% for assignment in assignments %}
@@ -81,7 +84,16 @@
                     {{ assignment.star_date }}
                     {% else %}
                     Unknown
-                    {% endif %}</td>
+                    {% endif %}
+                </td>
+                <td>
+                  {% if current_user.is_administrator %}
+                  <a href="{{ url_for('main.edit_assignment', officer_id=officer.id,
+                              assignment_id=assignment.id) }}">
+                    <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+                  </a>
+                  {% endif %}
+                </td>
               </tr>
               {% endfor %}
             </tbody>

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -35,6 +35,20 @@ def add_new_assignment(officer_id, form):
     db.session.commit()
 
 
+def edit_existing_assignment(assignment, form):
+    assignment.star_no = form.star_no.data
+    assignment.rank = form.rank.data
+    if form.unit.data:
+        officer_unit = form.unit.data.id
+    else:
+        officer_unit = None
+    assignment.unit = officer_unit
+    assignment.star_date = form.star_date.data
+    db.session.add(assignment)
+    db.session.commit()
+    return assignment
+
+
 def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -244,6 +244,34 @@ def test_user_can_add_officer_badge_number(mockdata, client, session):
         assert 'Added new assignment' in rv.data
 
 
+def test_user_can_edit_officer_badge_number(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        form = AssignmentForm(star_no='1234',
+                              rank='COMMANDER')
+
+        rv = client.post(
+            url_for('main.officer_profile', officer_id=3),
+            data=form.data,
+            follow_redirects=True
+        )
+
+        form = AssignmentForm(star_no='12345')
+        officer = Officer.query.filter_by(id=3).one()
+
+        rv = client.post(
+            url_for('main.edit_assignment', officer_id=officer.id,
+                    assignment_id=officer.assignments[0].id,
+                    form=form),
+            data=form.data,
+            follow_redirects=True
+        )
+
+        assert 'Edited officer assignment' in rv.data
+        assert officer.assignments[0].star_no == '12345'
+
+
 def test_user_can_view_submission(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #337.

## Notes for Deployment

easy pease

## Screenshots (if appropriate)

Adds a wee pencil icon next to each officer assignment which takes one to a form to update the relevant fields:

<img width="548" alt="screen shot 2017-12-23 at 9 07 38 pm" src="https://user-images.githubusercontent.com/7832803/34324367-9fee31da-e825-11e7-8aff-d03a7fef8a4c.png">

<img width="749" alt="screen shot 2017-12-23 at 9 07 45 pm" src="https://user-images.githubusercontent.com/7832803/34324368-ad33984e-e825-11e7-9da1-d04da5948caf.png">


## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
