### PR TITLE
Set content-type on uploaded images

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -4,7 +4,7 @@ import hashlib
 import random
 from sqlalchemy import func
 from sqlalchemy.sql.expression import cast
-
+import imghdr as imghdr
 from flask import current_app, url_for
 
 from .models import db, Officer, Assignment, Image, Face, User, Unit, Department
@@ -120,11 +120,12 @@ def upload_file(safe_local_path, src_filename, dest_filename):
     # Folder to store files in on S3 is first two chars of dest_filename
     s3_folder = dest_filename[0:2]
     s3_filename = dest_filename[2:]
+    s3_content_type = "image/%s" % imghdr.what(safe_local_path)
     s3_path = '{}/{}'.format(s3_folder, s3_filename)
     s3_client.upload_file(safe_local_path,
                           current_app.config['S3_BUCKET_NAME'],
                           s3_path,
-                          ExtraArgs={'ACL': 'public-read'})
+                          ExtraArgs={'ContentType': s3_content_type, 'ACL': 'public-read'})
 
     url = "https://s3-{}.amazonaws.com/{}/{}".format(
         current_app.config['AWS_DEFAULT_REGION'],

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -90,7 +90,7 @@ def test_compute_hash(mockdata):
     assert hash_result == expected_hash
 
 
-def test_s3_url(mockdata):
+def test_s3_upload_png(mockdata):
     local_path = 'OpenOversight/app/static/images/test_cop1.png'
 
     mocked_connection = Mock()
@@ -101,6 +101,18 @@ def test_s3_url(mockdata):
     assert 'https' in url
     # url should show folder structure with first two chars as folder name
     assert 'te/st' in url
+    assert mocked_connection.method_calls[0][2]['ExtraArgs']['ContentType'] == 'image/png'
+
+
+def test_s3_upload_jpeg(mockdata):
+    local_path = 'OpenOversight/app/static/images/test_cop5.jpg'
+
+    mocked_connection = Mock()
+    with patch('boto3.client', Mock(return_value=mocked_connection)):
+        OpenOversight.app.utils.upload_file(local_path,
+                                            'doesntmatter.png',
+                                            'test_cop1.png')
+    assert mocked_connection.method_calls[0][2]['ExtraArgs']['ContentType'] == 'image/jpeg'
 
 
 def test_user_can_submit_allowed_file(mockdata):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -1,5 +1,5 @@
 from mock import patch, Mock
-
+import os
 import OpenOversight
 
 
@@ -91,7 +91,8 @@ def test_compute_hash(mockdata):
 
 
 def test_s3_upload_png(mockdata):
-    local_path = 'OpenOversight/app/static/images/test_cop1.png'
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    local_path = os.path.join(test_dir, '../app/static/images/test_cop1.png')
 
     mocked_connection = Mock()
     with patch('boto3.client', Mock(return_value=mocked_connection)):
@@ -105,13 +106,14 @@ def test_s3_upload_png(mockdata):
 
 
 def test_s3_upload_jpeg(mockdata):
-    local_path = 'OpenOversight/app/static/images/test_cop5.jpg'
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    local_path = os.path.join(test_dir, '../app/static/images/test_cop5.jpg')
 
     mocked_connection = Mock()
     with patch('boto3.client', Mock(return_value=mocked_connection)):
         OpenOversight.app.utils.upload_file(local_path,
-                                            'doesntmatter.png',
-                                            'test_cop1.png')
+                                            'doesntmatter.jpg',
+                                            'test_cop5.jpg')
     assert mocked_connection.method_calls[0][2]['ExtraArgs']['ContentType'] == 'image/jpeg'
 
 


### PR DESCRIPTION
@bmintz pointed out in #290 that we don't set content-type on the images we upload to S3, leading to some frustrating browser experiences.
This naively sets them based on file extension, with the assumption that browsers will figure it out if someone uploads, say, a .png with a .gif extension.
It also adds a test to make sure that any added ALLOWED_EXTENSIONS are handled properly in `guess_mime_type()` to make sure we have programmatic prompting to keep the list up to date.
I don't actually know how deep inside the s3 library call we want to go to add a test asserting that a mock of the call has mime-type set, so I punted on that.
This doesn't fix historical S3 uploads, unfortunately, which I'll have to do by manually (well, programmatically, but outside of OO) re-PUTing them.

Tested that the test works by adding a new potential filetype to app/config.py and seeing it fail:
```
=================================================================================== FAILURES ===================================================================================
_____________________________________________________________________________ test_guess_mime_type _____________________________________________________________________________

    def test_guess_mime_type():
        for extension in current_app.config['ALLOWED_EXTENSIONS']:
            file_name = "testimage.%s" % extension
>           assert OpenOversight.app.utils.guess_mime_type(file_name) != "binary/octet-stream", "undefined mime-type for extension %s" % extension
E           AssertionError: undefined mime-type for extension gifv
E           assert 'binary/octet-stream' != 'binary/octet-stream'
E            +  where 'binary/octet-stream' = <function guess_mime_type at 0x7f661b216b90>('testimage.gifv')
E            +    where <function guess_mime_type at 0x7f661b216b90> = <module 'OpenOversight.app.utils' from '/vagrant/OpenOversight/app/utils.pyc'>.guess_mime_type
E            +      where <module 'OpenOversight.app.utils' from '/vagrant/OpenOversight/app/utils.pyc'> = <module 'OpenOversight.app' from '/vagrant/OpenOversight/app/__init__.pyc'>.utils
E            +        where <module 'OpenOversight.app' from '/vagrant/OpenOversight/app/__init__.pyc'> = OpenOversight.app

tests/test_utils.py:95: AssertionError
===================================================================== 1 failed, 13 passed in 12.33 seconds =====================================================================
```

## Status

Ready for review

## Description of Changes

Fixes #290.

## Notes for Deployment

None, though I'm going to have to go through and re-PUT all the images after this is deployed to prod.

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
