### PR TITLE
Officer template should default to PO

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -126,7 +126,7 @@ class AddOfficerForm(Form):
                          validators=[AnyOf(allowed_values(GENDER_CHOICES))])
     star_no = StringField('Badge Number', default='', validators=[
         Regexp('\w*'), Length(max=50)])
-    rank = SelectField('Rank', default='COMMANDER', choices=RANK_CHOICES,
+    rank = SelectField('Rank', default='PO', choices=RANK_CHOICES,
                        validators=[AnyOf(allowed_values(RANK_CHOICES))])
     unit = QuerySelectField('Unit', validators=[Optional()],
                             query_factory=unit_choices, get_label='descrip',


### PR DESCRIPTION
Hello,
To reference on issues #345 i've set the field rank "PO" by default when you add a New Officer in Volunteer page, if you can tell me if it's good or not :)