### PR TITLE
converts tiff and psd photo submissions to jpeg

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -37,6 +37,7 @@ class BaseConfig(object):
     # Upload Settings
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024
     ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif'])
+    REQUIRES_CONV = set(['tiff', 'psd'])
 
     SEED = 666
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -448,11 +448,15 @@ def submit_department_images(department_id=1):
 @limiter.limit('250/minute')
 def upload(department_id):
     file_to_upload = request.files['file']
-    if not allowed_file(file_to_upload.filename):
+    if not allowed_file(file_to_upload.filename, 'ALLOWED_EXTENSIONS'):
         return jsonify(error="File type not allowed!"), 415
     original_filename = secure_filename(file_to_upload.filename)
     image_data = file_to_upload.read()
-
+    if allowed_file (file_to_upload.filename, 'REQUIRES_CONV'):
+         changeimage = Image.open(file_to_upload.filename)
+         basename = os.path.splitext(file_to_upload.filename)[0].split('.')
+         changeimage.save(basename + '.jpeg')
+         os.remove(file_to_upload.filename)
     # See if there is a matching photo already in the db
     hash_img = compute_hash(image_data)
     hash_found = Image.query.filter_by(hash_img=hash_img).first()

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -2,6 +2,7 @@ import boto3
 import datetime
 import hashlib
 import random
+from PIL import Image
 from sqlalchemy import func
 from sqlalchemy.sql.expression import cast
 import imghdr as imghdr
@@ -90,9 +91,9 @@ def edit_officer_profile(officer, form):
     return officer
 
 
-def allowed_file(filename):
+def allowed_file(filename, extensions):
     return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']
+           filename.rsplit('.', 1)[1].lower() in current_app.config[extensions]
 
 
 def get_random_image(image_query):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ sqlalchemy==1.1.15
 flask-sqlalchemy>=2.1
 flask-bootstrap
 gunicorn==17.5
+Pillow
 fabric
 itsdangerous


### PR DESCRIPTION
## Status

this code should work, but cannot test because I can't set up a mock S3 bucket (open issue #171)

## Description of Changes

Fixes #369 .

Changes proposed in this pull request:

 - Converts tiff and psd file submissions to jpegs

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [ ] pytests pass in the development environment on my local machine
 
 [ ] `flake8` checks pass
