### PR TITLE
Fix migrations in vagrant dev env

### DIFF
--- a/vagrant/puppet/manifests/default.pp
+++ b/vagrant/puppet/manifests/default.pp
@@ -101,6 +101,14 @@
     require     => [ File["${source_path}/OpenOversight/.env"], Python::Virtualenv[$virtualenv], Postgresql::Server::Db[$database_name]  ]
   }
 
+  exec{'stamp database on latest migration':
+    command     => "python manage.py db stamp head",
+    cwd         => "$source_path/OpenOversight",
+    path        => "${virtualenv}/bin",
+    user        => $system_user,
+    require     => [ File["${source_path}/OpenOversight/.env"], Python::Virtualenv[$virtualenv], Postgresql::Server::Db[$database_name]  ]
+  }
+
   exec{'create test data':
     command     => "python test_data.py -p",
     cwd         => $source_path,


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - This PR fixes the issue reported by @pierwill and @magpiewings in #366 in the development environment. The issue was (from Slack):

"when i run `python manage.py db migrate` per `CONTRIB.md` i get

```(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py db migrate
--------------------------------------------------------------------------------
INFO in __init__ [/vagrant/OpenOversight/app/__init__.py:57]:
OpenOversight startup
--------------------------------------------------------------------------------
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
Traceback (most recent call last):
  File "manage.py", line 94, in <module>
    manager.run()
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/flask_script/__init__.py", line 417, in run
    result = self.handle(argv[0], argv[1:])
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/flask_script/__init__.py", line 386, in handle
    res = handle(*args, **config)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/flask_migrate/__init__.py", line 197, in migrate
    version_path=version_path, rev_id=rev_id)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/command.py", line 176, in revision
    script_directory.run_env()
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/script/base.py", line 427, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/util/pyfiles.py", line 81, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/util/compat.py", line 141, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "migrations/env.py", line 89, in <module>
    run_migrations_online()
  File "migrations/env.py", line 81, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/runtime/environment.py", line 836, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/runtime/migration.py", line 321, in run_migrations
    for step in self._migrations_fn(heads, self):
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/command.py", line 156, in retrieve_migrations
    revision_context.run_autogenerate(rev, context)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/autogenerate/api.py", line 415, in run_autogenerate
    self._run_environment(rev, migration_context, True)
  File "/home/vagrant/oovirtenv/local/lib/python2.7/site-packages/alembic/autogenerate/api.py", line 427, in _run_environment
    raise util.CommandError("Target database is not up to date.")
alembic.util.exc.CommandError: Target database is not up to date.
```
"

## How to verify the fix

1. Provision a fresh development environment.
2. Make a trivial change to `models.py`, e.g.: 
```
$ git diff app/models.py
diff --git a/OpenOversight/app/models.py b/OpenOversight/app/models.py
index 97b02f7..c838566 100644
--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -25,6 +25,7 @@ class Officer(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     last_name = db.Column(db.String(120), index=True, unique=False)
+    bleh = db.Column(db.String(120))
     first_name = db.Column(db.String(120), index=True, unique=False)
     middle_initial = db.Column(db.String(120), unique=False, nullable=True)
     race = db.Column(db.String(120), index=True, unique=False)
```
3. Attempt to generate a migration: `$ python manage.py db migrate` - if this works we are good!

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [ ] pytests pass in the development environment on my local machine
 
- [ ] `flake8` checks pass
