### PR TITLE
Add timeline to officer profiles

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -18,7 +18,7 @@ from .. import limiter
 from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
                      serve_image, compute_leaderboard_stats, get_random_image,
                      allowed_file, add_new_assignment, edit_existing_assignment,
-                     add_officer_profile, edit_officer_profile)
+                     add_officer_profile, edit_officer_profile, get_timeline)
 from .forms import (FindOfficerForm, FindOfficerIDForm, AddUnitForm,
                     FaceTag, AssignmentForm, DepartmentForm, AddOfficerForm,
                     BasicOfficerForm)
@@ -141,6 +141,8 @@ def officer_profile(officer_id):
                       format_exc(full_tback)])
         ))
 
+    timeline_events = get_timeline(faces)
+
     if form.validate_on_submit() and current_user.is_administrator:
         try:
             add_new_assignment(officer_id, form)
@@ -150,7 +152,8 @@ def officer_profile(officer_id):
         return redirect(url_for('main.officer_profile',
                                 officer_id=officer_id), code=302)
     return render_template('officer.html', officer=officer, paths=face_paths,
-                           assignments=assignments, form=form)
+                           assignments=assignments, form=form,
+                           timeline_events=timeline_events)
 
 
 @main.route('/officer/<int:officer_id>/assignment/<int:assignment_id>',
@@ -227,7 +230,6 @@ def classify_submission(image_id, contains_cops):
                       format_exc(full_tback)])
         ))
     return redirect(redirect_url())
-    # return redirect(url_for('main.display_submission', image_id=image_id))
 
 
 @main.route('/department/new', methods=['GET', 'POST'])

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,7 +4,7 @@
 <div class="container" role="main">
 
   <div class="page-header">
-    <h1>Officer Detail: <b>{{ officer.first_name|title }}
+    <h1>Officer Profile: <b>{{ officer.first_name|title }}
                            {% if officer.middle_initial %}
                            {{ officer.middle_initial }}
                            {% endif %}
@@ -13,11 +13,12 @@
 
   <div class="row">
     <div class="col-sm-6">
-      {% for path in paths %}
-      <img src="{{ path }}" alt="Submission">
-      {% endfor %}
+      {% if paths %}
+      <img src="{{ paths[0] }}" alt="Submission">
+      {% endif %}
     </div>
     <div class="col-sm-6 col-md-4">
+
       <div class="thumbnail">
         <div class="caption">
           <h3>General Information
@@ -55,12 +56,9 @@
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
       </div>
-    </div>
-  </div>
-
-  <div class="row">
     <div class="col-sm-6">
       <div class="thumbnail">
         <div class="caption">
@@ -158,8 +156,41 @@
             </tbody>
           </table>
           {% endif %}
+        </div>
       </div>
     </div>
   </div>
+
+  <div class="page-header">
+    <h1>Recent Activity</h1>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      {% for timeline_event in timeline_events %}
+        {% if timeline_event["date_image_inserted"] %}
+          <p>On {{ timeline_event["date_image_inserted"].strftime('%m/%d/%Y') }},
+          <a href="{{ url_for('main.display_submission', image_id=timeline_event["image_id"]) }}">a new photo</a>
+          was added to OpenOversight containing this officer.</p>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+
+  {% if paths[1] %}
+  {% set paths = paths[1:] %}
+  <div class="page-header">
+    <h1>Additional Photographs</h1>
+  </div>
+  <div class="row">
+    <div class="col-sm-6">
+      {% for path in paths %}
+      <div class="thumbnail">
+        <img src="{{ path }}" alt="Submission">
+      </div>
+      {% endfor %}
+    </div>
+  <div>
+  {% endif %}
+
 </div>
 {% endblock %}

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -170,7 +170,9 @@
         {% if timeline_event["date_image_inserted"] %}
           <p>On {{ timeline_event["date_image_inserted"].strftime('%m/%d/%Y') }},
           <a href="{{ url_for('main.display_submission', image_id=timeline_event["image_id"]) }}">a new photo</a>
-          was added to OpenOversight containing this officer.</p>
+          was added to OpenOversight
+          <a href="{{ url_for('main.display_tag', tag_id=timeline_event["tag_id"]) }}">containing</a>
+          this officer.</p>
         {% endif %}
       {% endfor %}
     </div>

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -249,7 +249,8 @@ def get_timeline(faces):
                        reverse=True)
     for face in faces_w_dates:
         event = {"date_image_inserted": face.image.date_image_inserted,
-                 "image_id": face.image.id}
+                 "image_id": face.image.id,
+                 "tag_id": face.id}
         timeline_events.append(event)
 
     return timeline_events

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -227,3 +227,29 @@ def compute_leaderboard_stats(select_top=25):
                             .order_by(func.count(Face.user_id).desc()) \
                             .limit(select_top).all()
     return top_sorters, top_taggers
+
+
+def get_timeline(faces):
+    # Get the events we want to show in a time ordered area on the profile
+    # of the officer.
+    timeline_events = []
+
+    # If there are no faces for this officer, let's return
+    if not faces:
+        return timeline_events
+
+    # If no faces are associated with images with dates, let's return
+    faces_w_dates = [x for x in faces
+                     if x.image.date_image_inserted is not None]
+    if not faces_w_dates:
+        return timeline_events
+
+    # Sort list of faces with newest first
+    faces_w_dates.sort(key=lambda i: i.image.date_image_inserted,
+                       reverse=True)
+    for face in faces_w_dates:
+        event = {"date_image_inserted": face.image.date_image_inserted,
+                 "image_id": face.image.id}
+        timeline_events.append(event)
+
+    return timeline_events

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -155,13 +155,17 @@ def mockdata(session, request):
     random.seed(SEED)
 
     image1 = models.Image(filepath='static/images/test_cop1.png',
-                          department_id=1)
+                          department_id=1,
+                          date_image_inserted=datetime.now())
     image2 = models.Image(filepath='static/images/test_cop2.png',
-                          department_id=1)
+                          department_id=1,
+                          date_image_inserted=datetime.now())
     image3 = models.Image(filepath='static/images/test_cop3.png',
-                          department_id=1)
+                          department_id=1,
+                          date_image_inserted=datetime.now())
     image4 = models.Image(filepath='static/images/test_cop4.png',
-                          department_id=1)
+                          department_id=1,
+                          date_image_inserted=datetime.now())
 
     unit1 = models.Unit(descrip="test")
 

--- a/OpenOversight/tests/test_routes.py
+++ b/OpenOversight/tests/test_routes.py
@@ -227,7 +227,7 @@ def test_user_can_access_officer_profile(mockdata, client, session):
             url_for('main.officer_profile', officer_id=3),
             follow_redirects=True
         )
-        assert 'Officer Detail' in rv.data
+        assert 'Officer Profile' in rv.data
 
 
 def test_user_can_add_officer_badge_number(mockdata, client, session):

--- a/test_data.py
+++ b/test_data.py
@@ -107,15 +107,20 @@ def populate():
 
     # Add images from Springfield Police Department
     image1 = models.Image(filepath='static/images/test_cop1.png',
-                          department_id=department1.id)
+                          department_id=department1.id,
+                          date_image_inserted=datetime.now())
     image2 = models.Image(filepath='static/images/test_cop2.png',
-                          department_id=department1.id)
+                          department_id=department1.id,
+                          date_image_inserted=datetime.now())
     image3 = models.Image(filepath='static/images/test_cop3.png',
-                          department_id=department2.id)
+                          department_id=department2.id,
+                          date_image_inserted=datetime.now())
     image4 = models.Image(filepath='static/images/test_cop4.png',
-                          department_id=department2.id)
+                          department_id=department2.id,
+                          date_image_inserted=datetime.now())
     image5 = models.Image(filepath='static/images/test_cop5.jpg',
-                          department_id=department2.id)
+                          department_id=department2.id,
+                          date_image_inserted=datetime.now())
 
     test_images = [image1, image2, image3, image4, image5]
     db.session.add_all(test_images)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Implements #414

Changes proposed in this pull request:

- Adds timeline to profile:

![screen shot 2018-04-28 at 11 44 20 pm](https://user-images.githubusercontent.com/7832803/39404034-e3566f4c-4b3e-11e8-9540-1358dcc7947d.png)

 - Show first photo only at top of officer profile, adds additional photos area for the remainder:

![screen shot 2018-04-28 at 10 54 39 pm](https://user-images.githubusercontent.com/7832803/39404032-d8ba72ea-4b3e-11e8-8eeb-e4bdb5c80c91.png)

## Notes for Deployment

No migrations needed

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
