### PR TITLE
Do not use department id if there is none.

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -455,7 +455,11 @@ def complete_tagging(image_id):
     image.is_tagged = True
     db.session.commit()
     flash('Marked image as completed.')
-    return redirect(url_for('main.label_data', department_id=request.args.get('department_id')))
+    department_id = request.args.get('department_id')
+    if department_id:
+        return redirect(url_for('main.label_data', department_id=department_id))
+    else:
+        return redirect(url_for('main.label_data'))
 
 
 @main.route('/tagger_gallery/<int:page>', methods=['GET', 'POST'])


### PR DESCRIPTION
The route handler raises an error if it receives an empty string as the
department id. This ensures that if there is no department id, we are
still redirected correctly.

## Status

Ready for review

## Description of Changes

Fixes an error introduced when fixing tagging in #430 

Changes proposed in this pull request:

 - Change the redirect after tagging a photo to send user to accommodate the situation in which a department is not set.


## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
-[ x ] I have rebased my changes on current `develop`
 
-[ x ] pytests pass in the development environment on my local machine
 
 -[ x ] `flake8` checks pass
