### PR TITLE
Success checkmark stays after file upload

### DIFF
--- a/OpenOversight/app/static/css/dropzone-override.css
+++ b/OpenOversight/app/static/css/dropzone-override.css
@@ -1,0 +1,14 @@
+/* Override Dropzone checkmark animation */
+.dropzone .dz-preview.dz-success .dz-success-mark {
+	opacity: 1;
+	-webkit-animation: none 0s ease
+  -moz-animation: none 0s ease
+  -ms-animation: none 0s ease
+  -o-animation: none 0s ease
+  animation: none 0s ease
+  -webkit-animation: slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)!important;
+  -moz-animation:  slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)!important;
+  -ms-animation: slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)!important;
+  -o-animation:  slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)!important;
+  animation:  slide-in 3s cubic-bezier(0.77, 0, 0.175, 1)!important;
+}

--- a/OpenOversight/app/templates/submit_department.html
+++ b/OpenOversight/app/templates/submit_department.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
+
+{% block head %}
+  <link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/dropzone-override.css') }}" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
-
-<link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
-
 <div class="container theme-showcase" role="main">
 
    <div class="page-header">

--- a/OpenOversight/app/templates/submit_deptselect.html
+++ b/OpenOversight/app/templates/submit_deptselect.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
-{% block content %}
 
-<link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
+
+{% block head %}
+	<link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
+	<link href="{{ url_for('static', filename='css/dropzone-override.css') }}" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
 
 <div class="container theme-showcase" role="main">
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Overrides dropzone's checkmark animation
Puts links to stylesheets in the header on dropzone pages

Fixes 373.

Changes proposed in this pull request:

 - Overrides the default css animation to an animation that stays put.

## Notes for Deployment

## Screenshots (if appropriate)
![screen shot 2018-05-14 at 1 55 51 pm](https://user-images.githubusercontent.com/13922520/40014459-a03d28e4-577e-11e8-806d-5345ccf57ba3.png)


## Tests and linting
 
 [x ] I have rebased my changes on current `develop`
 
 [ x] pytests pass in the development environment on my local machine
 
 [ x] `flake8` checks pass
