### PR TITLE
Fix year validation on incident form

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -219,6 +219,10 @@ class DateFieldForm(Form):
         if not type(field.data) == datetime.time:
             raise ValidationError('Not a valid time.')
 
+    def validate_date_field(self, field):
+        if field.data.year < 1900:
+            raise ValidationError('Incidents prior to 1900 not allowed.')
+
 
 class LocationForm(Form):
     street_name = StringField(validators=[Required()], description='Street on which incident occurred. For privacy reasons, please DO NOT INCLUDE street number.')


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #442

Changes proposed in this pull request:
 - Adds validation such that incidents <1900 cannot be made:

<img width="409" alt="screen shot 2018-05-20 at 12 08 38 pm" src="https://user-images.githubusercontent.com/7832803/40282730-716acd42-5c28-11e8-8c3f-ce84d9f333bf.png">

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
