### PR TITLE
Filter by race, gender: Return officers that we do not have race, gender info for

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -167,11 +167,15 @@ def filter_by_form(form, officer_query):
         )
     if form['race'] in ('BLACK', 'WHITE', 'ASIAN', 'HISPANIC',
                         'PACIFIC ISLANDER'):
-        officer_query = officer_query.filter(
-            Officer.race.like('%%{}%%'.format(form['race']))
-        )
+        officer_query = officer_query.filter(db.or_(
+            Officer.race.like('%%{}%%'.format(form['race'])),
+            Officer.race == 'Not Sure',
+            Officer.race == None  # noqa
+        ))
     if form['gender'] in ('M', 'F'):
-        officer_query = officer_query.filter(Officer.gender == form['gender'])
+        officer_query = officer_query.filter(db.or_(Officer.gender == form['gender'],
+                                                    Officer.gender == 'Not Sure',
+                                                    Officer.gender == None))  # noqa
     if form['dept']:
         officer_query = officer_query.filter(
             Officer.department_id == form['dept'].id

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -169,7 +169,7 @@ def filter_by_form(form, officer_query):
                         'PACIFIC ISLANDER'):
         officer_query = officer_query.filter(db.or_(
             Officer.race.like('%%{}%%'.format(form['race'])),
-            Officer.race == 'Not Sure',
+            Officer.race == 'Not Sure',  # noqa
             Officer.race == None  # noqa
         ))
     if form['gender'] in ('M', 'F'):
@@ -198,14 +198,16 @@ def filter_by_form(form, officer_query):
         officer_query = officer_query.filter(
             db.or_(Assignment.rank.like('%%PO%%'),
                    Assignment.rank.like('%%POLICE OFFICER%%'),
-                   Assignment.rank == None)  # noqa
+                   Assignment.rank == None,  # noqa
+                   Assignment.rank == 'Not Sure')  # noqa
         )
     if form['rank'] in ('FIELD', 'SERGEANT', 'LIEUTENANT', 'CAPTAIN',
                         'COMMANDER', 'DEP CHIEF', 'CHIEF', 'DEPUTY SUPT',
                         'SUPT OF POLICE'):
         officer_query = officer_query.filter(
             db.or_(Assignment.rank.like('%%{}%%'.format(form['rank'])),
-                   Assignment.rank == None)  # noqa
+                   Assignment.rank == None,  # noqa
+                   Assignment.rank == 'Not Sure')  # noqa
         )
 
     # This handles the sorting upstream of pagination and pushes officers w/o tagged faces to the end of list

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -28,11 +28,11 @@ def pick_birth_date():
 
 def pick_race():
     return random.choice(['WHITE', 'BLACK', 'HISPANIC', 'ASIAN',
-                         'PACIFIC ISLANDER'])
+                          'PACIFIC ISLANDER', 'Not Sure'])
 
 
 def pick_gender():
-    return random.choice(['M', 'F'])
+    return random.choice(['M', 'F', 'Not Sure'])
 
 
 def pick_first():

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -52,7 +52,7 @@ def pick_name():
 
 
 def pick_rank():
-    return random.choice(['COMMANDER', 'CAPTAIN', 'PO'])
+    return random.choice(['COMMANDER', 'CAPTAIN', 'PO', 'Not Sure'])
 
 
 def pick_star():

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -23,7 +23,7 @@ def test_race_filter_select_all_black_officers(mockdata):
          'dept': department}
     )
     for element in results:
-        assert element.race == 'BLACK'
+        assert element.race == 'BLACK' or element.race == 'Not Sure'
 
 
 def test_gender_filter_select_all_male_officers(mockdata):
@@ -34,7 +34,7 @@ def test_gender_filter_select_all_male_officers(mockdata):
          'dept': department}
     )
     for element in results:
-        assert element.gender == 'M'
+        assert element.gender == 'M' or element.gender == 'Not Sure'
 
 
 def test_rank_filter_select_all_commanders(mockdata):
@@ -46,7 +46,7 @@ def test_rank_filter_select_all_commanders(mockdata):
     )
     for element in results:
         assignment = element.assignments.first()
-        assert assignment.rank == 'COMMANDER'
+        assert assignment.rank == 'COMMANDER' or element.gender == 'Not Sure'
 
 
 def test_rank_filter_select_all_police_officers(mockdata):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -23,7 +23,7 @@ def test_race_filter_select_all_black_officers(mockdata):
          'dept': department}
     )
     for element in results:
-        assert element.race == 'BLACK' or element.race == 'Not Sure'
+        assert element.race in ('BLACK', 'Not Sure')
 
 
 def test_gender_filter_select_all_male_officers(mockdata):
@@ -34,7 +34,7 @@ def test_gender_filter_select_all_male_officers(mockdata):
          'dept': department}
     )
     for element in results:
-        assert element.gender == 'M' or element.gender == 'Not Sure'
+        assert element.gender in ('M', 'Not Sure')
 
 
 def test_rank_filter_select_all_commanders(mockdata):
@@ -46,7 +46,7 @@ def test_rank_filter_select_all_commanders(mockdata):
     )
     for element in results:
         assignment = element.assignments.first()
-        assert assignment.rank == 'COMMANDER' or element.gender == 'Not Sure'
+        assert assignment.rank in ('COMMANDER', 'Not Sure')
 
 
 def test_rank_filter_select_all_police_officers(mockdata):
@@ -58,7 +58,7 @@ def test_rank_filter_select_all_police_officers(mockdata):
     )
     for element in results:
         assignment = element.assignments.first()
-        assert assignment.rank == 'PO'
+        assert assignment.rank in ('PO', 'Not Sure')
 
 
 def test_filter_by_name(mockdata):

--- a/test_data.py
+++ b/test_data.py
@@ -30,11 +30,11 @@ def pick_birth_date():
 
 def pick_race():
     return random.choice(['WHITE', 'BLACK', 'HISPANIC', 'ASIAN',
-                          'PACIFIC ISLANDER'])
+                          'PACIFIC ISLANDER', None])
 
 
 def pick_gender():
-    return random.choice(['M', 'F'])
+    return random.choice(['M', 'F', None])
 
 
 def pick_first():

--- a/test_data.py
+++ b/test_data.py
@@ -30,11 +30,11 @@ def pick_birth_date():
 
 def pick_race():
     return random.choice(['WHITE', 'BLACK', 'HISPANIC', 'ASIAN',
-                          'PACIFIC ISLANDER', None])
+                          'PACIFIC ISLANDER', 'Not Sure'])
 
 
 def pick_gender():
-    return random.choice(['M', 'F', None])
+    return random.choice(['M', 'F', 'Not Sure'])
 
 
 def pick_first():

--- a/test_data.py
+++ b/test_data.py
@@ -54,7 +54,7 @@ def pick_name():
 
 
 def pick_rank():
-    return random.choice(['COMMANDER', 'CAPTAIN', 'PO'])
+    return random.choice(['COMMANDER', 'CAPTAIN', 'PO', 'Not Sure'])
 
 
 def pick_star():


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #425

Changes proposed in this pull request:

 - For some departments, we do not have per-officer race or gender information. In those cases, we do not currently return them if a user searches for a specific gender. This is confusing behavior - for a query for all male officers, we should return all male officers and those we are not sure about. Longer term, area coordinators should be maintaining this information  if possible.

## Notes for Deployment

No db migrations

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
 
- [x] pytests pass in the development environment on my local machine
 
- [x] `flake8` checks pass
