### PR TITLE
Prepopulate officer ID on incident form

### DIFF
--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -113,7 +113,8 @@ class ModelView(MethodView):
         self.model(**form.data)
 
     def dispatch_request(self, *args, **kwargs):
-        end_of_url = request.url.split('/')[-1]
+        # isolate the method at the end of the url
+        end_of_url = request.url.split('/')[-1].split('?')[0]
         endings = ['edit', 'new', 'delete']
         meth = None
         for ending in endings:

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -648,6 +648,9 @@ class IncidentApi(ModelView):
 
     def get_new_form(self):
         form = self.form()
+        if request.args.get('officer_id'):
+            form.officers[0].data = request.args.get('officer_id')
+
         for link in form.links:
             link.user_id.data = current_user.id
         return form

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -183,7 +183,7 @@
       </ul>
       {% if current_user.is_administrator
           or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id) %}
-        <a href="{{ url_for('main.incident_api') + 'new' }}" class='btn btn-primary'>New Incident</a>
+        <a href="{{ url_for('main.incident_api') + 'new?officer_id={}'.format(officer.id) }}" class='btn btn-primary'>New Incident</a>
       {% endif %}
     </div>{# end col #}
   </div> {# end row #}

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -434,3 +434,11 @@ def test_users_cannot_see_who_created_incidents(mockdata, client, session):
         login_ac(client)
         rv = client.get(url_for('main.incident_api', obj_id=1))
         assert 'Creator' not in rv.data
+
+
+def test_form_with_officer_id_prepopulates(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+        officer_id = '1234'
+        rv = client.get(url_for('main.incident_api') + 'new?officer_id={}'.format(officer_id))
+        assert officer_id in rv.data


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #455 .

Changes proposed in this pull request:

 - Changes the url on the officer page to include the officer id
 - Changes how the model view handles urls
 - Prepopulates incident form with officer ID when coming from the officer's page.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
