### PR TITLE
Do not require a report number to create an incident

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -256,7 +256,7 @@ class OfficerIdField(StringField):
 
 class IncidentForm(DateFieldForm):
     report_number = StringField(
-        validators=[Required(), Regexp(r'^[a-zA-Z0-9-]*$', message="Report numbers can contain letters, numbers, and dashes")],
+        validators=[Regexp(r'^[a-zA-Z0-9-]*$', message="Report numbers can contain letters, numbers, and dashes")],
         description='Incident number for the organization tracking incidents')
     description = TextAreaField(validators=[Optional()])
     department = QuerySelectField(

--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -13,7 +13,7 @@
 				<a href="{{ url_for('main.incident_api', department_id=incident.department_id)}}">More incidents in the {{ incident.department.name }}</a>
 			</p>
 		{% endif %}
-		<h1>Incident {{incident.report_number}}</h1>
+		<h1>Incident {% if incident.report_number %}{{incident.report_number}}{% endif %}</h1>
 		<div class='row'>
 			<div class="col-sm-12 col-md-6">
 				{% with detail=True %}

--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -14,7 +14,10 @@
 		  	<li class="list-group-item">
 		  		<h3>
 		  				<a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
-		  				Incident {{ incident.report_number }}
+		  				Incident
+              {% if incident.report_number %}
+                {{ incident.report_number }}
+              {% endif %}
 		  			</a>
 		  		</h3>
 		    	{% include 'partials/incident_fields.html' %}


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #456 .

Changes proposed in this pull request:

 - Removes the required from the incident report number field in the incident form
 - Makes the appropriate changes to the templates to deal with non-numbered incidents

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
