### PR TITLE
Hide last formset instead of removing it

### DIFF
--- a/OpenOversight/app/static/js/incidentAddButtons.js
+++ b/OpenOversight/app/static/js/incidentAddButtons.js
@@ -40,7 +40,7 @@ function cloneFieldList(selector) {
 }
 
 
-/* This function checks if it is the last fieldset element in its parent. If it is, it copies itself before deleting, and sets a new click handler and text on the add button. If it has other fieldset siblings, it simply deletes itself. */
+/* This function checks if it is the last fieldset element in its parent. If it is, it removes all field values before hiding the element, and sets a new click handler and text on the add button. If it has other fieldset siblings, it simply deletes itself. */
 
 function removeParent(event) {
     event.preventDefault()
@@ -51,16 +51,21 @@ function removeParent(event) {
        previousElement.tagName === 'LEGEND' &&
        nextElement &&
        nextElement.tagName === 'BUTTON'){
-
-        var new_element = $(event.target.parentElement).clone(true)
-        var add_button = $(event.target.parentElement.nextElementSibling)
+        var $lastElement = $(event.target.parentElement)
+        // Remove any filled in values (but not the csrf token)
+        $lastElement.find(':input:not(:hidden)').each(function(child) {
+            $(this).val('')
+        });
+        $lastElement.hide()
+        var add_button = $(nextElement)
         var fieldsetName = $(previousElement).text().slice(0, -1)
+
         // Remove previous click handler
         add_button.off('click')
         add_button.text('New ' + fieldsetName)
         add_button.on('click', function(event) {
             event.preventDefault()
-            add_button.before(new_element);
+            $lastElement.show()
             // remove this click handler
             add_button.off('click')
             add_button.text('Add another ' + fieldsetName)
@@ -71,5 +76,4 @@ function removeParent(event) {
             });
         })
     }
-    event.target.parentElement.remove()
 }


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #457 
The last link/license plate is now hidden rather than removed
Inputs on the form are cleared when it is hidden
This allows us to preserve the csrf token so that the form will send correctly

**To Review**
Go to the create a new incident page.
Add a license plate, remove it. Verify that the incident is created correctly and the license plate you made is not in it.
Do the same for links.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
