### PR TITLE
Include officers without assignments in search results

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -228,7 +228,7 @@ def filter_roster(form, officer_query):
             Officer.last_name.ilike('%%{}%%'.format(form['name']))
         )
 
-    officer_query = officer_query.join(Assignment)
+    officer_query = officer_query.outerjoin(Assignment)
     if form['badge']:
         officer_query = officer_query.filter(
             cast(Assignment.star_no, db.String)

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -207,7 +207,6 @@ def filter_by_form(form, officer_query):
         officer_query = officer_query.filter(
             db.or_(Assignment.rank.like('%%PO%%'),
                    Assignment.rank.like('%%POLICE OFFICER%%'),
-                   Assignment.rank == None,  # noqa
                    Assignment.rank == 'Not Sure')  # noqa
         )
     if form['rank'] in ('FIELD', 'SERGEANT', 'LIEUTENANT', 'CAPTAIN',
@@ -215,7 +214,6 @@ def filter_by_form(form, officer_query):
                         'SUPT OF POLICE'):
         officer_query = officer_query.filter(
             db.or_(Assignment.rank.like('%%{}%%'.format(form['rank'])),
-                   Assignment.rank == None,  # noqa
                    Assignment.rank == 'Not Sure')  # noqa
         )
 

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -197,7 +197,7 @@ def filter_by_form(form, officer_query):
                                                         Officer.birth_year >= max_birth_year),
                                                 Officer.birth_year == None))  # noqa
 
-    officer_query = officer_query.join(Assignment)
+    officer_query = officer_query.outerjoin(Assignment)
     if form['badge']:
         officer_query = officer_query.filter(
             cast(Assignment.star_no, db.String)

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -72,6 +72,17 @@ def test_filter_by_name(mockdata):
         assert 'J' in element.last_name
 
 
+def test_filters_do_not_exclude_officers_without_assignments(mockdata):
+    department = OpenOversight.app.models.Department.query.first()
+    officer = OpenOversight.app.models.Officer(first_name='Rachel', last_name='S', department=department, birth_year=1992)
+    results = OpenOversight.app.utils.grab_officers(
+        {'race': 'Not Sure', 'gender': 'Not Sure', 'rank': 'Not Sure',
+         'min_age': 16, 'max_age': 85, 'name': 'S', 'badge': '',
+         'dept': department}
+    )
+    assert officer in results
+
+
 def test_filter_by_badge_no(mockdata):
     department = OpenOversight.app.models.Department.query.first()
     results = OpenOversight.app.utils.grab_officers(


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #440 .

Changes proposed in this pull request:

 - use a left join on Assignment
 - Added a test to be sure it worked


## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting
 
 [x] I have rebased my changes on current `develop`
 
 [x] pytests pass in the development environment on my local machine
 
 [x] `flake8` checks pass
