### PR TITLE
Create links between documentation files

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -1,12 +1,12 @@
 # Contributing Guide
 
-First, thanks for being interested in helping us out! If you find an issue you're interested in, feel free to make a comment about how you're thinking of approaching implementing it in the issue and we can give you feedback.
+First, thanks for being interested in helping us out! If you find an issue you're interested in, feel free to make a comment about how you're thinking of approaching implementing it in the issue and we can give you feedback.  Please also read our [code of conduct](/CODE_OF_CONDUCT.md) before getting started.
 
 ## Submitting a PR
 
 When you come to implement your new feature, you should branch off `develop` and add commits to implement your feature. If your git history is not so clean, please do rewrite before you submit your PR - if you're not sure if you need to do this, go ahead and submit and we can let you know when you submit.
 
-Use `PULL_REQUEST_TEMPLATE.md` to create the description for your PR!
+Use [PULL_REQUEST_TEMPLATE.md](/PULL_REQUEST_TEMPLATE.md) to create the description for your PR! (The template should populate automatically when you go to open the pull request.)
 
 ### Linting / Style Checks
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,6 +1,6 @@
 # Deployment
 
-When this application is deployed you will need to do some setup. These instructions are for an Ubuntu server running an `nginx` reverse proxy  and `gunicorn`. 
+When this application is deployed you will need to do some setup. These instructions are for an Ubuntu server running an `nginx` reverse proxy  and `gunicorn`.
 
 # Dependencies
 
@@ -109,7 +109,7 @@ For more details about the S3 and AWS settings, see above. Please raise an issue
 
 # Systemd
 
-You can write a simple systemd unit file to launch OpenOversight on boot. We defined ours in `/etc/systemd/system/openoversight.service`. You should create the proper usernames and groups that are defined in the unit file since this allows you to drop privileges on boot. This unit file was adopted from this [DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-centos-7). More details can be found in `CONTRIB.md`.
+You can write a simple systemd unit file to launch OpenOversight on boot. We defined ours in `/etc/systemd/system/openoversight.service`. You should create the proper usernames and groups that are defined in the unit file since this allows you to drop privileges on boot. This unit file was adopted from this [DigitalOcean guide](https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-centos-7). More details can be found in [CONTRIB.md](/CONTRIB.md).
 
 ```
 [Unit]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,9 @@ Changes proposed in this pull request:
 ## Screenshots (if appropriate)
 
 ## Tests and linting
- 
- [ ] I have rebased my changes on current `develop`
- 
- [ ] pytests pass in the development environment on my local machine
- 
- [ ] `flake8` checks pass
+
+ - [ ] I have rebased my changes on current `develop`
+
+ - [ ] pytests pass in the development environment on my local machine
+
+ - [ ] `flake8` checks pass

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 OpenOversight is a Lucy Parsons Labs project to improve police accountability through public and crowdsourced data. We maintain a database of police officer demographic information and provide digital galleries of photographs to help people identify police officers for filing complaints and in order to see public information about their local police force.
 
-This project is written and maintained by [@lucyparsonslabs](https://twitter.com/lucyparsonslabs) with collaboration, partnerships, and contributions welcome. If you would like to contribute code or documentation, please see our contributing guide. You can get a tip for implementing important issues. If you prefer to contribute in other ways, please submit images to our platform or talk to us about how to help sort and tag images. This project is in public beta, and we are currently soliciting photographs to add to the database.
+This project is written and maintained by [@lucyparsonslabs](https://twitter.com/lucyparsonslabs) with collaboration, partnerships, and contributions welcome. If you would like to contribute code or documentation, please see our [contributing guide](/CONTRIB.md) and [code of conduct](/CODE_OF_CONDUCT.md). You can get a [tip](#tips) for implementing important issues. If you prefer to contribute in other ways, please submit images to our platform or talk to us about how to help sort and tag images. This project is in public beta, and we are currently soliciting photographs to add to the database.
 
 ## Note to Law Enforcement
 
@@ -41,11 +41,11 @@ Email: test@example.org
 Password: testtest
 ```
 
-Please see `CONTRIB.md` for the full developer setup instructions.
+Please see [CONTRIB.md](/CONTRIB.md) for the full developer setup instructions.
 
 ## Deployment
 
-Please see the `DEPLOY.md` file for deployment instructions.
+Please see the [DEPLOY.md](/DEPLOY.md) file for deployment instructions.
 
 ## What data do I need to set up OpenOversight in my city?
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Create links between documentation files + a few other small changes

Changes proposed in this pull request:

- Create links between documentation files.
- Add requests to read to the code of conduct in both README and CONTRIB.
- Fix inconsequential typo in a link in README.
- Add note that PR template should populate automatically.
- Make checkboxes in PR template actual checkboxes.

## Tests and linting
 
- [x] I have rebased my changes on current `develop`
- N/A ~pytests pass in the development environment on my local machine~
- N/A ~`flake8` checks pass~