### PR TITLE
Resolve all flake8 issues in root of repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ before_script:
   - cd OpenOversight
 script:
   - py.test -v --cov=app
-  - flake8 --ignore=E501,E722
+  - cd .. && flake8 --ignore=E501,E722
 after_success:
   - coveralls

--- a/create_db.py
+++ b/create_db.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python
-import os.path
-
 from OpenOversight.app import create_app
 from OpenOversight.app.models import db
 

--- a/flickrscraper/resize.and.detect.py
+++ b/flickrscraper/resize.and.detect.py
@@ -128,5 +128,5 @@ if __name__ == '__main__':
         max_results = '4'
         try:
             main(file, output, max_results)
-        except:
+        except:  # noqa
             os.remove(file)

--- a/socmint/grab_socmint.py
+++ b/socmint/grab_socmint.py
@@ -2,6 +2,7 @@ import subprocess
 from tqdm import tqdm
 from sys import argv
 
+
 def main():
     accounts_file_location = 'chicago.txt'
     if len(argv) == 2:

--- a/test_data.py
+++ b/test_data.py
@@ -98,10 +98,10 @@ def populate():
     """ Populate database with test data"""
 
     department1 = models.Department(name='Springfield Police Department',
-                                   short_name='SPD')
+                                    short_name='SPD')
     db.session.add(department1)
     department2 = models.Department(name='Gotham Police Department',
-                                   short_name='GPD')
+                                    short_name='GPD')
     db.session.add(department2)
     db.session.commit()
 
@@ -206,6 +206,7 @@ if __name__ == "__main__":
         try:
             cleanup()
             print("[*] Completed successfully!")
-        except:
+        except Exception as e:
             print("[!] Encountered an unknown issue, exiting.")
+            print(e)
             sys.exit(1)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The request to run `flake8` can be confusing: there are no linting errors reported in CI (as it's run from the OpenOversight directory). But in the root of the repo, there are a few linting errors. 

Changes proposed in this pull request:

 - Resolve the remainder of flake8 linting issues in the root of the repo
 - Run linting in CI from the root of the repo to prevent issues going forward

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
