### PR TITLE
Get URL of object uploaded to S3 from S3

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore
 import datetime
 import hashlib
 import random
@@ -174,10 +175,13 @@ def upload_file(safe_local_path, src_filename, dest_filename):
                           s3_path,
                           ExtraArgs={'ContentType': s3_content_type, 'ACL': 'public-read'})
 
-    url = "https://s3-{}.amazonaws.com/{}/{}".format(
-        current_app.config['AWS_DEFAULT_REGION'],
-        current_app.config['S3_BUCKET_NAME'], s3_path
-    )
+    config = s3_client._client_config
+    config.signature_version = botocore.UNSIGNED
+    url = boto3.resource(
+        's3', config=config).meta.client.generate_presigned_url(
+        'get_object',
+        Params={'Bucket': current_app.config['S3_BUCKET_NAME'],
+                'Key': s3_path})
 
     return url
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -106,13 +106,13 @@ def test_s3_upload_png(mockdata):
     local_path = os.path.join(test_dir, '../app/static/images/test_cop1.png')
 
     mocked_connection = Mock()
+    mocked_resource = Mock()
     with patch('boto3.client', Mock(return_value=mocked_connection)):
-        url = OpenOversight.app.utils.upload_file(local_path,
-                                                  'doesntmatter.png',
-                                                  'test_cop1.png')
-    assert 'https' in url
-    # url should show folder structure with first two chars as folder name
-    assert 'te/st' in url
+        with patch('boto3.resource', Mock(return_value=mocked_resource)):
+            OpenOversight.app.utils.upload_file(local_path,
+                                                'doesntmatter.png',
+                                                'test_cop1.png')
+
     assert mocked_connection.method_calls[0][2]['ExtraArgs']['ContentType'] == 'image/png'
 
 
@@ -121,10 +121,13 @@ def test_s3_upload_jpeg(mockdata):
     local_path = os.path.join(test_dir, '../app/static/images/test_cop5.jpg')
 
     mocked_connection = Mock()
+    mocked_resource = Mock()
     with patch('boto3.client', Mock(return_value=mocked_connection)):
-        OpenOversight.app.utils.upload_file(local_path,
-                                            'doesntmatter.jpg',
-                                            'test_cop5.jpg')
+        with patch('boto3.resource', Mock(return_value=mocked_resource)):
+            OpenOversight.app.utils.upload_file(local_path,
+                                                'doesntmatter.jpg',
+                                                'test_cop5.jpg')
+
     assert mocked_connection.method_calls[0][2]['ExtraArgs']['ContentType'] == 'image/jpeg'
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #483

Changes proposed in this pull request:
- This will prevent sadness for others configuring S3 in the development environment, or others that are spinning up this project on their own infra

## Notes for Deployment

- On staging, we should test photo uploads (I did test this in a dev env with valid S3 creds)

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
