### PR TITLE
Switch default order of Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default build run
 
-default: dev build start clean test stop
+default: dev build start test stop clean
 
 dev:
 	make build


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Previously, the default Makefile target listed `clean` before `test` and `stop`. This would cause an error when running the default target with `make` because it would try to remove running containers:

```
$ make
make build
docker-compose build postgres
...
docker rm openoversight_web_1
Error response from daemon: You cannot remove a running container e20158d3fee56fb8908a85731d64391c3a4ad5f12d83ae6ca4d03cf168695574. Stop the container before attempting removal or force remove
make: *** [clean] Error 1
```

I put `clean` at the end of the default target list, which resolved the error and allowed all the targets to run successfully:

```
$ make
make build
docker-compose build postgres
...
======================================================== 217 passed in 170.06 seconds ========================================================
docker-compose stop
...
Stopping openoversight_web_1      ... done
Stopping openoversight_postgres_1 ... done
docker rm openoversight_web_1
openoversight_web_1
docker rm openoversight_postgres_1
openoversight_postgres_1
```

Fixes # .

Changes proposed in this pull request:

 - Switch order of default Makefile targets

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [X] I have rebased my changes on current `develop`

 - [X] pytests pass in the development environment on my local machine

 - [X] `flake8` checks pass
