### PR TITLE
Incident form: show which fields are optional

### DIFF
--- a/OpenOversight/app/formfields.py
+++ b/OpenOversight/app/formfields.py
@@ -18,7 +18,7 @@ class TimeField(StringField):
             return self.data and self.data.strftime(self.format) or ''
 
     def process_formdata(self, valuelist):
-        if valuelist:
+        if valuelist and valuelist != [u'']:
             time_str = ' '.join(valuelist)
             try:
                 components = time_str.split(':')
@@ -36,4 +36,4 @@ class TimeField(StringField):
                 self.data = datetime.time(hour, minutes, seconds)
             except ValueError:
                 self.data = None
-                raise ValueError(self.gettext('Not a valid time string'))
+                raise ValueError(self.gettext('Not a valid time'))

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -223,12 +223,18 @@ class AddUnitForm(Form):
 
 
 class DateFieldForm(Form):
-    date_field = DateField('Date', validators=[Required()])
-    time_field = TimeField('Time')
+    date_field = DateField('Date <span class="text-danger">*</span>', validators=[Required()])
+    time_field = TimeField('Time', validators=[Optional()])
 
     @property
     def datetime(self):
-        return datetime.datetime.combine(self.date_field.data, self.time_field.data)
+        if self.time_field.data:
+            return datetime.datetime.combine(self.date_field.data,
+                                             self.time_field.data)
+        else:  # Code these events at a precise time so we can find them later
+            coded_no_time = datetime.time(1, 2, 3, 45678)
+            return datetime.datetime.combine(self.date_field.data,
+                                             coded_no_time)
 
     @datetime.setter
     def datetime(self, value):
@@ -245,13 +251,15 @@ class DateFieldForm(Form):
 
 
 class LocationForm(Form):
-    street_name = StringField(validators=[Required()], description='Street on which incident occurred. For privacy reasons, please DO NOT INCLUDE street number.')
-    cross_street1 = StringField(validators=[Required()], description="Closest cross street to where incident occurred.")
+    street_name = StringField(validators=[Optional()], description='Street on which incident occurred. For privacy reasons, please DO NOT INCLUDE street number.')
+    cross_street1 = StringField(validators=[Optional()], description="Closest cross street to where incident occurred.")
     cross_street2 = StringField(validators=[Optional()])
-    city = StringField(validators=[Required()])
-    state = SelectField('State', choices=STATE_CHOICES,
+    city = StringField('City <span class="text-danger">*</span>', validators=[Required()])
+    state = SelectField('State <span class="text-danger">*</span>', choices=STATE_CHOICES,
                         validators=[AnyOf(allowed_values(STATE_CHOICES))])
-    zip_code = StringField('Zip Code', validators=[Regexp('^\d{5}$', message='Zip codes must have 5 digits')])
+    zip_code = StringField('Zip Code',
+                           validators=[Optional(),
+                                       Regexp('^\d{5}$', message='Zip codes must have 5 digits')])
 
 
 class LicensePlateForm(Form):
@@ -280,7 +288,7 @@ class IncidentForm(DateFieldForm):
         description='Incident number for the organization tracking incidents')
     description = TextAreaField(validators=[Optional()])
     department = QuerySelectField(
-        'Department',
+        'Department <span class="text-danger">*</span>',
         validators=[Required()],
         query_factory=dept_choices,
         get_label='name')

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -205,10 +205,11 @@ class Location(db.Model):
 
     @validates('zip_code')
     def validate_zip_code(self, key, zip_code):
-        zip_re = r'^\d{5}$'
-        if not re.match(zip_re, zip_code):
-            raise ValueError('Not a valid zip code')
-        return zip_code
+        if zip_code:
+            zip_re = r'^\d{5}$'
+            if not re.match(zip_re, zip_code):
+                raise ValueError('Not a valid zip code')
+            return zip_code
 
     @validates('state')
     def validate_state(self, key, state):

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -4,10 +4,12 @@
 			<td><strong>Date</strong></td>
 			<td>{{ incident.date.strftime('%b %d, %Y %l:%M %p') }}</td>
 		</tr>
+		{% if incident.report_number %}
 		<tr>
 			<td><strong>Report #</strong></td>
 			<td>{{ incident.report_number }}</td>
 		</tr>
+		{% endif %}
 		<tr>
 			<td><strong>Department</strong></td>
 			<td>{{ incident.department.name }}</td>
@@ -50,7 +52,7 @@
 								 <em>near</em> {{ address.cross_street1 }}
 							{% endif %}
 							<br/>
-							{{ address.city }}, {{ address.state }} {{ address.zip_code }}
+							{{ address.city }}, {{ address.state }} {% if address.zipcode %} {{ address.zip_code }} {% endif %}
 						</td>
 				</tr>
 			{% endif %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #505

Changes proposed in this pull request:

 - Quick fix to show which fields are optional in incident form
 - (and a few more fields will be optional)
 - (want to get this in #508)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
