### PR TITLE
Quick fix for link in wrong place on profile

### DIFF
--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -220,9 +220,9 @@
       </div>
     {% endif %}
     </div>{# end col #}
+    {% with obj=officer %}
+      {% include "partials/links_and_videos_row.html" %}
+    {% endwith %}
   </div> {# end row #}
-  {% with obj=officer %}
-    {% include "partials/links_and_videos_row.html" %}
-  {% endwith %}
 </div> {# end container #}
 {% endblock %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

quick fix, link formatted poorly (see this ICE agent's profile: https://openoversight.com/officer/24840)

## Notes for Deployment

deploying to staging to test

## Screenshots (if appropriate)

### before

![screen shot 2018-07-15 at 10 37 06 am](https://user-images.githubusercontent.com/7832803/42736432-c44beebe-881b-11e8-8324-3ee2d7c344ee.png)
   

### after 


![screen shot 2018-07-15 at 10 42 36 am](https://user-images.githubusercontent.com/7832803/42736438-d1623cd4-881b-11e8-9561-93113186c4ad.png)


## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
