### PR TITLE
correct officer capitalization for names with multiple caps like McDo…

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -75,6 +75,11 @@ def create_app(config_name='default'):
     def rate_exceeded(e):
         return render_template('429.html'), 429
 
+    # create jinja2 filter for titles with multiple capitals
+    @app.template_filter('capfirst')
+    def capfirst_filter(s):
+        return s[0].capitalize() + s[1:]  # only change 1st letter
+
     return app
 
 

--- a/OpenOversight/app/templates/gallery.html
+++ b/OpenOversight/app/templates/gallery.html
@@ -37,9 +37,7 @@
           <div class="container">
             <div class="carousel-caption">
               <h1><a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}" id="officer-profile-{{ loop.index }}">
-                    {{ officer.first_name.lower()|title }}
-                    {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
-                    {{ officer.last_name.lower()|title }}</a> <small>#{{ assignment.star_no }}</small></h1>
+                    {% include 'partials/officer_name.html' %}</a> <small>#{{ assignment.star_no }}</small></h1>
 
               <div align="center">
                 <img src="{{ officer_image }}" class="img-responsive thumbnail">

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -8,7 +8,7 @@
                            {% if officer.middle_initial %}
                            {{ officer.middle_initial }}
                            {% endif %}
-                           {{ officer.last_name|title }}</b></h1>
+                           {{ officer.last_name|capfirst }}</b></h1>
   </div>
 
   <div class="row">

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,11 +4,7 @@
 <div class="container" role="main">
 
   <div class="page-header">
-    <h1>Officer Detail: <b>{{ officer.first_name|title }}
-                           {% if officer.middle_initial %}
-                           {{ officer.middle_initial }}
-                           {% endif %}
-                           {{ officer.last_name|capfirst }}</b></h1>
+    <h1>Officer Detail: <b>{% include 'partials/officer_name.html' %}</b></h1>
   </div>
 
   <div class="row">

--- a/OpenOversight/app/templates/partials/officer_name.html
+++ b/OpenOversight/app/templates/partials/officer_name.html
@@ -1,3 +1,3 @@
 {{ officer.first_name.lower()|title }}
 {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
-{{ officer.last_name.lower()|title }}
+{{ officer.last_name|capfirst }}

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -36,9 +36,7 @@
           <div class="container">
             <div class="carousel-caption">
               <h1><a href="{{ url_for('main.officer_profile', officer_id=officer.id) }}">
-                    {{ officer.first_name.lower()|title }}
-                    {% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
-                    {{ officer.last_name.lower()|title }}</a></h1>
+                    {% include 'partials/officer_name.html' %}</a></h1>
                   <h4 class="text-success"><b>OpenOversight ID: {{ officer.id }}</b></h4>
                   <h5 class="text-muted">Race: {{ officer.race }}</h5>
                   <h5 class="text-muted">Gender: {{ officer.gender }}</h5>

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -69,3 +69,41 @@ def test_user_can_get_to_complaint(mockdata, browser):
 
     title_text = browser.find_element_by_tag_name("h1").text
     assert "File a Complaint" in title_text
+
+
+def test_lastname_capitalization(mockdata, browser):
+    browser.get("http://localhost:5000/auth/login")
+    wait_for_page_load(browser)
+
+    # get past the login page
+    elem = browser.find_element_by_id("email")
+    elem.clear()
+    elem.send_keys("redshiftzero@example.org")
+    elem = browser.find_element_by_id("password")
+    elem.clear()
+    elem.send_keys("cat")
+    browser.find_element_by_id("submit").click()
+    wait_for_element(browser, By.ID, "cpd")
+
+    test_pairs = [("mcDonald", "McDonald"), ("Mei-Ying", "Mei-Ying"),
+                  ("G", "G"), ("oh", "Oh")]
+
+    for test_pair in test_pairs:
+        test_input = test_pair[0]
+        test_output = test_pair[1]
+
+        # enter a last name to test
+        browser.get("http://localhost:5000/officer/new")
+        wait_for_element(browser, By.ID, "last_name")
+        elem = browser.find_element_by_id("last_name")
+        elem.clear()
+        elem.send_keys(test_input)
+        browser.find_element_by_id("submit").click()
+
+        # check result
+        wait_for_element(browser, By.TAG_NAME, "tbody")
+        # assumes the page-header field is of the form:
+        # <div class="page-header"><h1>Officer Detail: <b>McDonald</b></h1></div>
+        rendered_field = browser.find_element_by_class_name("page-header").text
+        rendered_name = rendered_field.split(":")[1].strip()
+        assert rendered_name == test_output


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #343 

Changes proposed in this pull request:

 - new jinja2 capitalization filter in app/__init__, to only capitalize 1st letter of surname without lowering the rest of the name, for names with multiple caps like McDonald
 - filter is applied in app/templates/officer.html
 - new test case in tests/test_functional.py 

## Notes for Deployment

- test case depends presence of certain tags and field formatting. see test_lastname_capitalization() in tests/test_function.py for details

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
