### PR TITLE
fixing #519

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -17,8 +17,8 @@ from ..models import Officer
 import datetime
 
 
-def allowed_values(choices):
-    return [x[0] for x in choices]
+def allowed_values(choices, empty_allowed=True):
+    return [x[0] for x in choices if empty_allowed or x[0]]
 
 
 class HumintContribution(Form):
@@ -260,7 +260,7 @@ class LocationForm(Form):
     cross_street2 = StringField(validators=[Optional()])
     city = StringField('City <span class="text-danger">*</span>', validators=[Required()])
     state = SelectField('State <span class="text-danger">*</span>', choices=STATE_CHOICES,
-                        validators=[AnyOf(allowed_values(STATE_CHOICES))])
+                        validators=[AnyOf(allowed_values(STATE_CHOICES, False), message="Must select a state.")])
     zip_code = StringField('Zip Code',
                            validators=[Optional(),
                                        Regexp('^\d{5}$', message='Zip codes must have 5 digits')])
@@ -270,6 +270,10 @@ class LicensePlateForm(Form):
     number = StringField('Plate Number', validators=[])
     state = SelectField('State', choices=STATE_CHOICES,
                         validators=[AnyOf(allowed_values(STATE_CHOICES))])
+
+    def validate_state(self, field):
+        if self.number.data != "" and field.data == "":
+            raise ValidationError("Must also select a state.")
 
 
 class OfficerIdField(StringField):

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -256,14 +256,14 @@ class DateFieldForm(Form):
 
 class LocationForm(Form):
     street_name = StringField(validators=[Optional()], description='Street on which incident occurred. For privacy reasons, please DO NOT INCLUDE street number.')
-    cross_street1 = StringField(validators=[Optional()], description="Closest cross street to where incident occurred.")
+    cross_street1 = StringField(validators=[Optional()], description='Closest cross street to where incident occurred.')
     cross_street2 = StringField(validators=[Optional()])
     city = StringField('City <span class="text-danger">*</span>', validators=[Required()])
     state = SelectField('State <span class="text-danger">*</span>', choices=STATE_CHOICES,
-                        validators=[AnyOf(allowed_values(STATE_CHOICES, False), message="Must select a state.")])
+                        validators=[AnyOf(allowed_values(STATE_CHOICES, False), message='Must select a state.')])
     zip_code = StringField('Zip Code',
                            validators=[Optional(),
-                                       Regexp('^\d{5}$', message='Zip codes must have 5 digits')])
+                                       Regexp('^\d{5}$', message='Zip codes must have 5 digits.')])
 
 
 class LicensePlateForm(Form):
@@ -272,8 +272,8 @@ class LicensePlateForm(Form):
                         validators=[AnyOf(allowed_values(STATE_CHOICES))])
 
     def validate_state(self, field):
-        if self.number.data != "" and field.data == "":
-            raise ValidationError("Must also select a state.")
+        if self.number.data != '' and field.data == '':
+            raise ValidationError('Must also select a state.')
 
 
 class OfficerIdField(StringField):


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #519.
The drop-down for selecting the state in the add incident form has an empty value as its default. Since the field is required, leaving the field on this value shouldn't be allowed.
Similarly if a license plate number is added, the state field cannot be left untouched.

Changes proposed in this pull request:

 - Adding a boolean flag to the `allowed_values` function so that it is possible to exclude the empty string as an allowed value, so that not changing the license plate raises a validation flag
 - For the license plate, I added a validator to the form `LicensePlateForm` which doesn't allow the number field to be filled, but the state field be empty.

## Notes
This is my first pull request ever, so looking forward to any feedback.
I didn't find any tests for validating the new incident form, so maybe those should be added.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine
 (except for three unrelated tests that also failed before (related to image loading), not sure what I am missing there)

 - [x] `flake8` checks pass
