### PR TITLE
Use management interface with Docker dev environment

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -50,7 +50,7 @@ Make sure you've started VirtualBox, and then in your project directory, run:
 
 `vagrant up`
 
-This creates a new, pristine virtual machine and provisions it to be an almost-copy of production with a local test database. (Behind the scenes, this is all happening via the files in vagrant/puppet.) If everything works, you should get a webserver listening at `http://localhost:3000` that you can browse to on your host machine.
+This creates a new, pristine virtual machine and provisions it to be an almost-copy of production with a local test database. (Behind the scenes, this is all happening via the files in vagrant/puppet.) If everything works, you should get a webserver listening at `http://localhost:5000` that you can browse to on your host machine.
 
 In addition, you can now SSH into it:
 
@@ -94,8 +94,8 @@ $ sudo service gunicorn stop
  * Stopping Gunicorn workers
  [oo] *
 (oovirtenv)vagrant@vagrant-ubuntu-trusty-64:~$ cd /vagrant/OpenOversight/ # (again, if you're not already there)
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py runserver
- * Running on http://127.0.0.1:3000/ (Press CTRL+C to quit)
+(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py runserver --host 0.0.0.0
+ * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
  * Restarting with stat
  * Debugger is active!
 ```

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -72,11 +72,17 @@ In the VM instance, your code is copied to a folder inside of `/vagrant`, so you
 (oovirtenv)vagrant@vagrant-ubuntu-trusty-64:~$ cd /vagrant/OpenOversight
 ```
 
+Tests can be run with:
+```sh
+(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight/$ cd tests
+(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight/tests$ pytest
+```
+
 *Note:* the photo upload functionality - which uses an S3 bucket - and the email functionality - which
 requires an email account - do not work in the development environment as they require some environment
 variables to be configured.
 
-## Server commands
+#### Dynamically reloading changes
 
 The app, as provisioned, is running under gunicorn, which means that it does not dynamically reload your changes.
 
@@ -94,6 +100,26 @@ $ sudo service gunicorn stop
  * Debugger is active!
 ```
 
+#### Changing the Development Environment
+
+If you're making massive changes to the development environment provisioning, you should know that Vagrant and the Puppet modules that provision the box use Ruby, so you'll want some reasonably-modern Ruby. Anything in the 2.0-2.2 area should work. Puppet has some annoying interactions where puppet 3 doesn't work with ruby 2.2, though, so you might have to get creative on modern OSes.
+
+If you don't have bundler installed:
+
+`gem install bundler`
+
+If you don't have rake installed:
+
+`bundle install`
+
+Then provision the VM:
+
+`rake vagrant:provision`
+
+Puppet modules are dropped into place by librarian-puppet, and there's a rake task that'll do it without the headache of remembering all the paths and such:
+
+`rake vagrant:build_puppet`
+
 ## Database commands
 
 You can access your PostgreSQL development database via psql using:
@@ -105,16 +131,16 @@ psql  -h localhost -d openoversight-dev -U openoversight --password
 with the password `terriblepassword`.
 
 
-The provisioning step already does this, but in case you need it, in the `/vagrant` directory, there is a script to create the database:
+In the Docker environment, you'll need to run the script to create the database:
 
 ```sh
-~/oovirtenv/bin/python create_db.py
+$ python create_db.py
 ```
 
 In the event that you need to create or delete the test data, you can do that with
-`~/oovirtenv/bin/python test_data.py --populate` to create the data
+`$ python test_data.py --populate` to create the data
 or
-`~/oovirtenv/bin/python test_data.py --cleanup` to delete the data
+`$ python test_data.py --cleanup` to delete the data
 
 ### Migrating the Database
 
@@ -123,13 +149,13 @@ If you e.g. add a new column or table, you'll need to migrate the database.
 You can use the management interface to first generate migrations:
 
 ```sh
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py db migrate
+$ python manage.py db migrate
 ```
 
 And then you should inspect/edit the migrations. You can then apply the migrations:
 
 ```sh
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py db upgrade
+$ python manage.py db upgrade
 ```
 
 You can also downgrade the database using `python manage.py db downgrade`.
@@ -139,7 +165,7 @@ You can also downgrade the database using `python manage.py db downgrade`.
 In addition to running the development server, `manage.py` (OpenOversight's management interface) can be used to do the following:
 
 ```sh
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py
+$ python manage.py
 --------------------------------------------------------------------------------
 INFO in __init__ [/vagrant/OpenOversight/app/__init__.py:57]:
 OpenOversight startup
@@ -164,39 +190,10 @@ optional arguments:
 In development, you can make an administrator account without having to confirm your email:
 
 ```sh
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight$ python manage.py make_admin_user
+$ python manage.py make_admin_user
 Username: redshiftzero
 Email: jen@redshiftzero.com
 Password:
 Type your password again:
 Administrator redshiftzero successfully added
 ```
-
-## Running Unit Tests
-
- Run tests with `pytest`:
-
-```sh
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight/$ cd tests
-(oovirtenv)vagrant@vagrant-ubuntu-trusty-64:/vagrant/OpenOversight/tests$ pytest
-```
-
-## Changing the Development Environment
-
-If you're making massive changes to the development environment provisioning, you should know that Vagrant and the Puppet modules that provision the box use Ruby, so you'll want some reasonably-modern Ruby. Anything in the 2.0-2.2 area should work. Puppet has some annoying interactions where puppet 3 doesn't work with ruby 2.2, though, so you might have to get creative on modern OSes.
-
-If you don't have bundler installed:
-
-`gem install bundler`
-
-If you don't have rake installed:
-
-`bundle install`
-
-Then provision the VM:
-
-`rake vagrant:provision`
-
-Puppet modules are dropped into place by librarian-puppet, and there's a rake task that'll do it without the headache of remembering all the paths and such:
-
-`rake vagrant:build_puppet`

--- a/OpenOversight/manage.py
+++ b/OpenOversight/manage.py
@@ -1,7 +1,7 @@
 from getpass import getpass
 import sys
 
-from flask_script import Manager, Server, Shell
+from flask_script import Manager, Shell
 from flask_migrate import Migrate, MigrateCommand
 
 from app import app

--- a/OpenOversight/manage.py
+++ b/OpenOversight/manage.py
@@ -10,7 +10,6 @@ from app.models import db, User
 
 migrate = Migrate(app, db)
 manager = Manager(app)
-manager.add_command("runserver", Server(host="0.0.0.0", port=3000))
 manager.add_command("db", MigrateCommand)
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ vagrant up
 vagrant ssh
 ```
 
-And open `http://localhost:3000` in your favorite browser!
+And open `http://localhost:5000` in your favorite browser!
 
 If you need to log in, use the auto-generated test account
 credentials:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine.
-   config.vm.network "forwarded_port", guest: 3000, host: 3000
+   config.vm.network "forwarded_port", guest: 5000, host: 5000
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
      POSTGRES_USER: openoversight
      POSTGRES_PASSWORD: terriblepassword
      POSTGRES_DB: openoversight-dev
+   ports:
+     - "5432:5432"
 
  web:
    restart: always
@@ -28,4 +30,3 @@ services:
    command: /usr/local/bin/gunicorn -w 4 -b 0.0.0.0:3000 app:app
    ports:
      - "3000:3000"
-     - "5433:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
      POSTGRES_USER: openoversight
      POSTGRES_PASSWORD: terriblepassword
      POSTGRES_DB: openoversight-dev
+   volumes:
+     - ./container_data/postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
 

--- a/vagrant/puppet/manifests/default.pp
+++ b/vagrant/puppet/manifests/default.pp
@@ -87,7 +87,7 @@
     ensure     => present,
     virtualenv => $virtualenv,
     dir        => "${source_path}/OpenOversight",
-    bind       => '0.0.0.0:3000',
+    bind       => '0.0.0.0:5000',
     require    => [ File["${source_path}/OpenOversight/.env"], Postgresql::Server::Db['openoversight-dev'] ]
   }
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Currently the management interface (manage.py) won't interact with the Docker dev environment when run from localhost, since it requires direct database access. 

Changes proposed in this pull request:

* Moves the Postgres port to standard 5432 and exposes it to the host
* Removes the `runserver` command from manage.py since running it would cause a port conflict with the already running instance in Docker. The `runserver` command is still available as it is a default command in Flask-Script and runs on port 5000.
* Updates the CONTRIB documentation to reflect the changes. Now all management commands should work with the Docker env when run from localhost, including database migrations.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
