### PR TITLE
Remove extra officers from incidents

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -284,14 +284,23 @@ class OfficerIdField(StringField):
             self.data = value
 
 
-class OOIdForm(Form):
-    oo_id = StringField('OO Officer ID', validators=[])
+def validate_oo_id(self, field):
+    if field.data:
+        try:
+            officer_id = int(field.data)
+            officer = Officer.query.get(officer_id)
 
-    def validate_id(self, field):
-        if self.data:
-            officer = Officer.query.get(int(self.data))
-            if not officer:
-                raise ValueError('Not a valid officer id')
+        # Sometimes we get a string in field.data with py.test, this parses it
+        except ValueError:
+            officer_id = field.data.split("value=\"")[1][:-2]
+            officer = Officer.query.get(officer_id)
+
+        if not officer:
+            raise ValidationError('Not a valid officer id')
+
+
+class OOIdForm(Form):
+    oo_id = StringField('OO Officer ID', validators=[validate_oo_id])
 
 
 class IncidentForm(DateFieldForm):

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -283,7 +283,11 @@ class OfficerIdField(StringField):
         else:
             self.data = value
 
-    def pre_validate(self, form):
+
+class OOIdForm(Form):
+    oo_id = StringField('OO Officer ID', validators=[])
+
+    def validate_id(self, field):
         if self.data:
             officer = Officer.query.get(int(self.data))
             if not officer:
@@ -301,8 +305,8 @@ class IncidentForm(DateFieldForm):
         query_factory=dept_choices,
         get_label='name')
     address = FormField(LocationForm)
-    officers = FieldList(
-        OfficerIdField('OO Officer ID'),
+    officers = FieldList(FormField(
+        OOIdForm, widget=FormFieldWidget()),
         description='Officers present at the incident.',
         min_entries=1,
         widget=BootstrapListWidget())

--- a/OpenOversight/app/static/js/incidentAddButtons.js
+++ b/OpenOversight/app/static/js/incidentAddButtons.js
@@ -45,7 +45,7 @@ function cloneFieldList(selector) {
 function removeParent(event) {
     event.preventDefault()
     var things_to_add;
-    things_to_add = {"Plate Number" : "license plate", "Link" : "link", "OO Officer ID" : "OO officer ID number"};
+    things_to_add = {"Plate Number" : "license plate", "Link" : "link", "OO Officer ID" : "officer"};
     var previousElement = event.target.parentElement.previousElementSibling
     var nextElement = event.target.parentElement.nextElementSibling
 

--- a/OpenOversight/app/static/js/incidentAddButtons.js
+++ b/OpenOversight/app/static/js/incidentAddButtons.js
@@ -44,13 +44,12 @@ function cloneFieldList(selector) {
 
 function removeParent(event) {
     event.preventDefault()
+    var things_to_add;
+    things_to_add = {"Plate Number" : "license plate", "Link" : "link", "OO Officer ID" : "OO officer ID number"};
     var previousElement = event.target.parentElement.previousElementSibling
     var nextElement = event.target.parentElement.nextElementSibling
-    // If it's between the legend and the add button, it's the last remaining fieldset, and needs different handling
-    if(previousElement &&
-       previousElement.tagName === 'LEGEND' &&
-       nextElement &&
-       nextElement.tagName === 'BUTTON'){
+
+    if(previousElement && nextElement){
         var $lastElement = $(event.target.parentElement)
         // Remove any filled in values (but not the csrf token)
         $lastElement.find(':input:not(:hidden)').each(function(child) {
@@ -59,21 +58,37 @@ function removeParent(event) {
         $lastElement.hide()
         var add_button = $(nextElement)
         var fieldsetName = $(previousElement).text().slice(0, -1)
+        for (var key in things_to_add) {
+             if(fieldsetName.search(key) != -1) {
+                fieldsetName = things_to_add[key]
+                break;
+             }
+        }
 
-        // Remove previous click handler
-        add_button.off('click')
-        add_button.text('New ' + fieldsetName)
-        add_button.on('click', function(event) {
-            event.preventDefault()
-            $lastElement.show()
-            // remove this click handler
-            add_button.off('click')
-            add_button.text('Add another ' + fieldsetName)
-            // restore the previous add function
-            add_button.click(function (event) {
-                event.preventDefault()
-                cloneFieldList($(event.target.previousElementSibling));
-            });
-        })
-    }
+        // nextElement's textContent is short, like
+        // "Add another link" when we're removing the last element added
+        // When we are removing something that is not the
+        // last element added, it is huge (the whole input form)
+        // with lots of whitespace.
+        // If we're not removing the last element added,
+        // we already have a valid Add button so we don't
+        // want to create another
+        if (nextElement.textContent.length <= 40) {
+             // Remove previous click handler
+             add_button.off('click')
+             add_button.text('Add another ' + fieldsetName)
+             add_button.on('click', function(event) {
+                  event.preventDefault()
+                  $lastElement.show()
+                  // remove this click handler
+                  add_button.off('click')
+                  add_button.text('Add another ' + fieldsetName)
+                  // restore the previous add function
+                  add_button.click(function (event) {
+                      event.preventDefault()
+                      cloneFieldList($(event.target.previousElementSibling));
+                 });
+             })
+        }
+   }
 }

--- a/OpenOversight/app/templates/partials/incident_form.html
+++ b/OpenOversight/app/templates/partials/incident_form.html
@@ -23,17 +23,13 @@
 				{# buttons are disabled until the DOM loads and click handlers are added #}
 				<button class="btn btn-success js-add-another-button" disabled>Add another license plate</button>
 			</div>
-			<fieldset>
-				<legend>Officers Involved</legend>
-				<ul class='list-unstyled'>
-					{% for field in form.officers %}
-						<li>
-							{{ wtf.form_field(field) }}
-						</li>
-					{% endfor %}
-					<button class="btn btn-success js-add-another-button" disabled>Add another officer</button>
-				</ul>
-			</fieldset>
+            <legend>{{ form.officers.label }}</legend>
+				{% for subform in form.officers %}
+					{% with id="js-officer", number=loop.index %}
+					   {% include "partials/subform.html" %}
+					{% endwith %}
+				{% endfor %}
+				<button class="btn btn-success js-add-another-button" disabled>Add another officer</button>
 			<div>
 				<legend>{{ form.links.label }}</legend>
 				{% for subform in form.links %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -31,23 +31,10 @@ def set_dynamic_default(form_field, value):
 def get_or_create(session, model, defaults=None, **kwargs):
     if 'csrf_token' in kwargs:
         kwargs.pop('csrf_token')
+    # Because id is a keyword in Python, officers member is called oo_id
+    if 'oo_id' in kwargs:
+        kwargs = {'id': kwargs['oo_id']}
     instance = model.query.filter_by(**kwargs).first()
-    if instance:
-        return instance, False
-    else:
-        params = dict((k, v) for k, v in kwargs.iteritems())
-        params.update(defaults or {})
-        instance = model(**params)
-        session.add(instance)
-        return instance, True
-
-
-# Because id is a keyword in Python, officers member is called oo_id
-def get_or_create_officer(session, model, defaults=None, **kwargs):
-    if 'csrf_token' in kwargs:
-        kwargs.pop('csrf_token')
-    new_kwargs = {'id': kwargs['oo_id']}
-    instance = model.query.filter_by(**new_kwargs).first()
     if instance:
         return instance, False
     else:
@@ -360,7 +347,7 @@ def create_incident(self, form):
     if 'officers' in form.data:
         for officer in form.data['officers']:
             if officer['oo_id']:
-                of, _ = get_or_create_officer(db.session, Officer, **officer)
+                of, _ = get_or_create(db.session, Officer, **officer)
                 if of:
                     fields['officers'].append(of)
 

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -6,7 +6,7 @@ from OpenOversight.tests.conftest import AC_DEPT
 from .route_helpers import login_user, login_admin, login_ac, process_form_data
 
 
-from OpenOversight.app.main.forms import IncidentForm, LocationForm, LinkForm, LicensePlateForm
+from OpenOversight.app.main.forms import IncidentForm, LocationForm, LinkForm, LicensePlateForm, OOIdForm
 from OpenOversight.app.models import Incident, Officer, Department
 
 
@@ -100,6 +100,7 @@ def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
         )
         links_forms = [LinkForm(url=link.url, link_type=link.link_type).data for link in inc.links]
         license_plates_forms = [LicensePlateForm(number=lp.number, state=lp.state).data for lp in inc.license_plates]
+        ooid_forms = [OOIdForm(ooid=officer.id) for officer in inc.officers]
 
         form = IncidentForm(
             date_field=str(new_date.date()),
@@ -110,7 +111,7 @@ def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
             address=address_form.data,
             links=links_forms,
             license_plates=license_plates_forms,
-            officers=[officer.id for officer in inc.officers]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -146,6 +147,7 @@ def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session):
         old_license_plates = inc.license_plates
         new_number = '453893'
         license_plates_form = LicensePlateForm(number=new_number, state='IA')
+        ooid_forms = [OOIdForm(ooid=officer.id) for officer in inc.officers]
 
         form = IncidentForm(
             date_field=str(inc.date.date()),
@@ -156,7 +158,7 @@ def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session):
             address=address_form.data,
             links=old_links_forms + [link_form.data],
             license_plates=[license_plates_form.data],
-            officers=[officer.id for officer in inc.officers]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -190,6 +192,7 @@ def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
             state=inc.address.state,
             zip_code=inc.address.zip_code
         )
+        ooid_forms = [OOIdForm(ooid=officer.id) for officer in inc.officers]
 
         form = IncidentForm(
             date_field=date(1899, 12, 5),
@@ -198,7 +201,7 @@ def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
             description=inc.description,
             department='1',
             address=address_form.data,
-            officers=[officer.id for officer in inc.officers]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -224,6 +227,8 @@ def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
             state='',
             zip_code='03435'
         )
+        ooid_forms = [OOIdForm(ooid=officer.id)
+                      for officer in Officer.query.all()[:5]]
 
         form = IncidentForm(
             date_field=str(date.date()),
@@ -232,7 +237,7 @@ def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
             description='Something happened',
             department='1',
             address=address_form.data,
-            officers=[officer.id for officer in Officer.query.all()[:5]]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -265,6 +270,8 @@ def test_admins_cannot_make_incidents_with_multiple_validation_errors(mockdata, 
 
         # license plate number given, but no state selected => 'Must also select a state.'
         license_plate_form = LicensePlateForm(number='ABCDE', state='')
+        ooid_forms = [OOIdForm(ooid=officer.id)
+                      for officer in Officer.query.all()[:5]]
 
         form = IncidentForm(
             # no date given => 'This field is required.'
@@ -276,7 +283,7 @@ def test_admins_cannot_make_incidents_with_multiple_validation_errors(mockdata, 
             department='-1',
             address=address_form.data,
             license_plates=[license_plate_form.data],
-            officers=[officer.id for officer in Officer.query.all()[:5]]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -311,8 +318,10 @@ def test_admins_can_edit_incident_officers(mockdata, client, session):
 
         old_officers = inc.officers
         old_officer_ids = [officer.id for officer in inc.officers]
+        old_ooid_forms = [OOIdForm(oo_id=the_id) for the_id in old_officer_ids]
         # get a new officer that is different from the old officers
         new_officer = Officer.query.except_(Officer.query.filter(Officer.id.in_(old_officer_ids))).first()
+        new_ooid_form = OOIdForm(oo_id=new_officer.id)
 
         form = IncidentForm(
             date_field=str(inc.date.date()),
@@ -323,7 +332,7 @@ def test_admins_can_edit_incident_officers(mockdata, client, session):
             address=address_form.data,
             links=links_forms,
             license_plates=license_plates_forms,
-            officers=old_officer_ids + [new_officer.id]
+            officers=old_ooid_forms + [new_ooid_form]
         )
         data = process_form_data(form.data)
 
@@ -354,6 +363,7 @@ def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
         )
         links_forms = [LinkForm(url=link.url, link_type=link.link_type).data for link in inc.links]
         license_plates_forms = [LicensePlateForm(number=lp.number, state=lp.state).data for lp in inc.license_plates]
+        ooid_forms = [OOIdForm(ooid=officer.id) for officer in inc.officers]
 
         form = IncidentForm(
             date_field=str(new_date.date()),
@@ -364,7 +374,7 @@ def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
             address=address_form.data,
             links=links_forms,
             license_plates=license_plates_forms,
-            officers=[officer.id for officer in inc.officers]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 
@@ -395,6 +405,7 @@ def test_ac_cannot_edit_incidents_not_in_their_department(mockdata, client, sess
         )
         links_forms = [LinkForm(url=link.url, link_type=link.link_type).data for link in inc.links]
         license_plates_forms = [LicensePlateForm(number=lp.number, state=lp.state).data for lp in inc.license_plates]
+        ooid_forms = [OOIdForm(ooid=officer.id) for officer in inc.officers]
 
         form = IncidentForm(
             date_field=str(new_date.date()),
@@ -405,7 +416,7 @@ def test_ac_cannot_edit_incidents_not_in_their_department(mockdata, client, sess
             address=address_form.data,
             links=links_forms,
             license_plates=license_plates_forms,
-            officers=[officer.id for officer in inc.officers]
+            officers=ooid_forms
         )
         data = process_form_data(form.data)
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #443 .

Changes proposed in this pull request:

 - Allow extra officers to be removed from the incident form
 - Change remove button action to remove any element in any position

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
