### PR TITLE
Fixes for officer name and profile display

### DIFF
--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -41,7 +41,7 @@
                     <dt>Rank</dt>
                     <dd>{{ officer.rank|default('Unknown') }}</dd>
                     <dt>Race</dt>
-                    <dd>{{ officer.race.lower()|title|default('Unknown') }}</dd>
+                    <dd>{{ officer.race|default('Unknown')|lower|title }}</dd>
                   </dl>
                 </div>
                 <div class="col-md-6 col-xs-6">

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -39,7 +39,7 @@
                 <div class="col-md-6 col-xs-6">
                   <dl>
                     <dt>Rank</dt>
-                    <dd>{{ officer.rank|default('Unknown') }}</dd>
+                    <dd>{{ assignment.rank|default('Unknown') }}</dd>
                     <dt>Race</dt>
                     <dd>{{ officer.race|default('Unknown')|lower|title }}</dd>
                   </dl>

--- a/OpenOversight/app/templates/partials/officer_name.html
+++ b/OpenOversight/app/templates/partials/officer_name.html
@@ -1,4 +1,4 @@
 {{ officer.first_name.lower()|title }}
-{% if officer.middle_initial %}{{ officer.middle_initial }}. {% endif %}
+{% if officer.middle_initial %}{{ officer.middle_initial }}{% if officer.middle_initial|length == 1 %}.{% endif %} {% endif %}
 {{ officer.last_name|capfirst }}
 {% if officer.suffix %}{{ officer.suffix }}. {% endif %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes issue displaying officers with a race value of NULL.
Properly display middle names that are not initials (in Baltimore some middle names are given as initials and some as full middle names).
Fix rank display in officer list (they were previously all showing up as Unknown).

## Notes for Deployment

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2007008/44007643-460c1ee0-9e67-11e8-9555-065cc3f61038.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
