### PR TITLE
Show user position in pagination when browsing

### DIFF
--- a/OpenOversight/app/templates/partials/paginate_nav.html
+++ b/OpenOversight/app/templates/partials/paginate_nav.html
@@ -9,12 +9,15 @@
         </li>
       {% endif %}
       {% if paginate.has_next %}
+      Showing {{(paginate.page-1)*paginate.per_page + 1 }}-{{(paginate.page)*paginate.per_page}} of {{paginate.total}}
       <li class="next">
         <a role="button" href="{{ next_url }}">
           Next
           <span aria-hidden="true">&rarr;</span>
         </a>
       </li>
+      {% else %}
+      Showing {{(paginate.page-1)*paginate.per_page + 1 }}-{{paginate.total}} of {{paginate.total}}
       {% endif %}
     </ul>
   </nav>


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Displays "Showing (x)-(y) of (total)" between Next and Prev buttons when browsing officer listings

Fixes #501 

Changes proposed in this pull request:

 - display "Showing (x)-(y) of (total)"  in paginate_nav.html
 - new test in test_functional.py
 - 

## Notes for Deployment

## Screenshots (if appropriate)
![screenshot from 2018-08-13 11-48-04](https://user-images.githubusercontent.com/18009772/44025229-d9026b9a-9eef-11e8-8edf-79c1d0300665.png)


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
