### PR TITLE
Make officer search defaults 'Not Sure'

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -39,11 +39,11 @@ class FindOfficerForm(Form):
                                                          Length(max=10)])
     dept = QuerySelectField('dept', validators=[DataRequired()],
                             query_factory=dept_choices, get_label='name')
-    rank = SelectField('rank', default='COMMANDER', choices=RANK_CHOICES,
+    rank = SelectField('rank', default='Not Sure', choices=RANK_CHOICES,
                        validators=[AnyOf(allowed_values(RANK_CHOICES))])
-    race = SelectField('race', default='WHITE', choices=RACE_CHOICES,
+    race = SelectField('race', default='Not Sure', choices=RACE_CHOICES,
                        validators=[AnyOf(allowed_values(RACE_CHOICES))])
-    gender = SelectField('gender', default='M', choices=GENDER_CHOICES,
+    gender = SelectField('gender', default='Not Sure', choices=GENDER_CHOICES,
                          validators=[AnyOf(allowed_values(GENDER_CHOICES))])
     min_age = IntegerField('min_age', default=16, validators=[
         NumberRange(min=16, max=100)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

On the officer search page, changes default race, gender, and rank to "Not Sure."

I'm no UI expert, but I'd think that, esp. for non-tech savvy users, that having presumptive defaults could lead to search results not showing up, and complaints not being filed (when people don't realize they've left the default setting). Just a suggestion

## Notes for Deployment

None.

## Screenshots (if appropriate)

![2018-08-13-201154_1170x475_scrot](https://user-images.githubusercontent.com/12619481/44065191-3cd5e9ca-9f37-11e8-87c0-ee7b3be27491.png)

![2018-08-13-201215_1163x729_scrot](https://user-images.githubusercontent.com/12619481/44065196-40034e94-9f37-11e8-9967-bebd92e05e67.png)

## Tests and linting

 - [*] I have rebased my changes on current `develop`

 - [*] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
`flake8` is failing but not on any of the code I changed