### PR TITLE
Log who submitted photo

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -717,11 +717,19 @@ def upload(department_id):
         url = upload_file(safe_local_path, original_filename,
                           new_filename)
         # Update the database to add the image
-        new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
-                          date_image_inserted=datetime.datetime.now(),
-                          department_id=department_id,
-                          # TODO: Get the following field from exif data
-                          date_image_taken=datetime.datetime.now())
+        try:
+            new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
+                              date_image_inserted=datetime.datetime.now(),
+                              department_id=department_id,
+                              # TODO: Get the following field from exif data
+                              date_image_taken=datetime.datetime.now(),
+                              user_id=current_user.id)
+        except AttributeError:
+            new_image = Image(filepath=url, hash_img=hash_img, is_tagged=False,
+                              date_image_inserted=datetime.datetime.now(),
+                              department_id=department_id,
+                              # TODO: Get the following field from exif data
+                              date_image_taken=datetime.datetime.now())
         db.session.add(new_image)
         db.session.commit()
         return jsonify(success="Success!"), 200

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -16,6 +16,11 @@
    <div class="header">
       <h3>What happens when I submit a photograph?</h3>
       <p class="small">The next step after a photograph of an officer has been submitted is to match it to the correct badge number, name, and OpenOversight ID (a unique identifier in our system). Volunteers <a href="https://openoversight.com/label">sort through submitted images</a> by first confirming that officers are present in each photograph, and then by matching each photograph to the officer it depicts.</p>
+      {% if not current_user.id %}
+        <p class="small">Please consider creating an account and logging in so that we can keep track of the images you've submitted and contact you with any questions.</p>
+      {% else %}
+        <p class="small">Your user ID will be attached to all photo submissions while you are signed in.</p>
+      {% endif %}
    </div>
    <h3>Select the department that the police officer in your image belongs to:</h3>
    <div class="form-group">

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -1,5 +1,6 @@
 from pytest import raises
 import time
+import datetime
 from OpenOversight.app.models import (Officer, Assignment, Face, Image, Unit,
                                       User, db, Department, Location, Link,
                                       LicensePlate, Incident)
@@ -287,3 +288,17 @@ def test_incident_m2m_license_plates(mockdata):
     db.session.commit()
     assert license_plate in incident.license_plates
     assert incident in license_plate.incidents
+
+
+def test_images_added_with_user_id(mockdata):
+    user_id = 1
+    new_image = Image(filepath="http://www.example.com", hash_img="1234",
+                      is_tagged=False,
+                      date_image_inserted=datetime.datetime.now(),
+                      department_id=1,
+                      date_image_taken=datetime.datetime.now(),
+                      user_id=user_id)
+    db.session.add(new_image)
+    db.session.commit()
+    saved = Image.query.filter_by(user_id=user_id).first()
+    assert saved is not None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #376 .

Changes proposed in this pull request:

- If the user is logged in, their user ID will be added to the raw_images table along with the image information
- A note has been added on the photo submission page asking logged out users to sign up and log in. For logged in users, a note is added that their user ID will be attached to their photo submission.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
