### PR TITLE
306 department editable

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -103,6 +103,10 @@ class DepartmentForm(Form):
     submit = SubmitField(label='Add')
 
 
+class EditDepartmentForm(DepartmentForm):
+    submit = SubmitField(label='Update')
+
+
 class LinkForm(Form):
     title = StringField(
         validators=[Length(max=100, message='Titles are limited to 100 characters.')],

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -25,7 +25,8 @@ from ..utils import (grab_officers, roster_lookup, upload_file, compute_hash,
 
 from .forms import (FindOfficerForm, FindOfficerIDForm, AddUnitForm,
                     FaceTag, AssignmentForm, DepartmentForm, AddOfficerForm,
-                    EditOfficerForm, IncidentForm, NoteForm, EditNoteForm)
+                    EditOfficerForm, IncidentForm, NoteForm, EditNoteForm,
+                    EditDepartmentForm)
 from .model_view import ModelView
 from ..models import (db, Image, User, Face, Officer, Assignment, Department,
                       Unit, Incident, Location, LicensePlate, Link, Note)
@@ -276,7 +277,23 @@ def add_department():
             flash('Department {} already exists'.format(form.name.data))
         return redirect(url_for('main.get_started_labeling'))
     else:
-        return render_template('add_department.html', form=form)
+        return render_template('add_edit_department.html', form=form)
+
+
+@main.route('/department/<int:department_id>/edit', methods=['GET', 'POST'])
+@login_required
+@admin_required
+def edit_department(department_id):
+    department = Department.query.get_or_404(department_id)
+    form = EditDepartmentForm(obj=department)
+    if form.validate_on_submit():
+        department.name=form.name.data
+        department.short_name=form.short_name.data
+        db.session.commit()
+        flash('Department {} edited'.format(department.name))
+        return redirect(url_for('main.list_officer', department_id=department.id))
+    else:
+        return render_template('add_edit_department.html', form=form, update=True)
 
 
 @main.route('/department/<int:department_id>')

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -285,10 +285,17 @@ def add_department():
 @admin_required
 def edit_department(department_id):
     department = Department.query.get_or_404(department_id)
+    previous_name = department.name
     form = EditDepartmentForm(obj=department)
     if form.validate_on_submit():
-        department.name=form.name.data
-        department.short_name=form.short_name.data
+        new_name = form.name.data
+        if new_name != previous_name:
+            if Department.query.filter_by(name=new_name).count() > 0:
+                flash('Department {} already exists'.format(new_name))
+                return redirect(url_for('main.edit_department',
+                                        department_id=department_id))
+        department.name = new_name
+        department.short_name = form.short_name.data
         db.session.commit()
         flash('Department {} edited'.format(department.name))
         return redirect(url_for('main.list_officer', department_id=department.id))

--- a/OpenOversight/app/templates/add_edit_department.html
+++ b/OpenOversight/app/templates/add_edit_department.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% import "bootstrap/wtf.html" as wtf %}
-{% block title %}OpenOversight Admin - Add Department{% endblock %}
+{% block title %}OpenOversight Admin - {% if update %} Update {% else %} Add {% endif %} Department{% endblock %}
 
 {% block content %}
 <div class="container theme-showcase" role="main">
 
 <div class="page-header">
-    <h1>Add Department</h1>
+    <h1>{% if update %} Update {% else %} Add {% endif %} Department</h1>
 </div>
 <div class="col-md-6">
     <form class="form" method="post" role="form">

--- a/OpenOversight/app/templates/browse.html
+++ b/OpenOversight/app/templates/browse.html
@@ -12,6 +12,12 @@
     <p>
       <div class="btn-group">
         <h2>{{ department.name }}
+        {% if current_user.is_administrator %}
+            <a href="{{ url_for('main.edit_department', department_id=department.id) }}">
+              <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+            </a>
+        {% endif %}
+       </h2>
           <p>
           <a class="btn btn-lg btn-primary" href="{{ url_for('main.list_officer', department_id=department.id) }}">
              Officers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #306  .

Changes proposed in this pull request:

 - Admins see an edit-button in '/browse' now (see screenshot)
 - Clicking the button leads to an edit-form very similar to the form for adding a new department
 - Changes to the department name and short-name can be made

I am reusing the template (which I renamed to add_edit_department.html)  and form for adding a department since the two forms are very similar (except for the title and submit button being named "Update" instead of "Add") and to reduce copy and pasting of code. I hope this is acceptable.

## Screenshots
![screenshot from 2018-08-17 06-49-40](https://user-images.githubusercontent.com/41744410/44262853-858f9980-a1ea-11e8-959f-9fd074120aef.png)


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
