### PR TITLE
Do not return Departments with no officers

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -51,7 +51,7 @@ def index():
 
 @main.route('/browse', methods=['GET'])
 def browse():
-    departments = Department.query.all()
+    departments = Department.query.filter(Department.officers.any())
     return render_template('browse.html', departments=departments)
 
 


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Avoid displaying of departments without officers

Fixes issue #491 .

Changes proposed in this pull request:

 - Only get departments with officers
