### PR TITLE
Upgrade gunicorn to fix a CVE, and get live reloading in dev for free

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,11 @@ services:
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
    volumes:
-     - ./OpenOversight/:/usr/src/app/OpenOversight/
+     - ./OpenOversight/:/usr/src/app/OpenOversight/:z
    links:
      - postgres:postgres
    expose:
      - "3000"
-   command: /usr/local/bin/gunicorn -w 4 -b 0.0.0.0:3000 app:app
+   command: /usr/local/bin/gunicorn --reload -w 4 -b 0.0.0.0:3000 app:app
    ports:
      - "3000:3000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ Flask-WTF==0.14.2
 Pillow==5.1.0
 psycopg2>=2.6.2
 SQLAlchemy==1.1.15
-gunicorn==17.5
+gunicorn==19.9
 Fabric==1.14.0
 itsdangerous==0.24
 us>=1.0
+


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes CVE-2018-1000164 in gunicorn. Don't know if we're explicitly vulnerable, but let's not dawdle finding out. I propose cherry-picking this into master and releasing it as soon as it successfully deploys to staging, @redshiftzero.

Changes proposed in this pull request:

 - upgrade gunicorn from 17.5 to 19.9 (latest as of this moment)
 - add the gunicorn 19+ specific '--reload' flag for development environment

## Notes for Deployment
- I haven't done one of these in long enough to know if `pip install requirements.txt` over the existing gunicorn installation makes it inaccessible, and if so, for how long.

## Tests and linting

 - [x] I have rebased my changes on current `develop`
 - [ ] pytests pass in the development environment on my local machine (still waiting for the run)
 - [x] `flake8` checks pass
