### PR TITLE
First pass at python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   firefox: "45.4.0esr"
 python:
   - "2.7"
+  - "3.6"
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
   - mkdir geckodriver

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -9,7 +9,7 @@ from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_mail import Mail
 
-from config import config
+from .config import config
 
 
 bootstrap = Bootstrap()

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -1,3 +1,5 @@
+from future.utils import iteritems
+
 from flask import render_template, redirect, request, url_for, flash, current_app
 from flask.views import MethodView
 from flask_login import login_user, logout_user, login_required, \
@@ -218,7 +220,7 @@ class UserAPI(MethodView):
         user = User.query.get(user_id)
 
         if user and form.validate_on_submit():
-            for field, data in form.data.iteritems():
+            for field, data in iteritems(form.data):
                 setattr(user, field, data)
 
             db.session.add(user)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -1,5 +1,9 @@
 import re
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import validates
 from sqlalchemy import UniqueConstraint

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -1,3 +1,9 @@
+from future.moves.urllib.request import urlretrieve
+from future.utils import iteritems
+
+from builtins import bytes
+from io import open
+
 import boto3
 import botocore
 import datetime
@@ -6,7 +12,6 @@ import os
 import random
 import sys
 import tempfile
-import urllib
 from traceback import format_exc
 
 from sqlalchemy import func
@@ -38,7 +43,7 @@ def get_or_create(session, model, defaults=None, **kwargs):
     if instance:
         return instance, False
     else:
-        params = dict((k, v) for k, v in kwargs.iteritems())
+        params = dict((k, v) for k, v in iteritems(kwargs))
         params.update(defaults or {})
         instance = model(**params)
         session.add(instance)
@@ -144,7 +149,7 @@ def add_officer_profile(form, current_user):
 
 
 def edit_officer_profile(officer, form):
-    for field, data in form.data.iteritems():
+    for field, data in iteritems(form.data):
         if field == 'links':
             for link in data:
                 # don't try to create with a blank string
@@ -181,7 +186,7 @@ def serve_image(filepath):
 
 
 def compute_hash(data_to_hash):
-    return hashlib.sha256(data_to_hash).hexdigest()
+    return hashlib.sha256(bytes(data_to_hash)).hexdigest()
 
 
 def upload_file(safe_local_path, src_filename, dest_filename):
@@ -416,7 +421,7 @@ def get_uploaded_cropped_image(original_image, crop_data):
     original_filename = original_image.filepath.split('/')[-1]
     safe_local_path0 = os.path.join(tmpdir, original_filename)
     # get the original image and save it locally
-    urllib.urlretrieve(original_image.filepath, safe_local_path0)
+    urlretrieve(original_image.filepath, safe_local_path0)
     # import pdb; pdb.set_trace()
     pimage = Pimage.open(safe_local_path0)
     SIZE = 300, 300
@@ -434,7 +439,7 @@ def get_uploaded_cropped_image(original_image, crop_data):
     # TODO: For faster implementation,
     # avoid writing tempfile by passing a BytesIO object to cropped_image.save()
     cropped_image.save(fp=safe_local_path)
-    file = open(safe_local_path)
+    file = open(safe_local_path, 'rb')
 
     # See if there is a matching photo already in the db
     hash_img = compute_hash(file.read())

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -470,7 +470,7 @@ def get_uploaded_cropped_image(original_image, crop_data):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error uploading to S3: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
         rm_dirs()
         return None

--- a/OpenOversight/db_backup.py
+++ b/OpenOversight/db_backup.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 from app.config import config
 import os
 
 db = config['default'].SQLALCHEMY_DATABASE_URI
 os.system("/usr/bin/pg_dump %s -f backup.sql" % db)
-print "backup.sql created"
+print("backup.sql created")

--- a/OpenOversight/manage.py
+++ b/OpenOversight/manage.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import input
 from getpass import getpass
 import sys
 
@@ -24,18 +26,18 @@ manager.add_command("shell", Shell(make_context=make_shell_context))
 def make_admin_user():
     "Add confirmed administrator account"
     while True:
-        username = raw_input("Username: ")
+        username = input("Username: ")
         user = User.query.filter_by(username=username).one_or_none()
         if user:
-            print "Username is already in use"
+            print("Username is already in use")
         else:
             break
 
     while True:
-        email = raw_input("Email: ")
+        email = input("Email: ")
         user = User.query.filter_by(email=email).one_or_none()
         if user:
-            print "Email address already in use"
+            print("Email address already in use")
         else:
             break
 
@@ -45,13 +47,13 @@ def make_admin_user():
 
         if password == password_again:
             break
-        print "Passwords did not match"
+        print("Passwords did not match")
 
     u = User(username=username, email=email, password=password,
              confirmed=True, is_administrator=True)
     db.session.add(u)
     db.session.commit()
-    print "Administrator {} successfully added".format(username)
+    print("Administrator {} successfully added".format(username))
     app.logger.info('Administrator {} added with email {}'.format(username,
                                                                   email))
 
@@ -61,13 +63,13 @@ def link_images_to_department():
     """Link existing images to first department"""
     from app.models import Image, db
     images = Image.query.all()
-    print "Linking images to first department:"
+    print("Linking images to first department:")
     for image in images:
         if not image.department_id:
             sys.stdout.write(".")
             image.department_id = 1
         else:
-            print "Skipped! Department already assigned"
+            print("Skipped! Department already assigned")
     db.session.commit()
 
 
@@ -79,13 +81,13 @@ def link_officers_to_department():
     officers = Officer.query.all()
     units = Unit.query.all()
 
-    print "Linking officers and units to first department:"
+    print("Linking officers and units to first department:")
     for item in officers + units:
         if not item.department_id:
             sys.stdout.write(".")
             item.department_id = 1
         else:
-            print "Skipped! Object already assigned to department!"
+            print("Skipped! Object already assigned to department!")
     db.session.commit()
 
 

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -1,3 +1,5 @@
+from future.utils import iteritems
+
 from flask import url_for
 from OpenOversight.app.auth.forms import LoginForm
 
@@ -43,13 +45,13 @@ def process_form_data(form_dict):
 
         in the way that it is flattened in the browser"""
     new_dict = {}
-    for key, value in form_dict.iteritems():
+    for key, value in iteritems(form_dict):
 
         if type(value) == list:
             if value[0]:
                 if type(value[0]) is dict:
                     for idx, item in enumerate(value):
-                        for subkey, subvalue in item.iteritems():
+                        for subkey, subvalue in iteritems(item):
                             new_dict['{}-{}-{}'.format(key, idx, subkey)] = subvalue
                 elif type(value[0]) is str or type(value[0]) is int:
                     for idx, item in enumerate(value):
@@ -57,7 +59,7 @@ def process_form_data(form_dict):
                 else:
                     raise ValueError('Lists must contain dicts, strings or ints. {} submitted'.format(type(value[0])))
         elif type(value) == dict:
-            for subkey, subvalue in value.iteritems():
+            for subkey, subvalue in iteritems(value):
                 new_dict['{}-{}'.format(key, subkey)] = subvalue
         else:
             new_dict[key] = value

--- a/OpenOversight/tests/routes/test_auth.py
+++ b/OpenOversight/tests/routes/test_auth.py
@@ -1,7 +1,10 @@
 # Routing and view tests
 import pytest
 from flask import url_for, current_app
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 from .route_helpers import login_user
 
 from OpenOversight.app.auth.forms import (LoginForm, RegistrationForm,
@@ -52,7 +55,7 @@ def test_invalid_user_cannot_login(mockdata, client, session):
             url_for('auth.login'),
             data=form.data
         )
-        assert 'Invalid username or password.' in rv.data
+        assert b'Invalid username or password.' in rv.data
 
 
 def test_user_can_logout(mockdata, client, session):
@@ -63,7 +66,7 @@ def test_user_can_logout(mockdata, client, session):
             url_for('auth.logout'),
             follow_redirects=True
         )
-        assert 'You have been logged out.' in rv.data
+        assert b'You have been logged out.' in rv.data
 
 
 def test_user_cannot_register_with_existing_email(mockdata, client, session):
@@ -80,7 +83,7 @@ def test_user_cannot_register_with_existing_email(mockdata, client, session):
 
         # Form will return 200 only if the form does not validate
         assert rv.status_code == 200
-        assert 'Email already registered' in rv.data
+        assert b'Email already registered' in rv.data
 
 
 def test_user_cannot_register_if_passwords_dont_match(mockdata, client, session):
@@ -97,7 +100,7 @@ def test_user_cannot_register_if_passwords_dont_match(mockdata, client, session)
 
         # Form will return 200 only if the form does not validate
         assert rv.status_code == 200
-        assert 'Passwords must match' in rv.data
+        assert b'Passwords must match' in rv.data
 
 
 def test_user_can_register_with_legit_credentials(mockdata, client, session):
@@ -113,7 +116,7 @@ def test_user_can_register_with_legit_credentials(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A confirmation email has been sent to you.' in rv.data
+        assert b'A confirmation email has been sent to you.' in rv.data
 
 
 def test_user_cannot_register_with_weak_password(mockdata, client, session):
@@ -128,7 +131,7 @@ def test_user_cannot_register_with_weak_password(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A confirmation email has been sent to you.' not in rv.data
+        assert b'A confirmation email has been sent to you.' not in rv.data
 
 
 def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
@@ -140,7 +143,7 @@ def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'A new confirmation email has been sent to you.' in rv.data
+        assert b'A new confirmation email has been sent to you.' in rv.data
 
 
 def test_user_can_get_password_reset_token_sent(mockdata, client, session):
@@ -153,7 +156,7 @@ def test_user_can_get_password_reset_token_sent(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'An email with instructions to reset your password' in rv.data
+        assert b'An email with instructions to reset your password' in rv.data
 
 
 def test_user_can_get_reset_password_with_valid_token(mockdata, client, session):
@@ -170,7 +173,7 @@ def test_user_can_get_reset_password_with_valid_token(mockdata, client, session)
             follow_redirects=True
         )
 
-        assert 'Your password has been updated.' in rv.data
+        assert b'Your password has been updated.' in rv.data
 
 
 def test_user_cannot_reset_password_with_invalid_token(mockdata, client, session):
@@ -186,7 +189,7 @@ def test_user_cannot_reset_password_with_invalid_token(mockdata, client, session
             follow_redirects=True
         )
 
-        assert 'Your password has been updated.' not in rv.data
+        assert b'Your password has been updated.' not in rv.data
 
 
 def test_user_cannot_get_email_reset_token_sent_without_valid_password(mockdata, client, session):
@@ -201,7 +204,7 @@ def test_user_cannot_get_email_reset_token_sent_without_valid_password(mockdata,
             follow_redirects=True
         )
 
-        assert 'An email with instructions to confirm your new email' not in rv.data
+        assert b'An email with instructions to confirm your new email' not in rv.data
 
 
 def test_user_can_get_email_reset_token_sent_with_password(mockdata, client, session):
@@ -216,7 +219,7 @@ def test_user_can_get_email_reset_token_sent_with_password(mockdata, client, ses
             follow_redirects=True
         )
 
-        assert 'An email with instructions to confirm your new email' in rv.data
+        assert b'An email with instructions to confirm your new email' in rv.data
 
 
 def test_user_can_change_email_with_valid_reset_token(mockdata, client, session):
@@ -230,7 +233,7 @@ def test_user_can_change_email_with_valid_reset_token(mockdata, client, session)
             follow_redirects=True
         )
 
-        assert 'Your email address has been updated.' in rv.data
+        assert b'Your email address has been updated.' in rv.data
 
 
 def test_user_cannot_change_email_with_invalid_reset_token(mockdata, client, session):
@@ -243,7 +246,7 @@ def test_user_cannot_change_email_with_invalid_reset_token(mockdata, client, ses
             follow_redirects=True
         )
 
-        assert 'Your email address has been updated.' not in rv.data
+        assert b'Your email address has been updated.' not in rv.data
 
 
 def test_user_can_confirm_account_with_valid_token(mockdata, client, session):
@@ -257,7 +260,7 @@ def test_user_can_confirm_account_with_valid_token(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'You have confirmed your account.' in rv.data
+        assert b'You have confirmed your account.' in rv.data
 
 
 def test_user_can_not_confirm_account_with_invalid_token(mockdata, client,
@@ -271,7 +274,7 @@ def test_user_can_not_confirm_account_with_invalid_token(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'The confirmation link is invalid or has expired.' in rv.data
+        assert b'The confirmation link is invalid or has expired.' in rv.data
 
 
 def test_user_can_change_password_if_they_match(mockdata, client, session):
@@ -287,7 +290,7 @@ def test_user_can_change_password_if_they_match(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Your password has been updated.' in rv.data
+        assert b'Your password has been updated.' in rv.data
 
 
 def login_unconfirmed_user(client):
@@ -312,7 +315,7 @@ def test_unconfirmed_user_redirected_to_confirm_account(mockdata, client,
             follow_redirects=False
         )
 
-        assert 'Please Confirm Your Account' in rv.data
+        assert b'Please Confirm Your Account' in rv.data
 
 
 def test_user_cannot_change_password_if_they_dont_match(mockdata, client,
@@ -329,7 +332,7 @@ def test_user_cannot_change_password_if_they_dont_match(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'Passwords must match' in rv.data
+        assert b'Passwords must match' in rv.data
 
 
 def test_user_can_change_dept_pref(mockdata, client, session):
@@ -346,7 +349,7 @@ def test_user_can_change_dept_pref(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Updated!' in rv.data
+        assert b'Updated!' in rv.data
 
         user = User.query.filter_by(email='jen@example.org').one()
         assert user.dept_pref == test_department_id

--- a/OpenOversight/tests/routes/test_descriptions.py
+++ b/OpenOversight/tests/routes/test_descriptions.py
@@ -50,7 +50,7 @@ def test_admins_can_create_descriptions(mockdata, client, session):
         )
 
         assert rv.status_code == 200
-        assert 'created' in rv.data
+        assert 'created' in rv.data.decode('utf-8')
 
         created_description = Description.query.filter_by(text_contents=text_contents).first()
         assert created_description is not None
@@ -76,7 +76,7 @@ def test_acs_can_create_descriptions(mockdata, client, session):
         )
 
         assert rv.status_code == 200
-        assert 'created' in rv.data
+        assert 'created' in rv.data.decode('utf-8')
 
         created_description = Description.query.filter_by(text_contents=description).first()
         assert created_description is not None
@@ -110,7 +110,7 @@ def test_admins_can_edit_descriptions(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert description.text_contents == new_description
         assert description.date_updated > original_date
@@ -144,7 +144,7 @@ def test_ac_can_edit_their_descriptions_in_their_department(mockdata, client, se
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert description.text_contents == new_description
         assert description.date_updated > original_date
@@ -178,7 +178,7 @@ def test_ac_can_edit_others_descriptions(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert description.text_contents == new_description
         assert description.date_updated > original_date
@@ -296,7 +296,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Update' in rv.data
+        assert 'Update' in rv.data.decode('utf-8')
 
 
 def test_acs_can_get_others_edit_form(mockdata, client, session):
@@ -318,7 +318,7 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Update' in rv.data
+        assert 'Update' in rv.data.decode('utf-8')
 
 
 def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
@@ -361,7 +361,7 @@ def test_users_can_see_descriptions(mockdata, client, session):
         # ensures we're looking for a description that exists
         assert description in officer.descriptions
         assert rv.status_code == 200
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')
 
 
 def test_admins_can_see_descriptions(mockdata, client, session):
@@ -385,7 +385,7 @@ def test_admins_can_see_descriptions(mockdata, client, session):
         assert description in officer.descriptions
         assert rv.status_code == 200
         # import pdb; pdb.set_trace()
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')
 
 
 def test_acs_can_see_descriptions_in_their_department(mockdata, client, session):
@@ -409,7 +409,7 @@ def test_acs_can_see_descriptions_in_their_department(mockdata, client, session)
         # ensures we're looking for a description that exists
         assert description in officer.descriptions
         assert rv.status_code == 200
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')
 
 
 def test_acs_can_see_descriptions_not_in_their_department(mockdata, client, session):
@@ -432,4 +432,4 @@ def test_acs_can_see_descriptions_not_in_their_department(mockdata, client, sess
         # ensures we're looking for a description that exists
         assert description in officer.descriptions
         assert rv.status_code == 200
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -2,7 +2,10 @@
 import pytest
 from mock import MagicMock, patch
 from flask import url_for, current_app
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 from ..conftest import AC_DEPT
 from .route_helpers import login_user, login_admin, login_ac
 from OpenOversight.app.main import views
@@ -82,7 +85,7 @@ def test_logged_in_user_can_access_sort_form(mockdata, client, session):
             url_for('main.sort_images', department_id=1),
             follow_redirects=True
         )
-        assert 'Do you see law enforcement officers in the photo' in rv.data
+        assert b'Do you see law enforcement officers in the photo' in rv.data
 
 
 def test_user_can_view_submission(mockdata, client, session):
@@ -93,7 +96,7 @@ def test_user_can_view_submission(mockdata, client, session):
             url_for('main.display_submission', image_id=1),
             follow_redirects=True
         )
-        assert 'Image ID' in rv.data
+        assert b'Image ID' in rv.data
 
 
 def test_user_can_view_tag(mockdata, client, session):
@@ -104,7 +107,7 @@ def test_user_can_view_tag(mockdata, client, session):
             url_for('main.display_tag', tag_id=1),
             follow_redirects=True
         )
-        assert 'Tag' in rv.data
+        assert b'Tag' in rv.data
 
 
 def test_admin_can_delete_tag(mockdata, client, session):
@@ -115,7 +118,7 @@ def test_admin_can_delete_tag(mockdata, client, session):
             url_for('main.delete_tag', tag_id=1),
             follow_redirects=True
         )
-        assert 'Deleted this tag' in rv.data
+        assert b'Deleted this tag' in rv.data
 
 
 def test_ac_can_delete_tag_in_their_dept(mockdata, client, session):
@@ -129,7 +132,7 @@ def test_ac_can_delete_tag_in_their_dept(mockdata, client, session):
             url_for('main.delete_tag', tag_id=tag_id),
             follow_redirects=True
         )
-        assert 'Deleted this tag' in rv.data
+        assert b'Deleted this tag' in rv.data
 
         # test tag was deleted from database
         deleted_tag = Face.query.filter_by(id=tag_id).first()
@@ -175,7 +178,7 @@ def test_user_can_add_tag(mockdata, client, session, monkeypatch):
                 follow_redirects=True
             )
             views.get_uploaded_cropped_image.assert_called_once()
-            assert 'Tag added to database' in rv.data
+            assert b'Tag added to database' in rv.data
 
 
 def test_user_cannot_add_tag_if_it_exists(mockdata, client, session):
@@ -194,7 +197,7 @@ def test_user_cannot_add_tag_if_it_exists(mockdata, client, session):
             data=form.data,
             follow_redirects=True
         )
-        assert 'Tag already exists between this officer and image! Tag not added.' in rv.data
+        assert b'Tag already exists between this officer and image! Tag not added.' in rv.data
 
 
 def test_user_cannot_tag_nonexistent_officer(mockdata, client, session):
@@ -213,7 +216,7 @@ def test_user_cannot_tag_nonexistent_officer(mockdata, client, session):
             data=form.data,
             follow_redirects=True
         )
-        assert 'Invalid officer ID' in rv.data
+        assert b'Invalid officer ID' in rv.data
 
 
 def test_user_can_finish_tagging(mockdata, client, session):
@@ -224,7 +227,7 @@ def test_user_can_finish_tagging(mockdata, client, session):
             url_for('main.complete_tagging', image_id=4),
             follow_redirects=True
         )
-        assert 'Marked image as completed.' in rv.data
+        assert b'Marked image as completed.' in rv.data
 
 
 def test_user_can_view_leaderboard(mockdata, client, session):
@@ -235,7 +238,7 @@ def test_user_can_view_leaderboard(mockdata, client, session):
             url_for('main.leaderboard'),
             follow_redirects=True
         )
-        assert 'Top Users by Number of Images Sorted' in rv.data
+        assert b'Top Users by Number of Images Sorted' in rv.data
 
 
 def test_user_is_redirected_to_correct_department_after_tagging(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -78,7 +78,7 @@ def test_admins_can_create_basic_incidents(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'created' in rv.data
+        assert 'created' in rv.data.decode('utf-8')
 
         inc = Incident.query.filter_by(date=date).first()
         assert inc is not None
@@ -121,7 +121,7 @@ def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'successfully updated' in rv.data
+        assert 'successfully updated' in rv.data.decode('utf-8')
         updated = Incident.query.get(inc_id)
         assert updated.date == new_date
         assert updated.address.street_name == street_name
@@ -168,7 +168,7 @@ def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'successfully updated' in rv.data
+        assert 'successfully updated' in rv.data.decode('utf-8')
         # old links are still there
         for link in old_links:
             assert link in inc.links
@@ -211,7 +211,7 @@ def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Incidents prior to 1900 not allowed.' in rv.data
+        assert 'Incidents prior to 1900 not allowed.' in rv.data.decode('utf-8')
 
 
 def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
@@ -248,7 +248,7 @@ def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Must select a state.' in rv.data
+        assert 'Must select a state.' in rv.data.decode('utf-8')
         assert incident_count_before == Incident.query.count()
 
 
@@ -294,9 +294,9 @@ def test_admins_cannot_make_incidents_with_multiple_validation_errors(mockdata, 
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Must also select a state.' in rv.data
-        assert 'Zip codes must have 5 digits.' in rv.data
-        assert rv.data.count('This field is required.') >= 3
+        assert 'Must also select a state.' in rv.data.decode('utf-8')
+        assert 'Zip codes must have 5 digits.' in rv.data.decode('utf-8')
+        assert rv.data.decode('utf-8').count('This field is required.') >= 3
         assert incident_count_before == Incident.query.count()
 
 
@@ -342,7 +342,7 @@ def test_admins_can_edit_incident_officers(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'successfully updated' in rv.data
+        assert 'successfully updated' in rv.data.decode('utf-8')
         for officer in old_officers:
             assert officer in inc.officers
         assert new_officer.id in [off.id for off in inc.officers]
@@ -389,7 +389,7 @@ def test_admins_cannot_edit_nonexisting_officers(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Not a valid officer id' in rv.data
+        assert 'Not a valid officer id' in rv.data.decode('utf-8')
         for officer in old_officers:
             assert officer in inc.officers
 
@@ -430,7 +430,7 @@ def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'successfully updated' in rv.data
+        assert 'successfully updated' in rv.data.decode('utf-8')
         assert inc.date == new_date
         assert inc.address.street_name == street_name
 
@@ -525,7 +525,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Update' in rv.data
+        assert 'Update' in rv.data.decode('utf-8')
 
 
 def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
@@ -549,30 +549,30 @@ def test_users_can_view_incidents_by_department(mockdata, client, session):
 
         # Requires that report numbers in test data not include other report numbers
         for incident in department_incidents:
-            assert incident.report_number in rv.data
+            assert incident.report_number in rv.data.decode('utf-8')
         for incident in non_department_incidents:
-            assert incident.report_number not in rv.data
+            assert incident.report_number not in rv.data.decode('utf-8')
 
 
 def test_admins_can_see_who_created_incidents(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)
         rv = client.get(url_for('main.incident_api', obj_id=1))
-        assert 'Creator' in rv.data
+        assert 'Creator' in rv.data.decode('utf-8')
 
 
 def test_acs_cannot_see_who_created_incidents(mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
         rv = client.get(url_for('main.incident_api', obj_id=1))
-        assert 'Creator' not in rv.data
+        assert 'Creator' not in rv.data.decode('utf-8')
 
 
 def test_users_cannot_see_who_created_incidents(mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
         rv = client.get(url_for('main.incident_api', obj_id=1))
-        assert 'Creator' not in rv.data
+        assert 'Creator' not in rv.data.decode('utf-8')
 
 
 def test_form_with_officer_id_prepopulates(mockdata, client, session):
@@ -580,4 +580,4 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
         login_admin(client)
         officer_id = '1234'
         rv = client.get(url_for('main.incident_api') + 'new?officer_id={}'.format(officer_id))
-        assert officer_id in rv.data
+        assert officer_id in rv.data.decode('utf-8')

--- a/OpenOversight/tests/routes/test_notes.py
+++ b/OpenOversight/tests/routes/test_notes.py
@@ -50,7 +50,7 @@ def test_admins_can_create_notes(mockdata, client, session):
         )
 
         assert rv.status_code == 200
-        assert 'created' in rv.data
+        assert 'created' in rv.data.decode('utf-8')
 
         created_note = Note.query.filter_by(text_contents=text_contents).first()
         assert created_note is not None
@@ -76,7 +76,7 @@ def test_acs_can_create_notes(mockdata, client, session):
         )
 
         assert rv.status_code == 200
-        assert 'created' in rv.data
+        assert 'created' in rv.data.decode('utf-8')
 
         created_note = Note.query.filter_by(text_contents=note).first()
         assert created_note is not None
@@ -110,7 +110,7 @@ def test_admins_can_edit_notes(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert note.text_contents == new_note
         assert note.date_updated > original_date
@@ -144,7 +144,7 @@ def test_ac_can_edit_their_notes_in_their_department(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert note.text_contents == new_note
         assert note.date_updated > original_date
@@ -178,7 +178,7 @@ def test_ac_can_edit_others_notes(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'updated' in rv.data
+        assert 'updated' in rv.data.decode('utf-8')
 
         assert note.text_contents == new_note
         assert note.date_updated > original_date
@@ -296,7 +296,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Update' in rv.data
+        assert 'Update' in rv.data.decode('utf-8')
 
 
 def test_acs_can_get_others_edit_form(mockdata, client, session):
@@ -318,7 +318,7 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
             follow_redirects=True
         )
         assert rv.status_code == 200
-        assert 'Update' in rv.data
+        assert 'Update' in rv.data.decode('utf-8')
 
 
 def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
@@ -361,7 +361,7 @@ def test_users_cannot_see_notes(mockdata, client, session):
         # ensures we're looking for a note that exists
         assert note in officer.notes
         assert rv.status_code == 200
-        assert text_contents not in rv.data
+        assert text_contents not in rv.data.decode('utf-8')
 
 
 def test_admins_can_see_notes(mockdata, client, session):
@@ -385,7 +385,7 @@ def test_admins_can_see_notes(mockdata, client, session):
         assert note in officer.notes
         assert rv.status_code == 200
         # import pdb; pdb.set_trace()
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')
 
 
 def test_acs_can_see_notes_in_their_department(mockdata, client, session):
@@ -409,7 +409,7 @@ def test_acs_can_see_notes_in_their_department(mockdata, client, session):
         # ensures we're looking for a note that exists
         assert note in officer.notes
         assert rv.status_code == 200
-        assert text_contents in rv.data
+        assert text_contents in rv.data.decode('utf-8')
 
 
 def test_acs_cannot_see_notes_not_in_their_department(mockdata, client, session):
@@ -432,4 +432,4 @@ def test_acs_cannot_see_notes_not_in_their_department(mockdata, client, session)
         # ensures we're looking for a note that exists
         assert note in officer.notes
         assert rv.status_code == 200
-        assert text_contents not in rv.data
+        assert text_contents not in rv.data.decode('utf-8')

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -59,7 +59,7 @@ def test_user_can_access_officer_profile(mockdata, client, session):
             url_for('main.officer_profile', officer_id=3),
             follow_redirects=True
         )
-        assert 'Officer Detail' in rv.data
+        assert 'Officer Detail' in rv.data.decode('utf-8')
 
 
 def test_user_can_access_officer_list(mockdata, client, session):
@@ -68,7 +68,7 @@ def test_user_can_access_officer_list(mockdata, client, session):
             url_for('main.list_officer', department_id=2)
         )
 
-        assert 'Officers' in rv.data
+        assert 'Officers' in rv.data.decode('utf-8')
 
 
 def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):
@@ -80,7 +80,7 @@ def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):
             url_for('main.officer_profile', officer_id=officer.id),
             follow_redirects=True
         )
-        assert 'Admin only' in rv.data
+        assert 'Admin only' in rv.data.decode('utf-8')
 
 
 def test_ac_cannot_access_admin_on_non_dept_officer_profile(mockdata, client, session):
@@ -92,7 +92,7 @@ def test_ac_cannot_access_admin_on_non_dept_officer_profile(mockdata, client, se
             url_for('main.officer_profile', officer_id=officer.id),
             follow_redirects=True
         )
-        assert 'Admin only' not in rv.data
+        assert 'Admin only' not in rv.data.decode('utf-8')
 
 
 def test_admin_can_add_officer_badge_number(mockdata, client, session):
@@ -108,7 +108,7 @@ def test_admin_can_add_officer_badge_number(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Added new assignment' in rv.data
+        assert 'Added new assignment' in rv.data.decode('utf-8')
 
 
 def test_ac_can_add_officer_badge_number_in_their_dept(mockdata, client, session):
@@ -125,7 +125,7 @@ def test_ac_can_add_officer_badge_number_in_their_dept(mockdata, client, session
             follow_redirects=True
         )
 
-        assert 'Added new assignment' in rv.data
+        assert 'Added new assignment' in rv.data.decode('utf-8')
 
         # test that assignment exists in database
         assignment = Officer.query.filter(Officer.assignments.any(star_no='S1234'))
@@ -173,7 +173,7 @@ def test_admin_can_edit_officer_badge_number(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Edited officer assignment' in rv.data
+        assert 'Edited officer assignment' in rv.data.decode('utf-8')
         assert officer.assignments[0].star_no == '12345'
 
 
@@ -204,7 +204,7 @@ def test_ac_can_edit_officer_in_their_dept_badge_number(mockdata, client, sessio
             follow_redirects=True
         )
 
-        assert 'Edited officer assignment' in rv.data
+        assert 'Edited officer assignment' in rv.data.decode('utf-8')
         assert officer.assignments[0].star_no == new_star_no
 
 
@@ -251,7 +251,7 @@ def test_admin_can_add_police_department(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'New department' in rv.data
+        assert 'New department' in rv.data.decode('utf-8')
 
         # Check the department was added to the database
         department = Department.query.filter_by(
@@ -296,7 +296,7 @@ def test_admin_cannot_add_duplicate_police_department(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'already exists' in rv.data
+        assert 'already exists' in rv.data.decode('utf-8')
 
         # Check that only one department was added to the database
         # one() method will throw exception if more than one department found
@@ -318,7 +318,7 @@ def test_admin_can_edit_police_department(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'New department' in misspelled_rv.data
+        assert 'New department' in misspelled_rv.data.decode('utf-8')
 
         department = Department.query.filter_by(name='Misspelled Police Department').one()
 
@@ -331,7 +331,7 @@ def test_admin_can_edit_police_department(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Department Corrected Police Department edited' in corrected_rv.data
+        assert 'Department Corrected Police Department edited' in corrected_rv.data.decode('utf-8')
 
         # Check the department with the new name is now in the database.
         corrected_department = Department.query.filter_by(
@@ -351,7 +351,7 @@ def test_admin_can_edit_police_department(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Department Corrected Police Department edited' in edit_short_name_rv.data
+        assert 'Department Corrected Police Department edited' in edit_short_name_rv.data.decode('utf-8')
 
         edit_short_name_department = Department.query.filter_by(
             name='Corrected Police Department').one()
@@ -390,7 +390,7 @@ def test_admin_cannot_duplicate_police_department_during_edit(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'New department' in existing_dep_rv.data
+        assert 'New department' in existing_dep_rv.data.decode('utf-8')
 
         new_dep_form = DepartmentForm(name='New Police Department',
                                       short_name='NPD')
@@ -401,7 +401,7 @@ def test_admin_cannot_duplicate_police_department_during_edit(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'New department' in new_dep_rv.data
+        assert 'New department' in new_dep_rv.data.decode('utf-8')
 
         new_department = Department.query.filter_by(
             name='New Police Department').one()
@@ -415,7 +415,7 @@ def test_admin_cannot_duplicate_police_department_during_edit(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'already exists' in rv.data
+        assert 'already exists' in rv.data.decode('utf-8')
 
         # make sure original department is still here
         existing_department = Department.query.filter_by(
@@ -438,7 +438,7 @@ def test_expected_dept_appears_in_submission_dept_selection(mockdata, client,
             follow_redirects=True
         )
 
-        assert 'Springfield Police Department' in rv.data
+        assert 'Springfield Police Department' in rv.data.decode('utf-8')
 
 
 def test_admin_can_add_new_officer(mockdata, client, session):
@@ -468,7 +468,7 @@ def test_admin_can_add_new_officer(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'McTesterson' in rv.data
+        assert 'McTesterson' in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -508,7 +508,7 @@ def test_ac_can_add_new_officer_in_their_dept(mockdata, client, session):
         )
 
         assert rv.status_code == 200
-        assert last_name in rv.data
+        assert last_name in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -591,10 +591,10 @@ def test_admin_can_edit_existing_officer(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Changed' in rv.data
-        assert 'Testerinski' not in rv.data
-        assert link_url0 in rv.data
-        assert link_url1 not in rv.data
+        assert 'Changed' in rv.data.decode('utf-8')
+        assert 'Testerinski' not in rv.data.decode('utf-8')
+        assert link_url0 in rv.data.decode('utf-8')
+        assert link_url1 not in rv.data.decode('utf-8')
 
 
 def test_ac_cannot_edit_officer_not_in_their_dept(mockdata, client, session):
@@ -639,7 +639,7 @@ def test_ac_can_see_officer_not_in_their_dept(mockdata, client, session):
 
         assert rv.status_code == 200
         # Testing names doesn't work bc the way we display them varies
-        assert str(officer.id) in rv.data
+        assert str(officer.id) in rv.data.decode('utf-8')
 
 
 def test_ac_can_edit_officer_in_their_dept(mockdata, client, session):
@@ -695,8 +695,8 @@ def test_ac_can_edit_officer_in_their_dept(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert new_last_name in rv.data
-        assert last_name not in rv.data
+        assert new_last_name in rv.data.decode('utf-8')
+        assert last_name not in rv.data.decode('utf-8')
 
         # Check the changes were added to the database
         officer = Officer.query.filter_by(
@@ -727,7 +727,7 @@ def test_admin_adds_officer_without_middle_initial(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'McTesty' in rv.data
+        assert 'McTesty' in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -762,7 +762,7 @@ def test_admin_adds_officer_with_letter_in_badge_no(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'Testersly' in rv.data
+        assert 'Testersly' in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -787,7 +787,7 @@ def test_admin_can_add_new_unit(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'New unit' in rv.data
+        assert 'New unit' in rv.data.decode('utf-8')
 
         # Check the unit was added to the database
         unit = Unit.query.filter_by(
@@ -809,7 +809,7 @@ def test_ac_can_add_new_unit_in_their_dept(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'New unit' in rv.data
+        assert 'New unit' in rv.data.decode('utf-8')
 
         # Check the unit was added to the database
         unit = Unit.query.filter_by(
@@ -864,7 +864,7 @@ def test_admin_can_add_new_officer_with_suffix(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'McTesty' in rv.data
+        assert 'McTesty' in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -980,21 +980,21 @@ def test_browse_filtering_filters_bad(client, mockdata, session):
 
                     # Test that the combinations that should be filtered
                     # do not appear in the data
-                    filter_list = rv.data.split("<dt>Race</dt>")[1:]
+                    filter_list = rv.data.decode('utf-8').split("<dt>Race</dt>")[1:]
                     if race == "BLACK":
                         bad_substr = "<dd>White</dd>"
                     else:
                         bad_substr = "<dd>Black</dd>"
                     assert not any(bad_substr in token for token in filter_list)
 
-                    filter_list = rv.data.split("<dt>Gender</dt>")[1:]
+                    filter_list = rv.data.decode('utf-8').split("<dt>Gender</dt>")[1:]
                     if gender == "M":
                         bad_substr = "<dd>F</dd>"
                     else:
                         bad_substr = "<dd>M</dd>"
                     assert not any(bad_substr in token for token in filter_list)
 
-                    filter_list = rv.data.split("<dt>Rank</dt>")[1:]
+                    filter_list = rv.data.decode('utf-8').split("<dt>Rank</dt>")[1:]
                     if rank == "COMMANDER":
                         bad_substr = "<dd>PO</dd>"
                     else:
@@ -1031,7 +1031,7 @@ def test_browse_filtering_allows_good(client, mockdata, session):
             follow_redirects=True
         )
 
-        assert 'A' in rv.data
+        assert 'A' in rv.data.decode('utf-8')
 
         # Check the officer was added to the database
         officer = Officer.query.filter_by(
@@ -1055,13 +1055,13 @@ def test_browse_filtering_allows_good(client, mockdata, session):
             follow_redirects=True
         )
 
-        filter_list = rv.data.split("<dt>Race</dt>")[1:]
+        filter_list = rv.data.decode('utf-8').split("<dt>Race</dt>")[1:]
         assert any("<dd>White</dd>" in token for token in filter_list)
 
-        filter_list = rv.data.split("<dt>Rank</dt>")[1:]
+        filter_list = rv.data.decode('utf-8').split("<dt>Rank</dt>")[1:]
         assert any("<dd>COMMANDER</dd>" in token for token in filter_list)
 
-        filter_list = rv.data.split("<dt>Gender</dt>")[1:]
+        filter_list = rv.data.decode('utf-8').split("<dt>Gender</dt>")[1:]
         assert any("<dd>M</dd>" in token for token in filter_list)
 
 # def test_find_form_submission(client, mockdata):

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -904,8 +904,8 @@ def test_officer_csv(mockdata, client, session):
             url_for('main.download_dept_csv', department_id=department.id),
             follow_redirects=True
         )
-        # get csv entry matching officer last name
-        csv = filter(lambda row: form.last_name.data in row, rv.data.split("\n"))
+        # get csv entry matching officer last n"createdame
+        csv = list(filter(lambda row: form.last_name.data in row, rv.data.decode('utf-8').split("\n")))
         assert len(csv) == 1
         assert form.first_name.data in csv[0]
         assert form.last_name.data in csv[0]
@@ -940,7 +940,7 @@ def test_incidents_csv(mockdata, client, session):
             data=process_form_data(form.data),
             follow_redirects=True
         )
-        assert "created" in rv.data
+        assert "created" in rv.data.decode('utf-8')
         # dump incident csv
         rv = client.get(
             url_for('main.download_incidents_csv', department_id=department.id),
@@ -948,7 +948,7 @@ def test_incidents_csv(mockdata, client, session):
         )
         # print(rv.data)
         # get the csv entry with matching report number
-        csv = filter(lambda row: report_number in row, rv.data.split("\n"))
+        csv = list(filter(lambda row: report_number in row, rv.data.decode('utf-8').split("\n")))
         assert len(csv) == 1
         assert form.description.data in csv[0]
 

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -28,11 +28,11 @@ def test_user_can_access_profile(mockdata, client, session):
             url_for('main.profile', username='test_user'),
             follow_redirects=True
         )
-        assert 'test_user' in rv.data
+        assert 'test_user' in rv.data.decode('utf-8')
         # User email should not appear
-        assert 'User Email' not in rv.data
+        assert 'User Email' not in rv.data.decode('utf-8')
         # Toggle button should not appear for this non-admin user
-        assert 'Toggle (Disable/Enable) User' not in rv.data
+        assert 'Toggle (Disable/Enable) User' not in rv.data.decode('utf-8')
 
 
 def test_admin_sees_toggle_button_on_profiles(mockdata, client, session):
@@ -43,11 +43,11 @@ def test_admin_sees_toggle_button_on_profiles(mockdata, client, session):
             url_for('main.profile', username='test_user'),
             follow_redirects=True
         )
-        assert 'test_user' in rv.data
+        assert 'test_user' in rv.data.decode('utf-8')
         # User email should appear
-        assert 'User Email' in rv.data
+        assert 'User Email' in rv.data.decode('utf-8')
         # Admin should be able to see the Toggle button
-        assert 'Toggle (Disable/Enable) User' in rv.data
+        assert 'Toggle (Disable/Enable) User' in rv.data.decode('utf-8')
 
 
 def test_admin_can_toggle_user(mockdata, client, session):
@@ -58,7 +58,7 @@ def test_admin_can_toggle_user(mockdata, client, session):
             url_for('main.toggle_user', uid=1),
             follow_redirects=True
         )
-        assert 'Disabled' in rv.data
+        assert 'Disabled' in rv.data.decode('utf-8')
 
 
 def test_ac_cannot_toggle_user(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -36,7 +36,7 @@ def test_admin_can_update_users_to_ac(mockdata, client, session):
             follow_redirects=True
         )
 
-        assert 'updated!' in rv.data
+        assert 'updated!' in rv.data.decode('utf-8')
         assert user.is_area_coordinator is True
 
 
@@ -95,7 +95,7 @@ def test_admin_cannot_update_to_ac_without_department(mockdata, client, session)
             follow_redirects=True
         )
 
-        assert 'updated!' not in rv.data
+        assert 'updated!' not in rv.data.decode('utf-8')
         assert user.is_area_coordinator is False
 
 
@@ -117,5 +117,5 @@ def test_admin_cannot_update_to_ac_without_department(mockdata, client, session)
 #             follow_redirects=True
 #         )
 
-#         assert 'updated!' in rv.data
+#         assert 'updated!' in rv.data.decode('utf-8')
 #         assert user.is_administrator is True

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from contextlib import contextmanager
 import pytest
 from selenium.common.exceptions import TimeoutException
@@ -87,13 +88,13 @@ def test_officer_browse_pagination(mockdata, browser):
     assert expected in page_text
 
     # last page of results
-    last_page_index = (total / perpage) + 1
+    last_page_index = (total // perpage) + 1
     browser.get("http://localhost:5000/department/{}?from_search=False&page={}"
                 .format(dept_id, last_page_index))
     wait_for_element(browser, By.TAG_NAME, "body")
     page_text = browser.find_element_by_tag_name("body").text
     expected = ('Showing {}-{} of {}'
-                .format(perpage * (total / perpage) + 1, total, total))
+                .format(perpage * (total // perpage) + 1, total, total))
     assert expected in page_text
 
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -97,7 +97,7 @@ def test_filter_by_badge_no(mockdata):
 
 
 def test_compute_hash(mockdata):
-    hash_result = OpenOversight.app.utils.compute_hash('bacon')
+    hash_result = OpenOversight.app.utils.compute_hash(b'bacon')
     expected_hash = '9cca0703342e24806a9f64e08c053dca7f2cd90f10529af8ea872afb0a0c77d4'
     assert hash_result == expected_hash
 

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3
 
 WORKDIR /usr/src/app
 
@@ -12,8 +12,8 @@ RUN mkdir geckodriver
 RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
 COPY requirements.txt dev-requirements.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir -r dev-requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r dev-requirements.txt
 
 RUN mkdir /var/www && chmod a+xw /var/www
 

--- a/flickrscraper/flickrgroup.py
+++ b/flickrscraper/flickrgroup.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from builtins import input
+
 # creates a folder in the current directory and downloads pics and csv into it.
 # need to fix last loop so very last entry doesn't generate error
 
@@ -7,19 +10,18 @@ import time
 import io
 import os
 
-
 api_key = ''
 secret = ''
 flickr = flickrapi.FlickrAPI(api_key, secret, format='parsed-json')
 
 
 os.system('clear')
-group_url = raw_input("Enter a Flickr Group URL: ")
+group_url = input("Enter a Flickr Group URL: ")
 group_id = group_url.strip('/').split('/')[-1]
-print " "
-print "Files will be saved in folder " + group_id
+print(" ")
+print("Files will be saved in folder " + group_id)
 time.sleep(1)
-print "Retrieving ID's. Please wait."
+print("Retrieving ID's. Please wait.")
 group_pool_photos = []
 
 page = 1
@@ -35,7 +37,7 @@ with io.FileIO(group_id + "/" + "list.csv", "w") as file:
     while True:
         response = flickr.groups.pools.getPhotos(group_id=group_id, page=page, perpage=perpage)
         if response['stat'] != 'ok':
-            print 'Error occurred in flickr.groups.pools.getPhotos'
+            print('Error occurred in flickr.groups.pools.getPhotos')
             print(response)
             success = False
             break
@@ -47,10 +49,10 @@ with io.FileIO(group_id + "/" + "list.csv", "w") as file:
         page += 1
 
     if success:
-        print 'Photos: {}'.format(len(group_pool_photos))
+        print('Photos: {}'.format(len(group_pool_photos)))
         time.sleep(1)
-        print 'Downloading now.'
-        print " "
+        print('Downloading now.')
+        print(" ")
         file.write('PICID, PICURL, TAKEN, LOCATION, REALNAME, TITLE, DESCRIPTION, PATH_ALIAS')
         file.write('\r\n')
         for line in group_pool_photos:

--- a/flickrscraper/readme.md
+++ b/flickrscraper/readme.md
@@ -26,10 +26,8 @@ All output is save in the folder named after the Group ID.
 
 Each image takes about 1-2 seconds to download including JPG and data fields (CSV).
 
-
 ## Dependencies
 
-Python 2.7  
 flickrapi  
 wgetter  
 

--- a/flickrscraper/resize.and.detect.py
+++ b/flickrscraper/resize.and.detect.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 # Copyright 2015 Google, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,8 +109,8 @@ if __name__ == '__main__':
         filesize = statinfo.st_size
         if filesize > 8000000:
             basewidth = 6000
-            print statinfo.st_size
-            print file
+            print(statinfo.st_size)
+            print(file)
             img = Image.open(file)
             wpercent = (basewidth / float(img.size[0]))
             hsize = int((float(img.size[1]) * float(wpercent)))
@@ -117,8 +118,8 @@ if __name__ == '__main__':
             img.save(file)
         if filesize > 4000000:
             basewidth = 4000
-            print statinfo.st_size
-            print file
+            print(statinfo.st_size)
+            print(file)
             img = Image.open(file)
             wpercent = (basewidth / float(img.size[0]))
             hsize = int((float(img.size[1]) * float(wpercent)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ gunicorn==19.9
 Fabric==1.14.0
 itsdangerous==0.24
 us>=1.0
+future

--- a/test_data.py
+++ b/test_data.py
@@ -111,15 +111,15 @@ def populate():
     db.session.commit()
 
     # Add images from Springfield Police Department
-    image1 = models.Image(filepath='static/images/test_cop1.png',
+    image1 = models.Image(filepath='/static/images/test_cop1.png',
                           department_id=department1.id)
-    image2 = models.Image(filepath='static/images/test_cop2.png',
+    image2 = models.Image(filepath='/static/images/test_cop2.png',
                           department_id=department1.id)
-    image3 = models.Image(filepath='static/images/test_cop3.png',
+    image3 = models.Image(filepath='/static/images/test_cop3.png',
                           department_id=department2.id)
-    image4 = models.Image(filepath='static/images/test_cop4.png',
+    image4 = models.Image(filepath='/static/images/test_cop4.png',
                           department_id=department2.id)
-    image5 = models.Image(filepath='static/images/test_cop5.jpg',
+    image5 = models.Image(filepath='/static/images/test_cop5.jpg',
                           department_id=department2.id)
 
     test_images = [image1, image2, image3, image4, image5]


### PR DESCRIPTION
## Status

in progress

## Description of Changes

Adds python3 support, builds a python3 development environment instead of python2.

Changes proposed in this pull request:

 - python3 support
 - change relative import to explicit relative import (see [the docs](https://docs.python.org/3/tutorial/modules.html#intra-package-references) for more info)
 - urlparse got absorbed into urllib.parse in python3, so conditionally import it from the new place but fall back to the python2 place
 - fixups in manage.py and backup_db.py
 - change path in test data to a non-relative path so images display (in production these are AWS URLs so this shouldn't be an issue, but they were 404ing from /department and /officer/<id>)


## Notes for Deployment

 - don't, yet, at all

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
