### PR TITLE
tweak footer template to use smaller columns

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -96,7 +96,7 @@
       <hr>
       <div class="row text-center horizontal-padding">
 
-        <div class="col-lg-4">
+        <div class="col-sm-4">
           <h5>OpenOversight</h5>
           <p class="font-weight-300">
             A product of Lucy Parsons Labs in Chicago, IL. <br>
@@ -105,7 +105,7 @@
           </p>
         </div>
 
-        <div class="col-lg-4">
+        <div class="col-sm-4">
           <h5>Contact</h5>
           <p>
             <a href="https://www.facebook.com/lucyparsonslabs"><i class="fa fa-facebook-square fa-3x social"></i></a>
@@ -115,7 +115,7 @@
             <a href="/privacy" class="btn">Privacy Policy</a>
           </p>
         </div>
-        <div class="col-lg-4">
+        <div class="col-sm-4">
           <h5>Navigation</h5>
           <p class="font-weight-300">
             <a href="{{ url_for('main.get_officer') }}" class="btn-unstyled">Find an Officer</a><br>


### PR DESCRIPTION
## Status

Ready for review 
## Description of Changes

Fixes #496 .

Changes proposed in this pull request:

 - Change the bootstrap columns in the footer from `col-lg-4` to `col-sm-4`.  The footer will still collapse, but only when the screen is much smaller.  See screenshots below for comparison.

## Notes for Deployment

## Screenshots (if appropriate)
- Footer with `col-sm-4` doesn't collapse when the website takes up half the desktop (Screenshot 1).
-  <img width="1680" alt="screen shot 2018-09-02 at 12 06 22 pm" src="https://user-images.githubusercontent.com/5529982/44958689-55621f00-aea9-11e8-9876-6cc5c3bf3fd7.png">

-   It does collapse when the website is smaller (Screenshot 2).
- <img width="1680" alt="screen shot 2018-09-02 at 12 06 34 pm" src="https://user-images.githubusercontent.com/5529982/44958692-5dba5a00-aea9-11e8-91af-27b38d278e00.png">

- Footer with `col-lg-4` collapses when the website still takes up half the desktop.
- 
<img width="1680" alt="screen shot 2018-09-02 at 12 07 28 pm" src="https://user-images.githubusercontent.com/5529982/44958702-86daea80-aea9-11e8-9e29-86bd13ef0a20.png">


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
- Pytests didn't pass, but the one test that broke, `test_admins_can_edit_incident_links_and_licenses`, was also breaking on develop.
 - [ ] `flake8` checks pass
I didn't get all of the `flake8` checks to pass, and when I ran `flake8 OpenOversight\` it gave linting errors in the `manage.py` file for a lot of the print statements.  (It said they should be `print("text")` instead of `print "text"`)  This is similar to [errors I previously encountered](https://github.com/lucyparsons/OpenOversight/pull/534#issuecomment-413423160), and I think something is wrong with my setup.  I will ask for help in the slack channel.