### PR TITLE
Pin development dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
-flake8
-selenium
+flake8==3.5.0
+selenium==3.14.0
 nose>=1.3.1
 pytest==3.0.3
 faker==0.7.3
 pytest-cov==2.4.0
 pytest-pep8==1.0.6
-xvfbwrapper
-mock
-sphinx
-sphinx-autobuild
+xvfbwrapper==0.2.9
+mock==2.0.0
+sphinx==1.7.8
+sphinx-autobuild==0.7.1


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - In #553, @McEileen reported issues with a test failure and `flake8`, to ensure that we are all on the same development dependencies, this PR pins them to specific versions

## Notes for Deployment

Development env only

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
