### PR TITLE
Add ReadTheDocs build, beginnings of area coordinator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![](docs/img/lpl-logo.png)
 
-# OpenOversight [![Build Status](https://travis-ci.org/lucyparsons/OpenOversight.svg?branch=develop)](https://travis-ci.org/lucyparsons/OpenOversight) [![Coverage Status](https://coveralls.io/repos/github/lucyparsons/OpenOversight/badge.svg?branch=develop)](https://coveralls.io/github/lucyparsons/OpenOversight?branch=develop)
-
-[![Join the chat at https://gitter.im/OpenOversight/Lobby](https://badges.gitter.im/OpenOversight/Lobby.svg)](https://gitter.im/OpenOversight/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# OpenOversight [![Build Status](https://travis-ci.org/lucyparsons/OpenOversight.svg?branch=develop)](https://travis-ci.org/lucyparsons/OpenOversight) [![Coverage Status](https://coveralls.io/repos/github/lucyparsons/OpenOversight/badge.svg?branch=develop)](https://coveralls.io/github/lucyparsons/OpenOversight?branch=develop) [![Documentation Status](https://readthedocs.org/projects/openoversight/badge/?version=latest)](https://openoversight.readthedocs.io/en/latest/?badge=latest) [![Join the chat at https://gitter.im/OpenOversight/Lobby](https://badges.gitter.im/OpenOversight/Lobby.svg)](https://gitter.im/OpenOversight/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 OpenOversight is a Lucy Parsons Labs project to improve law enforcement accountability through public and crowdsourced data. We maintain a database of officer demographic information and provide digital galleries of photographs. This is done to help people identify law enforcement officers for filing complaints and in order for the public to see work-related information about law enforcement officers that interact with the public.
 

--- a/docs/area_coordinator.rst
+++ b/docs/area_coordinator.rst
@@ -1,0 +1,15 @@
+Area Coordinator
+================
+
+An area coordinator is a person with an account on
+OpenOversight that is charged with curating the collection for a particular
+department. There can be several area coordinators for a given department.
+The tasks they perform include:
+
+* Add new officers
+* Update officer information, such as new assignments or promotions
+* Add private notes to particular officer profiles (visible to other area
+  coordinators or administrators)
+* Add a brief description to an officer's profile
+* Add links and videos to officer's profiles
+* Add incidents linked to one or more officers

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,14 @@ Welcome to OpenOversight's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-This is a placeholder for OpenOversight's documentation.
+   area_coordinator
+
+OpenOversight is a Lucy Parsons Labs project to improve law enforcement
+accountability through public and crowdsourced data. We maintain a database
+of officer demographic information and provide digital galleries of photographs.
+This is done to help people identify law enforcement officers for filing
+complaints and in order for the public to see work-related information about
+law enforcement officers that interact with the public.
 
 Indices and tables
 ==================


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - I've set up our docs to be autobuilt on commit to `master` or `develop` on ReadTheDocs, you can see it here: https://openoversight.readthedocs.io/en/latest/
 - I've added the beginning of an area coordinator guide to the `docs/` directory here so potential documentation contributors have an example and starting point

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
