### PR TITLE
tweak documentation for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please see [CONTRIB.md](/CONTRIB.md) for the full developer setup instructions.
 ## Documentation Quickstart
 
 ```
-pip install dev-requirements.txt
+pip install -r dev-requirements.txt
 make docs
 ```
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - Make the documentation be `pip install -r dev-requirements.txt` instead of `pip install dev-requirements.txt` because `pip install dev-requirements.txt` didn't work

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [X] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
One pytest didn't pass, `test_admins_can_edit_incident_links_and_licenses`, but it was already failing before I made this change.

 - [X] `flake8` checks pass
