### PR TITLE
479/badge number optional

### DIFF
--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -109,7 +109,7 @@ class Assignment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     officer_id = db.Column(db.Integer, db.ForeignKey('officers.id'))
     baseofficer = db.relationship('Officer')
-    star_no = db.Column(db.String(120), index=True, unique=False)
+    star_no = db.Column(db.String(120), index=True, unique=False, nullable=True)
     rank = db.Column(db.String(120), index=True, unique=False)
     unit = db.Column(db.Integer, db.ForeignKey('unit_types.id'), nullable=True)
     star_date = db.Column(db.Date, index=True, unique=False, nullable=True)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Makes officer badge number optional.  Fixes #479  .

Changes proposed in this pull request:

 - Make `star_no` in the `assignments` table nullable.
## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
The test `test_admins_can_edit_incident_links_and_licenses` fails, however, I don't think it is caused by my changes. 
 - [ ] `flake8` checks pass
The `flake8` checks fail on the generated migration because of indentation errors.  I wasn't sure how to resolve this, since they're generated files, so I left them as is.