### PR TITLE
Flickrscraper URL parsing fix

### DIFF
--- a/flickrscraper/flickrgroup.py
+++ b/flickrscraper/flickrgroup.py
@@ -15,7 +15,7 @@ flickr = flickrapi.FlickrAPI(api_key, secret, format='parsed-json')
 
 os.system('clear')
 group_url = raw_input("Enter a Flickr Group URL: ")
-group_id = group_url.split('/')[-2]
+group_id = group_url.strip('/').split('/')[-1]
 print " "
 print "Files will be saved in folder " + group_id
 time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ gunicorn==19.9
 Fabric==1.14.0
 itsdangerous==0.24
 us>=1.0
+


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes none.

Changes proposed in this pull request:

 - Simple one-line change to the Flickr scraping script so that it will work on URL's regardless if they have a trailing slash.

## Notes for Deployment

None.

## Screenshots (if appropriate)

N/A

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [N/A] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
