### PR TITLE
Small improvement to flickrscraper URL parsing

### DIFF
--- a/flickrscraper/flickrgroup.py
+++ b/flickrscraper/flickrgroup.py
@@ -15,7 +15,7 @@ flickr = flickrapi.FlickrAPI(api_key, secret, format='parsed-json')
 
 os.system('clear')
 group_url = raw_input("Enter a Flickr Group URL: ")
-group_id = group_url.split('/')[-2]
+group_id = group_url.strip('/').split('/')[-1]
 print " "
 print "Files will be saved in folder " + group_id
 time.sleep(1)


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes none.

Changes proposed in this pull request:

 - Makes flickrscraper work on URL's w/ or w/o trailing slashes. Previously, it assumed that URL's were pasted in w/ trailing slashes.

## Notes for Deployment

None.

## Screenshots (if appropriate)

N/A

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [N/A (this script doesn't have tests)] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
