### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: dev build start test stop clean
+default: build start test stop clean
 
 .PHONY: dev
 dev:  ## Build and run containers

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ dev:  ## Build and run containers
 .PHONY: build
 build:  ## Build containers
 	docker-compose build postgres
-	docker-compose up -d postgres
 	docker-compose build web
+	docker-compose up -d postgres
 	docker-compose up -d web
 	docker-compose run --rm web /usr/local/bin/python ../create_db.py
 	docker-compose run --rm web /usr/local/bin/python ../test_data.py -p


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes two makefile bugs that didn't have issue numbers.

Changes proposed in this pull request:

 - Fixes a bug where "make default" runs "make build" and "make start" twice.
 - Fixes a bug where "make build" is broken on Gentoo.

## Notes for Deployment

None.

## Screenshots (if appropriate)

N/A

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [NOPE but not passing on develop either] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
