### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ create_db: start
 	docker-compose run --rm web /usr/local/bin/python ../create_db.py
 
 .PHONY: dev
-dev: build start create_db
+dev: build start create_db populate
 
 .PHONY: populate
 populate: create_db  ## Build and run containers

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,52 @@
-default: build start test stop clean
-
-.PHONY: dev
-dev:  ## Build and run containers
-	make build
-	make start
+default: build start create_db populate test stop clean
 
 .PHONY: build
 build:  ## Build containers
-	docker-compose build postgres
-	docker-compose build web
-	docker-compose up -d postgres
-	docker-compose up -d web
-	docker-compose run --rm web /usr/local/bin/python ../create_db.py
-	docker-compose run --rm web /usr/local/bin/python ../test_data.py -p
+	docker-compose build
 
 .PHONY: start
-start:  ## Run containers
+start: build  ## Run containers
 	docker-compose up -d
 
-.PHONY: clean
-clean:  ## Remove containers
-	docker rm openoversight_web_1
-	docker rm openoversight_postgres_1
+.PHONY: create_db
+create_db: start
+	@until docker exec -it openoversight_postgres_1 psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+		echo "Postgres is unavailable - sleeping..."; \
+		sleep 1; \
+	done
+	@echo "Postgres is up"
+	## Creating database
+	docker-compose run --rm web /usr/local/bin/python ../create_db.py
+
+.PHONY: dev
+dev: build start create_db
+
+.PHONY: populate
+populate: create_db  ## Build and run containers
+	@until docker exec -it openoversight_postgres_1 psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+		echo "Postgres is unavailable - sleeping..."; \
+		sleep 1; \
+	done
+	@echo "Postgres is up"
+	## Populate database with test data
+	docker-compose run --rm web /usr/local/bin/python ../test_data.py -p
 
 .PHONY: test
-test:  ## Run tests
+test: start  ## Run tests
 	docker-compose run --rm web /usr/local/bin/pytest -v tests/
 
 .PHONY: stop
 stop:  ## Stop containers
 	docker-compose stop
+
+.PHONY: clean
+clean: stop  ## Remove containers
+	docker rm openoversight_web_1 || true
+	docker rm openoversight_postgres_1 || true
+
+.PHONY: clean_all
+clean_all: clean stop ## Wipe database
+	rm -rf container_data
 
 .PHONY: docs
 docs: ## Build project documentation in live reload for editing


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Separate out commands in Makefile for easier use
Wait until Postgres is ready before creating DB or populating test data

## Notes for Deployment

`make dev` will now create the docker environment and the database, but will no longer populate it with test data. `make populate` was added to do that.

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
