### PR TITLE
Update Geckodriver

### DIFF
--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -4,11 +4,12 @@ WORKDIR /usr/src/app
 
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
+ENV GECKODRIVER_VERSION="v0.23.0"
 RUN apt-get update && apt-get install -y xvfb firefox-esr
 
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
+RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 RUN mkdir geckodriver
-RUN tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
+RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
 COPY requirements.txt dev-requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
fixes #596 

## Status

Ready for review

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
