### PR TITLE
fix bug preventing incident edit form submission

### DIFF
--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -71,7 +71,7 @@ class ModelView(MethodView):
             form = self.get_edit_form(obj)
             # if the object doesn't have a creator id set, st it to current user
             # import pdb; pdb.set_trace()
-            if hasattr(obj, 'creator_id') and hasattr(form, 'creator_id') and not getattr(obj, 'creator_id'):
+            if hasattr(obj, 'creator_id') and hasattr(form, 'creator_id') and getattr(obj, 'creator_id'):
                 form.creator_id.data = obj.creator_id
             elif hasattr(form, 'creator_id'):
                 form.creator_id.data = current_user.id


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In the model view edit form, where the `creator_id` is set on the form, the check for whether or not the object has one attempts to set `form.creator_id.data = obj.creator_id` *only* if `obj.creator_id` returned None, which then prevented setting the current user's id instead. This prevented editing incidents, so I fixed the if statement to work as the comment above that line describes.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
