### PR TITLE
avoid trying to push container_data to dockerd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 backup/**
+container_data


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes  an error where `make build` would crash.

```
postgres uses an image, skipping                                                                          
Building web                                                                                              
Traceback (most recent call last):                                                                        
  File "bin/docker-compose", line 6, in <module>                                                          
  File "compose/cli/main.py", line 71, in main                                                            
  File "compose/cli/main.py", line 127, in perform_command                                                
  File "compose/cli/main.py", line 287, in build                                                          
  File "compose/project.py", line 384, in build                                                           
  File "compose/project.py", line 366, in build_service                                                   
  File "compose/service.py", line 1080, in build                                                          
  File "site-packages/docker/api/build.py", line 154, in build                                            
  File "site-packages/docker/utils/build.py", line 30, in tar                                             
  File "site-packages/docker/utils/build.py", line 49, in exclude_paths                                   
  File "site-packages/docker/utils/build.py", line 214, in rec_walk                                       
  File "site-packages/docker/utils/build.py", line 214, in rec_walk                                       
  File "site-packages/docker/utils/build.py", line 184, in rec_walk                                       
PermissionError: [Errno 13] Permission denied: '/home/jack/Projects/OpenOversight/container_data/postgres'
[7615] Failed to execute script docker-compose                                                            
Makefile:5: recipe for target 'build' failed                                                              
make: *** [build] Error 255
```

Changes proposed in this pull request:

 - add a directory to dockerignore

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
