### PR TITLE
include age next to birth year in officer profile

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -83,7 +83,8 @@ def create_app(config_name='default'):
 
     @app.template_filter('get_age')
     def get_age_from_birth_year(birth_year):
-        return int(datetime.datetime.now().year - birth_year)
+        if birth_year:
+            return int(datetime.datetime.now().year - birth_year)
 
     return app
 

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from logging.handlers import RotatingFileHandler
 
@@ -80,7 +81,10 @@ def create_app(config_name='default'):
     def capfirst_filter(s):
         return s[0].capitalize() + s[1:]  # only change 1st letter
 
-    return app
+    @app.template_filter('get_age')
+    def get_age_from_birth_year(birth_year):
+        return int(datetime.datetime.now().year - birth_year)
 
+    return app
 
 app = create_app()

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -88,4 +88,5 @@ def create_app(config_name='default'):
 
     return app
 
+
 app = create_app()

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -55,8 +55,8 @@
                 <td>{{ officer.gender }}</td>
               </tr>
               <tr>
-                <td><b>Birth Year</b></td>
-                <td>{{ officer.birth_year }}</td>
+                <td><b>Birth Year (Age)</b></td>
+                <td>{{ officer.birth_year }} ({{ officer.birth_year|get_age }})</td>
               </tr>
               <tr>
                 <td><b>First Employment Date</b></td>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #569 
Added a template filter to calculate age based on birth year, and updated the officer profile to include the age alongside the birth year in parenthesis e.g., `1955 (63)`.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
