### PR TITLE
Navigation Breadcrumb For Officer Page

### DIFF
--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,11 +4,11 @@
 <div class="container" role="main">
 
   <div class="page-header">
-      <h1>Officer Detail: <b>{% include 'partials/officer_name.html' %}</b></h1>
       <ol class="breadcrumb">
           <li><a href={{url_for('main.list_officer',department_id=officer.department.id)}}>{{ officer.department.name|title }}</a></li>
           <li class="active">{% include 'partials/officer_name.html' %}</li>
       </ol>
+      <h1>Officer Detail: <b>{% include 'partials/officer_name.html' %}</b></h1>
   </div>
 
   <div class="row">

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,7 +4,10 @@
 <div class="container" role="main">
 
   <div class="page-header">
-      <h1><a href={{url_for('main.list_officer',department_id=officer.department.id)}}>{{ officer.department.name|title }}</a> >> <b>{% include 'partials/officer_name.html' %}</b></h1>
+      <ol class="breadcrumb">
+          <li><a href={{url_for('main.list_officer',department_id=officer.department.id)}}>{{ officer.department.name|title }}</a></li>
+          <li class="active">{% include 'partials/officer_name.html' %}</li>
+      </ol>
   </div>
 
   <div class="row">
@@ -34,6 +37,10 @@
           </h3>
           <table class="table table-hover">
             <tbody>
+              <tr>
+                <td><b>Name</b></td>
+                <td>{% include 'partials/officer_name.html' %}</td>
+              </tr>
               <tr>
                 <td><b>OpenOversight ID</b></td>
                 <td>{{ officer.id }}</td>

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,6 +4,7 @@
 <div class="container" role="main">
 
   <div class="page-header">
+      <h1>Officer Detail: <b>{% include 'partials/officer_name.html' %}</b></h1>
       <ol class="breadcrumb">
           <li><a href={{url_for('main.list_officer',department_id=officer.department.id)}}>{{ officer.department.name|title }}</a></li>
           <li class="active">{% include 'partials/officer_name.html' %}</li>

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -4,7 +4,7 @@
 <div class="container" role="main">
 
   <div class="page-header">
-    <h1>Officer Detail: <b>{% include 'partials/officer_name.html' %}</b></h1>
+      <h1><a href={{url_for('main.list_officer',department_id=officer.department.id)}}>{{ officer.department.name|title }}</a> >> <b>{% include 'partials/officer_name.html' %}</b></h1>
   </div>
 
   <div class="row">

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -128,8 +128,6 @@ def test_lastname_capitalization(mockdata, browser):
 
         # check result
         wait_for_element(browser, By.TAG_NAME, "tbody")
-        # assumes the page-header field is of the form:
-        # <div class="page-header"><h1>Officer Detail: <b>McDonald</b></h1></div>
-        rendered_field = browser.find_element_by_class_name("page-header").text
+        rendered_field = browser.find_element_by_tag_name("h1").text
         rendered_name = rendered_field.split(":")[1].strip()
         assert rendered_name == test_output


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #582 

Changes proposed in this pull request:

 - Navigation Breadcrumbs for Office Page

## Notes for Deployment

Nuns.

## Screenshots (if appropriate)

![breadcrumbs](https://user-images.githubusercontent.com/5983782/50061707-ae13aa00-0170-11e9-9c3e-3991f30aac8c.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass - broken on master???
