### PR TITLE
allow supplying test names to make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ populate: create_db  ## Build and run containers
 
 .PHONY: test
 test: start  ## Run tests
-	docker-compose run --rm web /usr/local/bin/pytest -v tests/
+	if [ -z "$(name)" ]; \
+	    then docker-compose run --rm web /usr/local/bin/pytest -v tests/; \
+	    else docker-compose run --rm web /usr/local/bin/pytest -v tests/ -k $(name); \
+	fi
 
 .PHONY: stop
 stop:  ## Stop containers


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Updated Makefile to handle test names when running `make test`, e.g., `make test name=test_ac_cannot_update_users_to_ac`.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass (n/a)
