### PR TITLE
Parallelize tests: 100s speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - pip install coveralls
   - cd OpenOversight
 script:
-  - py.test -v --cov=app
+  - py.test -v -n 4 --dist=loadfile --cov=app
   - cd .. && flake8 --ignore=E501,E722
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ populate: create_db  ## Build and run containers
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; \
-	    then docker-compose run --rm web /usr/local/bin/pytest -v tests/; \
-	    else docker-compose run --rm web /usr/local/bin/pytest -v tests/ -k $(name); \
+	    then docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/; \
+	    else docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
 	fi
 
 .PHONY: stop

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,8 @@
 flake8==3.5.0
 selenium==3.14.0
 nose>=1.3.1
-pytest==3.0.3
+pytest==4.0.2
+pytest-xdist==1.25.0
 faker==0.7.3
 pytest-cov==2.4.0
 pytest-pep8==1.0.6


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - Tests were starting to get a bit slow, so they are now run by multiple workers and distributed one test file per worker such that the selenium tests don't need to be modified (they fail if run in parallel as is)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
