### PR TITLE
Improve wording on sort page

### DIFF
--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -30,7 +30,7 @@ $(document).bind('keydown', 's', function(){
       {% if image and current_user.is_disabled == False %}
       <div class="row">
         <div class="text-center">
-          <h1><small>Do you see law enforcement officers in the photo?</small></h1>
+          <h1><small>Do you see uniformed law enforcement officers in the photo?</small></h1>
         </div>
       </div>
 

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -85,7 +85,7 @@ def test_logged_in_user_can_access_sort_form(mockdata, client, session):
             url_for('main.sort_images', department_id=1),
             follow_redirects=True
         )
-        assert b'Do you see law enforcement officers in the photo' in rv.data
+        assert b'Do you see uniformed law enforcement officers in the photo' in rv.data
 
 
 def test_user_can_view_submission(mockdata, client, session):


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Simply changes the wording on the sort page to ask "Is there a *Uniformed* officer in this photo?" I myself was confused by the original wording the first time I clicked "volunteer" on OO.

## Notes for Deployment

None

## Screenshots (if appropriate)

N/A

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
