### PR TITLE
Email settings pulled from environment vars if available

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -17,16 +17,16 @@ class BaseConfig(object):
 
     # Form Settings
     WTF_CSRF_ENABLED = True
-    SECRET_KEY = 'changemeplzorelsehax'
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'changemeplzorelsehax')
 
     # Mail Settings
-    MAIL_SERVER = 'smtp.googlemail.com'
+    MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp.googlemail.com')
     MAIL_PORT = 587
     MAIL_USE_TLS = True
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
-    OO_MAIL_SUBJECT_PREFIX = '[OpenOversight]'
-    OO_MAIL_SENDER = 'OpenOversight <OpenOversight@gmail.com>'
+    OO_MAIL_SUBJECT_PREFIX = os.environ.get('OO_MAIL_SUBJECT_PREFIX', '[OpenOversight]')
+    OO_MAIL_SENDER = os.environ.get('OO_MAIL_SENDER', 'OpenOversight <OpenOversight@gmail.com>')
     # OO_ADMIN = os.environ.get('OO_ADMIN')
 
     # AWS Settings


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

These changes will cause OO to get additional email settings and the CSRF secret key from environment variables if available, but keeping the same default values.

To test, add `MAIL_SERVER`, `OO_MAIL_SUBJECT_PREFIX`, `OO_MAIL_SENDER` to `.env` and perform an action that sends an email (like user account registration).

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
