### PR TITLE
Replace generated docker container names with docker-compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ start: build  ## Run containers
 
 .PHONY: create_db
 create_db: start
-	@until docker exec -it openoversight_postgres_1 psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+	@until docker-compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
 		echo "Postgres is unavailable - sleeping..."; \
 		sleep 1; \
 	done
@@ -23,7 +23,7 @@ dev: build start create_db populate
 
 .PHONY: populate
 populate: create_db  ## Build and run containers
-	@until docker exec -it openoversight_postgres_1 psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+	@until docker-compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
 		echo "Postgres is unavailable - sleeping..."; \
 		sleep 1; \
 	done
@@ -44,8 +44,7 @@ stop:  ## Stop containers
 
 .PHONY: clean
 clean: stop  ## Remove containers
-	docker rm openoversight_web_1 || true
-	docker rm openoversight_postgres_1 || true
+	docker-compose rm -f
 
 .PHONY: clean_all
 clean_all: clean stop ## Wipe database


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Several Makefile commands refer to docker containers by their generated names (e.g. `openoversight_web_1`). When I cloned a second development environment, the generated names were different (e.g. `openoversight2_web_1`), which caused the commands to fail. These fixes use docker-compose commands instead, which can refer to services rather than specific containers.

To test, run `make dev` and `make clean_all`.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
