### PR TITLE
Fix S3 image upload and explain how to use in dev

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -37,6 +37,24 @@ $ docker exec -it openoversight_web_1 /bin/bash
 
 Once you're done, `make stop` and `make clean` to stop and remove the containers respectively.
 
+## Testing S3 Functionality
+
+We use an S3 bucket for image uploads. If you are working on functionality involving image uploads,
+then you should follow the "S3 Image Hosting" section in [DEPLOY.md](/DEPLOY.md) to make a test S3 bucket
+on Amazon Web Services.
+
+Once you have done this, you can put your AWS credentials in the following environmental variables:
+
+```sh
+$ export S3_BUCKET_NAME=openoversight-test
+$ export AWS_ACCESS_KEY_ID=testtest
+$ export AWS_SECRET_ACCESS_KEY=testtest
+$ export AWS_DEFAULT_REGION=us-east-1
+```
+
+Now when you run `make dev` as usual in the same session, you will be able to submit images to
+your test bucket.
+
 ## Database commands
 
 Running `make dev` will create the database and persist it into your local filesystem.

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -708,7 +708,7 @@ def upload(department_id):
     # Save temporarily on local filesystem
     tmpdir = tempfile.mkdtemp()
     safe_local_path = os.path.join(tmpdir, new_filename)
-    with open(safe_local_path, 'w') as tmp:
+    with open(safe_local_path, 'wb') as tmp:
         tmp.write(image_data)
     os.umask(SAVED_UMASK)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,14 @@ services:
      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
+     FLASK_APP: app
+     FLASK_ENV: development
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
    links:
      - postgres:postgres
    expose:
      - "3000"
-   command: /usr/local/bin/gunicorn --reload -w 4 -b 0.0.0.0:3000 app:app
+   command: flask run --host=0.0.0.0 --port=3000
    ports:
      - "3000:3000"


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This PR has some dev agility fixes based on issues recent contributors have ran into

Changes proposed in this pull request:

 - Minor python 2/python 3 fix in upload function
 - Add docs explaining how to use a test S3 bucket with the dev environment
 - Run server in debug mode using flask dev server

## Notes for Deployment

Worth double checking image upload on staging

## Screenshots (if appropriate)

One should follow the instructions here and be able to upload successfully via the dev container: 

<img width="685" alt="screen shot 2019-01-05 at 4 13 20 pm" src="https://user-images.githubusercontent.com/7832803/50730681-d8b9a880-1107-11e9-8245-6974f9ecf55d.png">

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
