### PR TITLE
Pull FLASK_ENV from host environment so tests will run in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ populate: create_db  ## Build and run containers
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; \
-	    then docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/; \
-	    else docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
+	    then FLASK_ENV=testing docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/; \
+	    else FLASK_ENV=testing docker-compose run --rm web /usr/local/bin/pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
 	fi
 
 .PHONY: stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
      FLASK_APP: app
-     FLASK_ENV: development
+     FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
    links:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Commit f850c0f44262617c9f101b257951b208f61b7869 added the `FLASK_ENV` environment variable to the docker web service. Because it is set to `development`, pytest will fail when run within docker, such as when you run `make test`.

This fix pulls FLASK_ENV from the host environment so that `make test` will run without error.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
