### PR TITLE
Fixing #580

### DIFF
--- a/OpenOversight/migrations/versions/2a9064a2507c_remove_dots_middle_initial.py
+++ b/OpenOversight/migrations/versions/2a9064a2507c_remove_dots_middle_initial.py
@@ -1,0 +1,30 @@
+"""remove_dots_middle_initial
+
+Revision ID: 2a9064a2507c
+Revises: e2c2efde8b55
+Create Date: 2019-02-03 05:33:05.296642
+
+"""
+from flask import current_app
+import os
+import sys
+# Add our Flask app to the search paths for modules
+sys.path.insert(0, os.path.dirname(current_app.root_path))
+from app.models import Officer, db  # noqa: E402
+
+
+# revision identifiers, used by Alembic.
+revision = '2a9064a2507c'
+down_revision = 'e2c2efde8b55'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    for officer in Officer.query.filter(Officer.middle_initial.in_([".", "-"])).all():
+        officer.middle_initial = ""
+        db.session.commit()
+
+
+def downgrade():
+    pass

--- a/OpenOversight/migrations/versions/2a9064a2507c_remove_dots_middle_initial.py
+++ b/OpenOversight/migrations/versions/2a9064a2507c_remove_dots_middle_initial.py
@@ -1,7 +1,7 @@
 """remove_dots_middle_initial
 
 Revision ID: 2a9064a2507c
-Revises: e2c2efde8b55
+Revises: 5c5b80cab45e
 Create Date: 2019-02-03 05:33:05.296642
 
 """
@@ -15,7 +15,7 @@ from app.models import Officer, db  # noqa: E402
 
 # revision identifiers, used by Alembic.
 revision = '2a9064a2507c'
-down_revision = 'e2c2efde8b55'
+down_revision = '5c5b80cab45e'
 branch_labels = None
 depends_on = None
 

--- a/OpenOversight/migrations/versions/5c5b80cab45e_add_approved.py
+++ b/OpenOversight/migrations/versions/5c5b80cab45e_add_approved.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5c5b80cab45e'
-down_revision = '9e2827dae28c'
+down_revision = 'e2c2efde8b55'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Migration script to remove "." and "-" entries for middle initial of officers.

## Status

Ready for review

## Description of Changes

Fixes #580 

Changes proposed in this pull request:

 - Quick migration script that removes entries that only have a dot "." or a dash "-"

### Remarks 
 - I haven't done a migration script before. But it did what it's supposed to be doing on my version
- I followed what's done in 59e9993c169c_change_faces_to_thumbnails.py for the import of app.models, not sure if a more "database-centric" (without using the model) approach is preferred.


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
