### PR TITLE
requirements: specify to install psycopg2 from source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.3.2
 Flask-WTF==0.14.2
 Pillow==5.1.0
-psycopg2>=2.6.2
+psycopg2>=2.6.2 --no-binary psycopg2
 SQLAlchemy==1.1.15
 gunicorn==19.9
 Fabric==1.14.0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

(Fixing this because it's causing confusion for new contributors, supercedes #618)

Previously we were getting a warning about the fact that the built
wheel packages for psycopg2 are to be distributed under another name,
psycopg2-binary. These wheels are recommended [in the docs](http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
) not for
production use. Let's keep what we have now and suppress the warning via specifying
--no-binary in the requirements file (also see the psycopg2 issue comment [here](https://github.com/psycopg/psycopg2/issues/674#issuecomment-434352029)).

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
