### PR TITLE
Remove errant format_exc param in views

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -134,7 +134,7 @@ def officer_profile(officer_id):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error finding officer: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
 
     try:
@@ -147,7 +147,7 @@ def officer_profile(officer_id):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error loading officer profile: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
 
     return render_template('officer.html', officer=officer, paths=face_paths,
@@ -255,7 +255,7 @@ def classify_submission(image_id, contains_cops):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error classifying image: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
     return redirect(redirect_url())
     # return redirect(url_for('main.display_submission', image_id=image_id))
@@ -442,7 +442,7 @@ def delete_tag(tag_id):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error classifying image: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
     return redirect(url_for('main.index'))
 
@@ -737,7 +737,7 @@ def upload(department_id):
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error('Error uploading to S3: {}'.format(
             ' '.join([str(exception_type), str(value),
-                      format_exc(full_tback)])
+                      format_exc()])
         ))
         return jsonify(error="Server error encountered. Try again later."), 500
     os.remove(safe_local_path)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes exception handling as in 3123aa2

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
