### PR TITLE
Decode generated tokens to fix environment-specific bug

### DIFF
--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -348,7 +348,7 @@ class User(UserMixin, db.Model):
 
     def generate_confirmation_token(self, expiration=3600):
         s = Serializer(current_app.config['SECRET_KEY'], expiration)
-        return s.dumps({'confirm': self.id})
+        return s.dumps({'confirm': self.id}).decode('utf-8')
 
     def confirm(self, token):
         s = Serializer(current_app.config['SECRET_KEY'])
@@ -364,7 +364,7 @@ class User(UserMixin, db.Model):
 
     def generate_reset_token(self, expiration=3600):
         s = Serializer(current_app.config['SECRET_KEY'], expiration)
-        return s.dumps({'reset': self.id})
+        return s.dumps({'reset': self.id}).decode('utf-8')
 
     def reset_password(self, token, new_password):
         s = Serializer(current_app.config['SECRET_KEY'])
@@ -380,7 +380,7 @@ class User(UserMixin, db.Model):
 
     def generate_email_change_token(self, new_email, expiration=3600):
         s = Serializer(current_app.config['SECRET_KEY'], expiration)
-        return s.dumps({'change_email': self.id, 'new_email': new_email})
+        return s.dumps({'change_email': self.id, 'new_email': new_email}).decode('utf-8')
 
     def change_email(self, token):
         s = Serializer(current_app.config['SECRET_KEY'])


### PR DESCRIPTION
## Status

Ready for review. Big thanks to @McEileen for helping to troubleshoot this!

## Description of Changes

This fixes a weird bug we were seeing that seemed to only occur in Linux environments. As far as I can tell, the generated tokens used in the user registration system were being deserialized as bytes rather than strings in some environments, causing 3 tests to fail. This fixes that by ensuring generated tokens are deserialized and decoded into utf-8 strings.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
