### PR TITLE
remove out of date test credentials

### DIFF
--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -214,9 +214,9 @@ def mockdata(session):
                             confirmed=True)
     session.add(test_user)
 
-    test_admin = models.User(email='redshiftzero@example.org',
+    test_admin = models.User(email='test@example.org',
                              username='test_admin',
-                             password='cat',
+                             password='testtest',
                              confirmed=True,
                              is_administrator=True)
     session.add(test_admin)

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -17,8 +17,8 @@ def login_user(client):
 
 
 def login_admin(client):
-    form = LoginForm(email='redshiftzero@example.org',
-                     password='cat',
+    form = LoginForm(email='test@example.org',
+                     password='testtest',
                      remember_me=True)
     rv = client.post(
         url_for('auth.login'),

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -105,10 +105,10 @@ def test_lastname_capitalization(mockdata, browser):
     # get past the login page
     elem = browser.find_element_by_id("email")
     elem.clear()
-    elem.send_keys("redshiftzero@example.org")
+    elem.send_keys("test@example.org")
     elem = browser.find_element_by_id("password")
     elem.clear()
-    elem.send_keys("cat")
+    elem.send_keys("testtest")
     browser.find_element_by_id("submit").click()
     wait_for_element(browser, By.ID, "cpd")
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ make dev
 
 And open `http://localhost:3000` in your favorite browser!
 
-If you need to log in, use the auto-generated test account
-credentials:
-
-```
-Email: test@example.org
-Password: testtest
-```
-
 Please see [CONTRIB.md](/CONTRIB.md) for the full developer setup instructions.
 
 ## Documentation Quickstart

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ make dev
 
 And open `http://localhost:3000` in your favorite browser!
 
+If you need to log in, use the auto-generated test account
+credentials:
+
+```
+Email: test@example.org
+Password: testtest
+```
+
 Please see [CONTRIB.md](/CONTRIB.md) for the full developer setup instructions.
 
 ## Documentation Quickstart


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #649.

Changes proposed in this pull request:

 - Remove from `README.md` log-in credentials that didn't work 

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
I didn't run pytests because I only changed documentation.

 - [ ] `flake8` checks pass
I didn't run `flake8` because I only changed documentation.