### PR TITLE
add explanation of bug where werkzeug reloader starts two pdb process…

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -186,6 +186,12 @@ In `docker-compose.yml`, below the line specifying the port number, add the foll
    stdin_open: true
    tty: true    
 ```
+Also in `docker-compose.yml`, below the line specifying the `FLASK_ENV`, add the following to the `environment` portion of the `web` service:
+```yml
+  FLASK_DEBUG: 0
+```
+The above line disables the werkzeug reloader, which can otherwise cause a bug when you place a breakpoint in code that loads at import time, such as classes.  The werkzeug reloader will start one pdb process at import time and one when you navigate to the class.  This makes it impossible to interact with the pdb prompt, but we can fix it by disabling the reloader.
+    
 To set a breakpoint in OpenOversight, first import the pdb module by adding `import pdb` to the file you want to debug.  Call `pdb.set_trace()` on its own line wherever you want to break for debugging.
 Next, in your terminal run `docker ps` to find the container id of the `openoversight_web` image, then run `docker attach ${container_id}` to connect to the debugger in your terminal.  You can now use pdb prompts to step through the app.
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #638 and builds off the recently-closed PR #640.

Changes proposed in this pull request:

 - Explains how to set a pdb breakpoint in code that is loaded at import time.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
I didn't run pytests because I only changed documentation.

 - [ ] `flake8` checks pass
I didn't run `flake8` because I only changed documentation.