### PR TITLE
Only display overtime pay if it is greater than zero

### DIFF
--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -200,7 +200,11 @@
           <tr>
             <td>{{ '${:,.2f}'.format(salary.salary) }}</td>
             {% if salary.overtime_pay %}
-            <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
+              {% if salary.overtime_pay > 0 %}
+              <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
+              {% else %}
+              <td></td>
+              {% endif %}
             <td>{{ '${:,.2f}'.format(salary.salary + salary.overtime_pay) }}</td>
             {% else %}
             <td></td>


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Tiny change that only shows overtime pay on officer profiles when it's greater than zero. For some of the officer salary data I have, they have a higher annual salary than their total annual pay, and IMO it doesn't really make sense to display a negative overtime amount.

## Notes for Deployment

## Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/2007008/56910705-37b97980-6a79-11e9-9af2-39cab9a818d8.png)

After:
![image](https://user-images.githubusercontent.com/2007008/56910715-3be59700-6a79-11e9-8f34-d6f6ff348432.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
