### PR TITLE
581/display long incident descriptions

### DIFF
--- a/OpenOversight/app/static/js/incidentDescription.js
+++ b/OpenOversight/app/static/js/incidentDescription.js
@@ -1,0 +1,17 @@
+$(document).ready(function() {
+    $(".incident-description").each(function () {
+        let description = this;
+        let incidentId = $( this ).data("incident");
+        if (description.innerText.length < 300) {
+            $("#description-overflow-row_" + incidentId).hide();
+        }
+        if(description.innerText.length > 300) {
+            let originalDescription = description.innerText;
+            description.innerText = description.innerText.substring(0, 300);
+            $(`#description-overflow-button_${incidentId}`).on('click', function(event) {
+                description.innerText = originalDescription;
+                $("#description-overflow-row_" + incidentId).hide();
+            })
+        }
+    })
+});

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -262,15 +262,15 @@
         	<li class="list-group-item">
           	<h4>
               	<a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
-              	Incident {{ incident.report_number }}
-            	</a>
+              	  Incident {{ incident.report_number }}
+            	  </a>
             	{% if current_user.is_administrator
               	or (current_user.is_area_coordinator and current_user.ac_department_id == incident.department_id) %}
              	<a href="{{ url_for('main.incident_api', obj_id=incident.id) + '/edit' }}">
               	<i class="fa fa-pencil-square-o" aria-hidden="true"></i>
             	</a>
             	{% endif %}
-          	</h4>
+            </h4>
           	{% include 'partials/incident_fields.html' %}
         	</li>
       	{% endfor %}

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -37,7 +37,17 @@
 		{% if not detail %}
 			<tr>
 				<td><strong>Description</strong></td>
-				<td>{{ incident.description|truncate(300) }}</td>
+				<td class="incident-description" id="incident-description_{{incident.id}}" data-incident='{{incident.id | tojson}}'>
+					{{ incident.description }}
+				</td>
+			</tr>
+			<tr id="description-overflow-row_{{ incident.id }}" >
+				<td></td>
+				<td id="description-overflow-cell_{{ incident.id }}">
+					<button id="description-overflow-button_{{ incident.id }}">
+						Click to read more
+					</button>
+				</td>
 			</tr>
 		{% endif %}
 		{% with address=incident.address %}
@@ -73,3 +83,9 @@
 		{% endif %}
 	</tbody>
 </table>
+
+{% block js_footer %}
+	<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+	<script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+	<script src="{{ url_for('static', filename='js/incidentDescription.js') }}"></script>
+{% endblock %}

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -42,8 +42,8 @@
 				</td>
 			</tr>
 			<tr id="description-overflow-row_{{ incident.id }}" >
-				<td></td>
-				<td id="description-overflow-cell_{{ incident.id }}">
+				<td style="border-top: none"></td>
+				<td style="border-top: none" id="description-overflow-cell_{{ incident.id }}">
 					<button id="description-overflow-button_{{ incident.id }}">
 						Click to read more
 					</button>

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -352,6 +352,18 @@ def mockdata(session):
             creator_id=2,
             last_updated_id=1
         ),
+        models.Incident(
+            date=datetime(2019, 1, 15),
+            report_number='39',
+            description='A test description that has over 300 chars. The purpose is to see how to display a larger descrption. Descriptions can get lengthy. So lengthy. It is a description with a lot to say. Descriptions can get lengthy. So lengthy. It is a description with a lot to say. Descriptions can get lengthy. So lengthy. It is a description with a lot to say. Lengthy lengthy lengthy.',
+            department_id=2,
+            address=test_addresses[1],
+            license_plates=[test_license_plates[0]],
+            links=test_links,
+            officers=[all_officers[o] for o in range(1)],
+            creator_id=2,
+            last_updated_id=1
+        ),
     ]
     session.add_all(test_incidents)
     session.commit()

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -548,10 +548,11 @@ def test_users_can_view_incidents_by_department(mockdata, client, session):
             url_for('main.incident_api', department_id=department.id))
 
         # Requires that report numbers in test data not include other report numbers
+        # Tests for report numbers in table formatting, because testing for the raw report number can get false positives due to html encoding
         for incident in department_incidents:
-            assert incident.report_number in rv.data.decode('utf-8')
+            assert '<td>{}</td>'.format(incident.report_number) in rv.data.decode('utf-8')
         for incident in non_department_incidents:
-            assert incident.report_number not in rv.data.decode('utf-8')
+            assert '<td>{}</td>'.format(incident.report_number) not in rv.data.decode('utf-8')
 
 
 def test_admins_can_see_who_created_incidents(mockdata, client, session):

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -5,7 +5,8 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.common.by import By
-from OpenOversight.app.models import Officer, Department
+from sqlalchemy.sql.expression import func
+from OpenOversight.app.models import Officer, Incident, Department
 from OpenOversight.app.config import BaseConfig
 
 
@@ -160,3 +161,53 @@ def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(mockdata, b
 
     results = browser.find_elements_by_id("#uii-question")
     assert len(results) is 0
+
+
+def test_incident_detail_display_read_more_button_for_descriptions_over_300_chars(mockdata, browser):
+    # Navigate to profile page for officer with short and long incident descriptions
+    browser.get("http://localhost:5000/officer/1")
+
+    incident_long_descrip = Incident.query.filter(func.length(Incident.description) > 300).one_or_none()
+    incident_id = str(incident_long_descrip.id)
+
+    result = browser.find_element_by_id("description-overflow-row_" + incident_id)
+    assert result.is_displayed()
+
+
+def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_300_chars(mockdata, browser):
+    # Navigate to profile page for officer with short and long incident descriptions
+    browser.get("http://localhost:5000/officer/1")
+
+    # Select incident for officer that has description under 300 chars
+    result = browser.find_element_by_id("description-overflow-row_1")
+    assert not result.is_displayed()
+
+
+def test_click_to_read_more_displays_full_description(mockdata, browser):
+    # Navigate to profile page for officer with short and long incident descriptions
+    browser.get("http://localhost:5000/officer/1")
+
+    incident_long_descrip = Incident.query.filter(func.length(Incident.description) > 300).one_or_none()
+    orig_descrip = incident_long_descrip.description
+    incident_id = str(incident_long_descrip.id)
+
+    button = browser.find_element_by_id("description-overflow-button_" + incident_id)
+    button.click()
+
+    description_text = browser.find_element_by_id("incident-description_" + incident_id).text
+    assert len(description_text) == len(orig_descrip)
+    assert description_text == orig_descrip
+
+
+def test_click_to_read_more_hides_the_read_more_button(mockdata, browser):
+    # Navigate to profile page for officer with short and long incident descriptions
+    browser.get("http://localhost:5000/officer/1")
+
+    incident_long_descrip = Incident.query.filter(func.length(Incident.description) > 300).one_or_none()
+    incident_id = str(incident_long_descrip.id)
+
+    button = browser.find_element_by_id("description-overflow-button_" + incident_id)
+    button.click()
+
+    buttonRow = browser.find_element_by_id("description-overflow-row_" + incident_id)
+    assert not buttonRow.is_displayed()


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Fixes #581.

Changes proposed in this pull request:
 
 - If an incident description is over 300 chars, show a "read more" button.
 - Clicking on "read more" displays the full incident description.
 - After the user clicks on "read more," the "read more" button is hidden. 

## Notes for Deployment

## Screenshots (if appropriate)
Description before the button is clicked.
![2019-05-02-163053_924x298_scrot](https://user-images.githubusercontent.com/5529982/57151683-8891e080-6d9f-11e9-80ec-96ddf0fcb0bc.png)

Description once the button is clicked.
![2019-05-03-123524_1469x257_scrot](https://user-images.githubusercontent.com/5529982/57151844-f3dbb280-6d9f-11e9-8561-95034c95ccc2.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass