### PR TITLE
Locally build and ship assets to remote servers

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -54,7 +54,7 @@ def deploy():
                 run('su %s -c "PATH=%s/bin:$PATH pip install -r requirements.txt"' % (env.unprivileged_user, env.venv_dir))
                 run('su %s -c "mkdir --parents %s/OpenOversight/app/static/dist"' % (env.unprivileged_user, env.code_dir))
                 put(local_path=os.path.join('OpenOversight', 'app', 'static', 'dist'),
-                    remote_path=os.path.join(env.code_dir, 'OpenOversight', 'app', 'static', 'dist')
+                    remote_path=os.path.join(env.code_dir, 'OpenOversight', 'app', 'static')
                     )
                 run('sudo systemctl restart openoversight')
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -16,7 +16,6 @@ env.use_ssh_config = False
 # being done in dev to assign env a key_filename
 
 
-
 def staging():
     env.environment = 'staging'
     env.user = 'root'
@@ -37,6 +36,7 @@ def production():
     env.code_dir = '/home/nginx/oovirtenv/OpenOversight'
     env.backup_dir = '/home/nginx/openoversight_backup'
     env.s3bucket = 'openoversight-prod'
+
 
 env.roledefs = {
     'staging': staging(),


### PR DESCRIPTION
First pass, so we can at least get deploying unblocked.

Two things I'd like to add later:
* make sure we're on a appropriate branch with a clean workdir
* wipe out remote static/dist/ dir before scping new files

But this will suffice to unblock deploys. Still requiring python2
fabric, unfortunately. Sloppily fixes #658.

## Status

Ready for review / in progress

## Description of Changes

Fixes #658.

## Notes for Deployment
- Makes it possible again

## Tests and linting

 - [x] I have rebased my changes on current `develop`
 - [ ] pytests pass in the development environment on my local machine (unrelated, see #671)
 - [x] `flake8` checks pass
