### PR TITLE
test: add test for branching database migration history

### DIFF
--- a/OpenOversight/tests/test_alembic.py
+++ b/OpenOversight/tests/test_alembic.py
@@ -1,0 +1,12 @@
+from flask import current_app
+from alembic.script import ScriptDirectory
+
+
+def test_alembic_has_single_head(session):
+    """
+    Avoid unintentional branches in the migration history.
+    """
+    migrations_dir = current_app.extensions['migrate'].directory
+    heads = ScriptDirectory(migrations_dir).get_heads()
+
+    assert len(heads) == 1


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This is a test to guard against branching migrations history (see: https://github.com/lucyparsons/OpenOversight/pull/671). We _could_ force the rebase of all PRs on the very latest `develop` prior to merge so that this test will prevent the merge of any branching migrations (without that, even with this test it's still possible that branching migrations will land in `develop` if a PR's CI run occurred on an out-of-date `develop`), but that will produce even more slowdown to merge. With this test we'll at least be alerted in `develop` (and more likely prior to merge) by failing the `develop` build, at which time we can address and fix. 

## Notes for Deployment

Test only

## Tests and linting

 - [ ] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
