### PR TITLE
ci: add separate lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  lint:
+    docker:
+      - image: circleci/python
+    steps:
+      - checkout
+      - run:
+          name: Install lint dependencies and run linting
+          command: |
+            virtualenv .venv
+            source .venv/bin/activate
+            pip install flake8==3.5.0
+            flake8 --ignore=E501,E722 --exclude=.venv/
+workflows:
+  version: 2
+  per_pr:
+    jobs:
+      - lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ before_install:
 install:
   - true
 before_script:
-  - pip install coveralls flake8==3.5.0
+  - pip install coveralls
   - sudo service postgresql stop
 script:
   - sudo make test
-  - flake8 --ignore=E501,E722
 after_success:
   - coveralls


### PR DESCRIPTION
I'm mostly adding this because I turned on Circle CI building for the CD
pipeline in PR #685 and I don't want our CI checks to have a red build indicator
until that PR is merged, so this PR moves linting checks from Travis into a separate CI job
