### PR TITLE
converts bad photo file extensions (supercedes 404/412)

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -37,7 +37,8 @@ class BaseConfig(object):
 
     # Upload Settings
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024
-    ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif'])
+    ALLOWED_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif', 'psd', 'tiff'])
+    PHOTO_REQUIRES_CONV = set(['tiff', 'psd'])
 
     # User settings
     APPROVE_REGISTRATIONS = os.environ.get('APPROVE_REGISTRATIONS', False)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -22,7 +22,8 @@ from ..utils import (roster_lookup, upload_file, compute_hash,
                      ac_can_edit_officer, add_department_query, add_unit_query,
                      create_incident, get_or_create, replace_list,
                      set_dynamic_default, create_note, get_uploaded_cropped_image,
-                     create_description, filter_by_form, dept_choices)
+                     create_description, filter_by_form, dept_choices,
+                     requires_conversion, convert_image)
 
 from .forms import (FindOfficerForm, FindOfficerIDForm, AddUnitForm,
                     FaceTag, AssignmentForm, DepartmentForm, AddOfficerForm,
@@ -848,6 +849,8 @@ def upload(department_id):
     file_to_upload = request.files['file']
     if not allowed_file(file_to_upload.filename):
         return jsonify(error="File type not allowed!"), 415
+    if requires_conversion(file_to_upload.filename):
+        convert_image(file_to_upload.filename)
     original_filename = secure_filename(file_to_upload.filename)
     image_data = file_to_upload.read()
 

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -189,6 +189,21 @@ def allowed_file(filename):
            filename.rsplit('.', 1)[1].lower() in current_app.config['ALLOWED_EXTENSIONS']
 
 
+def requires_conversion(filename):
+    return '.' in filename and \
+        filename.split('.', 1)[1].lower() in current_app.config['PHOTO_REQUIRES_CONV']
+
+
+def convert_image(filename):
+    try:
+        img_to_change = Pimage.open(filename)
+    except Pimage.DecompressionBombWarning:
+        return None
+    basename = os.path.splitext(filename)[0].split('.')
+    fixed_img = img_to_change.save(basename + 'jpeg')
+    return fixed_img
+
+
 def get_random_image(image_query):
     if image_query.count() > 0:
         rand = random.randrange(0, image_query.count())

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -151,7 +151,7 @@ def test_s3_upload_jpeg(mockdata):
 
 
 def test_user_can_submit_allowed_file(mockdata):
-    for file_to_submit in ['valid_photo.png', 'valid_photo.jpg', 'valid.photo.jpg', 'valid_photo.PNG', 'valid_photo.JPG']:
+    for file_to_submit in ['valid_photo.png', 'valid_photo.jpg', 'valid.photo.jpg', 'valid_photo.PNG', 'valid_photo.JPG', 'valid_photo.TIFF', 'valid_photo.tiff', 'valid_photo.psd', 'valid_photo.PSD']:
         assert OpenOversight.app.utils.allowed_file(file_to_submit) is True
 
 


### PR DESCRIPTION
Resolves #369 and supercedes PRs #404 and #412. I made a real mess of this issue, and I figured a new branch is the cleanest fix since that was a while ago.

## Status

WIP

## Description of Changes

Fixes # 369.

Changes proposed in this pull request:

 - Convert psd and tiff files to jpeg
 - Test that tiff and psd files can be uploaded
- Note: avoided using os.open, I don't believe this is necessary and avoids dealing with safety warnings

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine
*Note*: I get 'TypeError: attrib() got an unexpected keyword argument 'convert' when I `make test`. This seems to be an issue with the package attrs rather than anything I changed, but please let me know if this is not correct. 

 - [ ] `flake8` checks pass
