### PR TITLE
Bump Flask-WTF version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.3.2
-Flask-WTF==0.14.2
+Flask-WTF==0.14.3
 Pillow>=5.2.0
 psycopg2>=2.6.2 --no-binary psycopg2
 SQLAlchemy==1.1.15


### PR DESCRIPTION
Fixes https://github.com/lucyparsons/OpenOversight/issues/699

## Status

Ready for review

## Description of Changes

Just bumps the Flask-WTF according to @redshiftzero's suggestion in https://github.com/lucyparsons/OpenOversight/issues/699.

Changes proposed in this pull request:
 - Bump Flask-WTF from 0.14.2 to 0.14.3 (the latest version at the time of writing).

## Notes for Deployment
None.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
       These don't pass either, but it's nothing I changed on this PR.
