### PR TITLE
Add an undecorated version of the mockdata func

### DIFF
--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -214,8 +214,7 @@ def test_jpg_BytesIO():
     return byte_io
 
 
-@pytest.fixture
-def mockdata(session):
+def add_mockdata(session):
     NUM_OFFICERS = current_app.config['NUM_OFFICERS']
     department = models.Department(name='Springfield Police Department',
                                    short_name='SPD', unique_internal_identifier_label='homer_number')
@@ -426,6 +425,11 @@ def mockdata(session):
     session.commit()
 
     return assignments_dept1[0].star_no
+
+
+@pytest.fixture
+def mockdata(session):
+    return add_mockdata(session)
 
 
 @pytest.fixture

--- a/test_data.py
+++ b/test_data.py
@@ -4,7 +4,7 @@ import argparse
 
 from OpenOversight.app import create_app
 from OpenOversight.app.models import db
-from OpenOversight.tests.conftest import mockdata
+from OpenOversight.tests.conftest import add_mockdata
 
 app = create_app('development')
 ctx = app.app_context()
@@ -22,7 +22,7 @@ if __name__ == "__main__":
 
     if args.populate:
         print("[*] Populating database with test data...")
-        mockdata(db.session)
+        add_mockdata(db.session)
         print("[*] Completed successfully!")
 
     if args.cleanup:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

    The function mockdata() in conftest.py apparently needs to be decorated
    as a pytest fixture in order for unit tests to work. However, the test
    data population scripts call mockdata() directly, which leads to an
    error saying pytest fixures cannot be called directly. This fix
    undecorated mockdata(), renames it to add_mockdata(), and adds a
    new, decorated mockdata() function which wraps add_mockdata(). Test data
    script work now, and tests pass.

Fixes https://github.com/lucyparsons/OpenOversight/issues/701.

Changes proposed in this pull request:

- See description, above.

## Notes for Deployment

None that I know of

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
