### PR TITLE
Allow uploading files with the ".jpe" extension

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -37,7 +37,7 @@ class BaseConfig(object):
 
     # Upload Settings
     MAX_CONTENT_LENGTH = 50 * 1024 * 1024
-    ALLOWED_EXTENSIONS = set(['jpeg', 'jpg', 'png', 'gif'])
+    ALLOWED_EXTENSIONS = set(['jpeg', 'jpg', 'jpe', 'png', 'gif'])
 
     # User settings
     APPROVE_REGISTRATIONS = os.environ.get('APPROVE_REGISTRATIONS', False)


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes https://github.com/lucyparsons/OpenOversight/issues/709.

Changes proposed in this pull request:

 - Allow users to upload files ending in ".jpe". This is important because a popular social media site hosts JPEG files with this extension.

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
