### PR TITLE
Docker compose local file permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ create_db: start
 	done
 	@echo "Postgres is up"
 	## Creating database
-	docker-compose run --rm web python ../create_db.py
+	DC_UID=`id -u` docker-compose run --rm web python ../create_db.py
 
 .PHONY: assets
 assets:
-	docker-compose run --rm web yarn build
+	DC_UID=`id -u` docker-compose run --rm web yarn build
 
 .PHONY: dev
 dev: build start create_db populate
@@ -33,13 +33,13 @@ populate: create_db  ## Build and run containers
 	done
 	@echo "Postgres is up"
 	## Populate database with test data
-	docker-compose run --rm web python ../test_data.py -p
+	DC_UID=`id -u` docker-compose run --rm web python ../test_data.py -p
 
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; \
-	    then FLASK_ENV=testing docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/; \
-	    else FLASK_ENV=testing docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
+	    then FLASK_ENV=testing DC_UID=`id -u` docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/; \
+	    else FLASK_ENV=testing DC_UID=`id -u` docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
 	fi
 
 .PHONY: cleanassets

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 default: build start create_db populate test stop clean
 
+export DC_UID := $(shell id -u)
+
 .PHONY: build
 build:  ## Build containers
 	docker-compose build
 
 .PHONY: start
 start: build  ## Run containers
-	DC_UID=`id -u` docker-compose up -d
+	docker-compose up -d
 
 .PHONY: create_db
 create_db: start
@@ -16,11 +18,11 @@ create_db: start
 	done
 	@echo "Postgres is up"
 	## Creating database
-	DC_UID=`id -u` docker-compose run --rm web python ../create_db.py
+	docker-compose run --rm web python ../create_db.py
 
 .PHONY: assets
 assets:
-	DC_UID=`id -u` docker-compose run --rm web yarn build
+	docker-compose run --rm web yarn build
 
 .PHONY: dev
 dev: build start create_db populate
@@ -33,13 +35,13 @@ populate: create_db  ## Build and run containers
 	done
 	@echo "Postgres is up"
 	## Populate database with test data
-	DC_UID=`id -u` docker-compose run --rm web python ../test_data.py -p
+	docker-compose run --rm web python ../test_data.py -p
 
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; \
-	    then FLASK_ENV=testing DC_UID=`id -u` docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/; \
-	    else FLASK_ENV=testing DC_UID=`id -u` docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
+	    then FLASK_ENV=testing docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/; \
+	    else FLASK_ENV=testing docker-compose run --rm web pytest -n 4 --dist=loadfile -v tests/ -k $(name); \
 	fi
 
 .PHONY: cleanassets

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:  ## Build containers
 
 .PHONY: start
 start: build  ## Run containers
-	docker-compose up -d
+	DC_UID=`id -u` docker-compose up -d
 
 .PHONY: create_db
 create_db: start
@@ -56,7 +56,7 @@ clean: cleanassets stop  ## Remove containers
 
 .PHONY: clean_all
 clean_all: clean stop ## Wipe database
-	rm -rf container_data
+	docker-compose down -v
 
 .PHONY: docs
 docs: ## Build project documentation in live reload for editing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 version: "3"
 
+volumes:
+  postgres:
+    driver: local
+
 services:
  postgres:
    restart: always
@@ -9,7 +13,7 @@ services:
      POSTGRES_PASSWORD: terriblepassword
      POSTGRES_DB: openoversight-dev
    volumes:
-     - ./container_data/postgres:/var/lib/postgresql/data
+     - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
 
@@ -30,6 +34,7 @@ services:
      FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
+   user: "${DC_UID}"
    links:
      - postgres:postgres
    expose:

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -22,11 +22,11 @@ RUN pip3 install --no-cache-dir virtualenv
 RUN virtualenv /ve
 ENV PATH=/ve/bin:$PATH
 
-RUN mkdir /var/www ./node_modules; chown -R www-data /var/www /ve ./node_modules
+RUN mkdir /var/www ./node_modules /.cache /.yarn; chown -R www-data /var/www /ve ./node_modules /.cache /.yarn
 RUN touch /usr/src/app/yarn-error.log
 COPY yarn.lock /usr/src/app/
 RUN chown www-data yarn.lock yarn-error.log
-RUN chmod -R 777 /usr/src/app/
+RUN chmod -R 777 /usr/src/app/ /.cache /.yarn
 
 USER www-data
 

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3-stretch
+FROM python:3-buster
 
 WORKDIR /usr/src/app
 
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
-ENV GECKODRIVER_VERSION="v0.23.0"
+ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && apt-get install -y xvfb firefox-esr
 RUN apt-get install -y -t stretch-backports libsqlite3-0
@@ -13,22 +13,14 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_
 RUN mkdir geckodriver
 RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
-RUN apt-get update && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
+RUN wget -O - https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update && apt-get install -y nodejs npm
 RUN npm install -g yarn
 
-RUN pip3 install --no-cache-dir virtualenv
-RUN virtualenv /ve
-ENV PATH=/ve/bin:$PATH
-
-RUN mkdir /var/www ./node_modules /.cache /.yarn; chown -R www-data /var/www /ve ./node_modules /.cache /.yarn
+RUN mkdir /var/www ./node_modules /.cache /.yarn /.mozilla
 RUN touch /usr/src/app/yarn-error.log
 COPY yarn.lock /usr/src/app/
-RUN chown www-data yarn.lock yarn-error.log
-RUN chmod -R 777 /usr/src/app/ /.cache /.yarn
-
-USER www-data
+RUN chmod -R 777 /usr/src/app/ /var/lib/xkb /.cache /.yarn /.mozilla
 
 COPY requirements.txt dev-requirements.txt /usr/src/app/
 RUN pip3 install --no-cache-dir -r requirements.txt
@@ -36,7 +28,6 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 ARG DOCKER_BUILD_ENV
 RUN test "${DOCKER_BUILD_ENV}" = production || pip3 install --no-cache-dir -r dev-requirements.txt
 
-CMD ["/bin/bash"]
 COPY package.json /usr/src/app/
 RUN yarn
 


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #713 

Changes proposed in this pull request:

 - Moves the dev postgres storage to a docker volume, which removes a lot of the difficulties of managing file permissions shared between the docker container and the host. 
 - Sets the web container to run as the same UID as the current user.  That does a couple of things
   - Makes the `__pycache__` directories that get created on the host's filesystem owned by the user, which makes them manageable and deleteable from outside the container.
    - Gives the container process access to the OpenOversight/app/static/dist directory so that css compilation works like you expect, without needing fancy `sudo` tricks.

## Notes for Deployment

- This will invalidate any dev database you currently have.  We're no longer looking at `container_data/postgres` so if there's any data you've got in there that you're particularly fond of, you'll want to find a way to re-create it.
- If you already have a bunch of `__pycache__` directories I can't promise you'll be able to read them.  Same goes for an index.css that was created with the root user.  Honestly your best bet might be to re-clone your git repo.  Alternatively, `sudo find ./ ! -uid "$UID" -delete` would probably work if you're feeling foolishly brave.

## Screenshots (if appropriate)

## Tests and linting
 I tested all of this on a Fedora 31 installation with Docker 19.03 and docker-compose 1.25.4.  I'd appreciate it if someone with a different system could tell me if something obviously goes wrong.  I made sure that SCSS compilation worked, but I'm not super sure what other things I should look at.

 - [/] I have rebased my changes on current `develop`

 - [/] pytests pass in the development environment on my local machine

 - [/] `flake8` checks pass
