### PR TITLE
Modify pager output when search returns no results

### DIFF
--- a/OpenOversight/app/templates/partials/paginate_nav.html
+++ b/OpenOversight/app/templates/partials/paginate_nav.html
@@ -16,6 +16,10 @@
           <span aria-hidden="true">&rarr;</span>
         </a>
       </li>
+      {% elif paginate.total == 0 %}
+          {% if location == 'top' %}
+          Showing 0 of 0
+          {% endif %}
       {% else %}
       Showing {{(paginate.page-1)*paginate.per_page + 1 }}-{{paginate.total}} of {{paginate.total}}
       {% endif %}


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Previously, when no results were returned for a search, the page navigation text output was confusing.  It would display something like "Showing 1 of 0" pages, and this text appeared twice.  This PR makes the text read "Showing 0 of 0" pages, and removes the duplicate text.

Changes proposed in this pull request:

 - Page navigation text reads "Showing 0 of 0" instead of "Showing 1 of 0"
 - When zero results are returned for a search, the "Showing 0 of 0" text is printed only once

## Notes for Deployment

## Screenshots (if appropriate)

Old output when search returns no results:

![Screenshot_2020-06-08 OpenOversight - a Lucy Parsons Labs project(1)](https://user-images.githubusercontent.com/7423402/84073719-0b0aad80-a96d-11ea-9d85-befd17c3ec48.png)

New output when search returns no results:

![Screenshot_2020-06-08 OpenOversight - a Lucy Parsons Labs project](https://user-images.githubusercontent.com/7423402/84073156-fb3e9980-a96b-11ea-8e33-672b65dda35e.png)

## Tests and linting

 - [x ] I have rebased my changes on current `develop`