### PR TITLE
persist deleting rank on department edit page

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -425,11 +425,15 @@ def edit_department(department_id):
                     db.session.commit()
                 except IntegrityError as e:
                     db.session.rollback()
-                    rank = Job.query.filter_by(id=e.params['id']).one()
-                    home_route = url_for('main.index')
-                    print(home_route)
-                    link = '/department/{}?name=&badge=&unique_internal_identifier=&rank={}&min_age=16&max_age=100&submit=Submit'.format(department_id, rank)
-                    flash(Markup('You attempted to delete a rank, {}, that is in use by <a href={}>the linked officers</a>.'.format(rank, link)))
+                    if len(e.params) > 1:
+                        for param in e.params:
+                            rank = Job.query.filter_by(id=param['id']).one()
+                            link = '/department/{}?name=&badge=&unique_internal_identifier=&rank={}&min_age=16&max_age=100&submit=Submit'.format(department_id, rank)
+                            flash(Markup('You attempted to delete a rank, {}, that is in use by <a href={}>the linked officers</a>.'.format(rank, link)))
+                    else:
+                        rank = Job.query.filter_by(id=e.params['id']).one()
+                        link = '/department/{}?name=&badge=&unique_internal_identifier=&rank={}&min_age=16&max_age=100&submit=Submit'.format(department_id, rank)
+                        flash(Markup('You attempted to delete a rank, {}, that is in use by <a href={}>the linked officers</a>.'.format(rank, link)))
                     return redirect(url_for('main.edit_department', department_id=department_id))
             
             for (new_rank, order) in new_ranks:

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -5,12 +5,11 @@ import os
 import re
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql import text
 import sys
 from traceback import format_exc
 
 from flask import (abort, render_template, request, redirect, url_for,
-                   flash, current_app, jsonify, Response)
+                   flash, current_app, jsonify, Response, Markup)
 from flask_login import current_user, login_required, login_user
 
 from . import main
@@ -417,6 +416,22 @@ def edit_department(department_id):
                 if rank:
                     new_ranks.append((rank, order))
                     order += 1
+            updated_ranks = form.jobs.data
+            if len(updated_ranks) < len(original_ranks):
+                deleted_ranks = [rank for rank in original_ranks if rank.job_title not in updated_ranks]
+                for rank in deleted_ranks:
+                    db.session.delete(rank)
+                try:
+                    db.session.commit()
+                except IntegrityError as e:
+                    db.session.rollback()
+                    rank = Job.query.filter_by(id=e.params['id']).one()
+                    home_route = url_for('main.index')
+                    print(home_route)
+                    link = '/department/{}?name=&badge=&unique_internal_identifier=&rank={}&min_age=16&max_age=100&submit=Submit'.format(department_id, rank)
+                    flash(Markup('You attempted to delete a rank, {}, that is in use by <a href={}>the linked officers</a>.'.format(rank, link)))
+                    return redirect(url_for('main.edit_department', department_id=department_id))
+            
             for (new_rank, order) in new_ranks:
                 existing_rank = Job.query.filter_by(department_id=department_id, job_title=new_rank).one_or_none()
                 if existing_rank:
@@ -431,16 +446,6 @@ def edit_department(department_id):
                     ))
             db.session.commit()
 
-            updated_ranks = form.jobs.data
-            if len(updated_ranks) < len(original_ranks):
-                deleted_ranks = [rank for rank in original_ranks if rank.job_title not in updated_ranks]
-                for rank in deleted_ranks:
-                    db.session.delete(rank)
-                db.session.commit()
-            # Prune any jobs from department that aren't referenced by any current officers
-            query = text("DELETE FROM jobs WHERE department_id = :department_id AND is_sworn_officer = False AND NOT EXISTS (SELECT 1 FROM assignments WHERE assignments.job_id = jobs.id)")
-            query = query.bindparams(department_id=department_id)
-            db.session.execute(query)
         flash('Department {} edited'.format(department.name))
         return redirect(url_for('main.list_officer', department_id=department.id))
     else:

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -440,15 +440,15 @@ def test_admin_cannot_delete_rank_in_use(mockdata, client, session):
         rank_change_form = EditDepartmentForm(name='Springfield Police Department', short_name='SPD', jobs=ranks_update)
         processed_data = process_form_data(rank_change_form.data)
 
-        with pytest.raises(IntegrityError):
-            rv = client.post(
-                url_for('main.edit_department', department_id=1),
-                data=processed_data,
-                follow_redirects=True
-            )
+        
+        result = client.post(
+            url_for('main.edit_department', department_id=1),
+            data=processed_data,
+            follow_redirects=True
+        )
 
         updated_ranks = Department.query.filter_by(name='Springfield Police Department').one().jobs
-        assert 'You attempted to delete a rank, Not Sure, that is in use' in rv.data.decode('utf-8')
+        assert 'You attempted to delete a rank, Commander, that is in use' in result.data.decode('utf-8')
         assert len(updated_ranks) == len(original_ranks)
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #708.

Changes proposed in this pull request:

 - Previously, if a user deleted a rank through the department edit page, the change didn't persist.
 - This fix makes the change persist.

## Notes for Deployment
- As of Thursday, June 4, this was the last bug I knew of on staging!

## Screenshots (if appropriate)
I made [a video ](https://www.dropbox.com/s/uzpp06hjyno3qcm/OORankFix.mp4?dl=0)of the functionality. 

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
