### PR TITLE
allow photo submission with only faces, no longer require badges/names in frame

### DIFF
--- a/OpenOversight/app/templates/about.html
+++ b/OpenOversight/app/templates/about.html
@@ -26,7 +26,7 @@
       <span class="fa fa-map-marker fa-2x"></span><p>
         It is the first project of its kind in the United States, and was first implemented in Chicago in October 2016.
         OpenOversight launched in the East Bay of the San Francisco Bay Area in fall 2017 and in New York City in 2018. A
-        Baltimore instance is anticipated to launch in early 2019.
+        Baltimore instance was launched in 2019 at <a href="https://bpdwatch.com">BPDWatch.com</a>.
     </p>
     </div>
     <div class="col-lg-4 col-half-border">
@@ -41,7 +41,7 @@
 <div class="row display-flex  horizontal-padding vertical-padding pb-50">
   <div class="col-lg-6 col-half-no-border bg-light-blue">
     <h2>Legal</h2> <i>A note to law enforcement</i>
-    <p>Illinois: This project does not perform facial recognition and is thus in compliance with the Biometric
+    <p>Illinois: This project does not perform facial recognition on officers in Illinois and is thus in compliance with the Biometric
       Information Privacy Act.
       Requests or questions regarding this project from those affiliated with law enforcement must be directed to our
       legal representation at <a href="mailto:legal@lucyparsonslabs.com">legal@lucyparsonslabs.com</a>.</p>

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -92,13 +92,13 @@
                 </div>
               </p>
 
-	      
+
 	      <div class="text-center input-explanation">
 		<div class="text addface-button-explanation"><b>Explanation</b>: click this button to associate the selected image with the entered OpenOversight ID.</div>
-		<div class="text id-explanation"><b>Explanation</b>: after matching the officer's name or badge number to the roster, enter the officer's OpenOversight ID here.</div>
+		<div class="text id-explanation"><b>Explanation</b>: after matching the officer's name, badge number, or face to the roster, enter the officer's OpenOversight ID here.</div>
 	      </div>
 
-	      
+
           </div>
 
         </div>
@@ -125,8 +125,8 @@
 	</div>
 
       </div>
- 
-      
+
+
       {% elif current_user.is_disabled == True %}
       <h3>Your account has been disabled due to too many incorrect classifications/tags!</h3>
       <p><a href="mailto:info@lucyparsonslabs.com" class="btn btn-lg btn-primary" role="button">Mail us to get it enabled again</a></p>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -35,8 +35,8 @@
                 </h1>
                 <div class="text-gray-lighter">Contribute to the database</div>
                 <p>
-                    Have a photo containing faces and/or badge numbers of uniformed law enforcement officers? Drop them here.
-                    Alternatively, for very high security uploads of photos or videos, you can use our
+                    Have a photo containing uniformed law enforcement officers? Drop them here.
+                    Alternatively, for high security uploads of photos or videos, you can use our
                     <a href="https://lucyparsonslabs.com/securedrop/" target="_blank">SecureDrop</a> tool.
                 </p>
                 <a class="btn btn-lg btn-primary" href="{{ url_for('main.submit_data') }}">

--- a/OpenOversight/app/templates/input_find_ooid.html
+++ b/OpenOversight/app/templates/input_find_ooid.html
@@ -4,7 +4,7 @@
 <div class="container theme-showcase" role="main">
     {% if current_user and current_user.is_authenticated %}
       <div class="page-header">
-        <h2>Find an Officer's OpenOversight ID</h2>
+        <h2>See badge number or name? Lookup an Officer's OpenOversight ID</h2>
       </div>
 
       <p>Use the following form to put in the details you can see in the image. (It's okay if you can only see a partial name or badge number.)</p>
@@ -32,6 +32,14 @@
           <input class="btn btn-lg" type="submit" value="Lookup name/badge number in roster"/>
         </p>
       </form>
+
+      <div class="page-header">
+        <h2>See only a face?</h2>
+      </div>
+
+      <p>
+        <a href="{{ url_for('main.get_officer') }}" class="btn btn-lg">Launch Find an Officer to generate a face gallery</a>
+      </p>
     {% else %}
       <p>Please register or sign up to view this form:</p>
 

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -103,7 +103,7 @@
                         Identify Officers
                     </p>
                     <div class="font-weight-300">
-                        Have a photo containing faces and/or badge numbers of uniformed officers?
+                        Have a photo containing uniformed officers?
                     </div>
                 </div>
                 <div class="col-lg-4 horizontal-padding"">

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -10,7 +10,7 @@
 <div class="container theme-showcase" role="main">
 
    <div class="page-header">
-      <h1>Submit images <small>of officers in uniform. Law enforcement officer faces, and either a badge number or name, should be clearly visible in each photograph.</small></h1>
+      <h1>Submit images <small>of officers in uniform. Officer faces should be clearly visible in each photograph. It is preferred if the name and/or badge number is also visible. <small></h1>
    </div>
 
    <div class="header">
@@ -27,7 +27,7 @@
       <form class="form" name = "deptselect" id = "deptselect" method="post" role="form" label="deptselect">
          {{ wtf.form_field(form.department) }}
       </form>
-      <br> 
+      <br>
    </div>
 
    <h3>Drop images here to submit photos of officers:</h3>
@@ -52,7 +52,7 @@
          // fires when department selection changes
          dept_id = document.getElementById("department").value;
       });
-   }); 
+   });
 
    Dropzone.autoDiscover = false;
    const getURL = (file) => {
@@ -77,7 +77,7 @@
 
 <div class="container">
    <h3>High Security Submissions</h3>
-   <p class="small">We do not log unique identifying information of visitors to our website, but if you have privacy concerns in submitting photographs, we recommend using <a href="https://www.torproject.org/projects/torbrowser.html.en">Tor Browser.</a> For very high security submissions of photos or videos, you can use an anonymous dropbox called SecureDrop (launch instructions below). All files that we receive through SecureDrop are <a href="https://mat.boum.org/">scrubbed of metadata.</a></p>
+   <p class="small">We do not log unique identifying information of visitors to our website, but if you have privacy concerns in submitting photographs, we recommend using <a href="https://www.torproject.org/projects/torbrowser.html.en">Tor Browser.</a> For high security submissions of photos or videos, you can use an anonymous dropbox called SecureDrop (launch instructions below). All files that we receive through SecureDrop are <a href="https://mat.boum.org/">scrubbed of metadata.</a></p>
    <a href="https://lucyparsonslabs.com/securedrop"><img src="{{url_for('static', filename='images/securedrop.png')}}"/> Launch SecureDrop Instructions</a>
 </div>
 

--- a/OpenOversight/app/templates/submit_officer_image.html
+++ b/OpenOversight/app/templates/submit_officer_image.html
@@ -9,7 +9,7 @@
 <div class="container theme-showcase" role="main">
 
    <div class="page-header">
-      <h1>Submit images <small>of {{ officer.full_name() }} in uniform. The officer's face, and either a badge number or name, should be clearly visible in each photograph.</small></h1>
+      <h1>Submit images <small>of {{ officer.full_name() }} in uniform. Officer faces should be clearly visible in each photograph. It is preferred (but not required) for the name and/or badge number to be visible. </small></h1>
    </div>
 
   <div class='header'>

--- a/OpenOversight/app/templates/tutorial.html
+++ b/OpenOversight/app/templates/tutorial.html
@@ -60,7 +60,8 @@
       </div>
 
     <p>Search for the officer using what you can see from their badge number and
-      name. Once you find the officer, look at their <b>OpenOversight ID</b> number in green:</p>
+      name (if available), or by seeing if you can match the officer's face to an existing face in the dataset.
+      Once you find the officer, look at their <b>OpenOversight ID</b> number in green:</p>
 
       <div class="row">
         <div class="col-sm-6 col-md-6">

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 OpenOversight is a Lucy Parsons Labs project to improve law enforcement accountability through public and crowdsourced data. We maintain a database of officer demographic information and provide digital galleries of photographs. This is done to help people identify law enforcement officers for filing complaints and in order for the public to see work-related information about law enforcement officers that interact with the public.
 
-This project is written and maintained by [@lucyparsonslabs](https://twitter.com/lucyparsonslabs) with collaboration, partnerships, and contributions welcome. If you would like to contribute code or documentation, please see our [contributing guide](/CONTRIB.md) and [code of conduct](/CODE_OF_CONDUCT.md). You can get a [tip](#tips) for implementing important issues. If you prefer to contribute in other ways, please submit images to our platform or talk to us about how to help sort and tag images. This project is in public beta, and we are currently soliciting photographs to add to the database.
+This project is written and maintained by [@lucyparsonslabs](https://twitter.com/lucyparsonslabs) with collaboration, partnerships, and contributions welcome. If you would like to contribute code or documentation, please see our [contributing guide](/CONTRIB.md) and [code of conduct](/CODE_OF_CONDUCT.md). If you prefer to contribute in other ways, please submit images to our platform or talk to us about how to help sort and tag images. This project is live, and we are currently soliciting photographs to add to the database.
 
 ## Note to Law Enforcement
 
@@ -13,12 +13,6 @@ Please contact our legal representation with requests, questions, or concerns of
 ## Issues
 
 Please use [our issue tracker](https://github.com/lucyparsons/OpenOversight//issues/new) to submit issues or suggestions.
-
-## Tips
-
-We offer financial tips as a thank you for certain issues being implemented. Please view [issues labeled tip](
-https://github.com/lucyparsons/OpenOversight/issues?q=is%3Aissue+is%3Aopen+label%3Atip) to see which contributions are eligible for tips. If you do not want a tip for that
-contribution, just include "#notip" in your PR description. The amount of the tip depends on the size of the ticket: S ($20), M ($50), and L ($100). Tips are provided once your contribution is merged in (i.e. contributions must have the appropriate unit tests).
 
 ## Developer Quickstart
 
@@ -60,4 +54,4 @@ Please see the [DEPLOY.md](/DEPLOY.md) file for deployment instructions.
   * Badge/star number history (if badge/star numbers change upon promotion)
   * Demographic information - race, gender, etc.
   * Assignments - what bureau, precinct/division and/or beat are they assigned to? When has this changed?
-* *Clear images of officers with badge numbers and/or names displayed*: Scrape through social media (as we have done) and/or solicit submissions.
+*Clear images of officers*: Scrape through social media (as we have done) and/or solicit submissions. Encourage submissions with the badge number or name in frame such that it can be used to establish the face of the officer in the roster. After that point, new photos with a face matching the existing face in the database can be added to that officer's profile.


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This modifies OpenOversight to instruct folks to submit _any_ photos of officers - as long as they are in uniform. We will request that clear faces are in the frame. It will be preferred for badge numbers and/or name tags to also be in frame, but no longer strictly required. 

This will enable us to better handle the following cases: (i) where area coordinators know all cops in the city and can identify officers by face alone, (ii) where officers are in public with their badge covered by tape and there already are other images of that same face in the database.

Initially I was thinking there should be two volunteer "cop identification" buckets for folks to work from, one for identifying cops by badge/name, and one for identifying cops by face, but I'm thinking now that this is overcomplicated and we can just use our existing cop identification workflow (slightly modified the tagger search in this PR to allow this). 

Closes #723

## Notes for Deployment

I'm planning to apply this as a hotfix to prod (since not everything in `develop` is ready to ship) once merged. 

## Screenshots (if appropriate)

### Submit

<img width="1214" alt="Screen Shot 2020-06-12 at 5 37 12 PM" src="https://user-images.githubusercontent.com/7832803/84548341-62917c00-acd3-11ea-8c3e-d4a4f146044d.png">

### Tagger search

<img width="1012" alt="Screen Shot 2020-06-12 at 5 37 03 PM" src="https://user-images.githubusercontent.com/7832803/84548342-632a1280-acd3-11ea-961a-57ff661a44c5.png">

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
