### PR TITLE
rename prod branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
       - production_backup_and_deploy:
           filters:
             branches:
-              only: master
+              only: main
   weekly:
     triggers:
       - schedule:
@@ -115,6 +115,6 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - production_backup_only


### PR DESCRIPTION
## Status

Closes #724

openoversight.com prod is deploying from `main` (done as of 0.5.2)

This CI config takes effect for the prod branch when we next merge from `develop` -> `main`, so this PR just ensures that the branch names in the CI config are updated. 