### PR TITLE
new officers csv download - added assignments csv download

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -842,9 +842,9 @@ def download_dept_officers_csv(department_id):
             most_recent_assignment = None
             most_recent_title = None
         if officer.salaries:
-            most_recent_salery = max(officer.salaries, key=lambda s: s.year)
+            most_recent_salary = max(officer.salaries, key=lambda s: s.year)
         else:
-            most_recent_salery = None
+            most_recent_salary = None
         record = {
             "id": officer.id,
             "unique identifier": officer.unique_internal_identifier,
@@ -858,7 +858,7 @@ def download_dept_officers_csv(department_id):
             "employment date": officer.employment_date,
             "badge number": most_recent_assignment and most_recent_assignment.star_no,
             "job title": most_recent_title,
-            "most recent salary": most_recent_salery and most_recent_salery.salary,
+            "most recent salary": most_recent_salary and most_recent_salary.salary,
         }
         csv_writer.writerow(record)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,4 +1,5 @@
 import csv
+from datetime import date
 import io
 import os
 import re
@@ -835,7 +836,7 @@ def download_dept_officers_csv(department_id):
 
     for officer in officers:
         if officer.assignments_lazy:
-            most_recent_assignment = max(officer.assignments_lazy, key=lambda a: a.star_date)
+            most_recent_assignment = max(officer.assignments_lazy, key=lambda a: a.star_date or date.min)
             most_recent_title = most_recent_assignment.job and check_output(most_recent_assignment.job.job_title)
         else:
             most_recent_assignment = None

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -101,6 +101,7 @@ class Officer(db.Model):
     employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
     birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
     assignments = db.relationship('Assignment', backref='officer', lazy='dynamic')
+    assignments_lazy = db.relationship('Assignment')
     face = db.relationship('Face', backref='officer', lazy='dynamic')
     department_id = db.Column(db.Integer, db.ForeignKey('departments.id'))
     department = db.relationship('Department', backref='officers')

--- a/OpenOversight/app/templates/all_depts.html
+++ b/OpenOversight/app/templates/all_depts.html
@@ -8,8 +8,8 @@
   {% for dept in departments %}
     <p>
        {{ dept.name }}
-       <a href={{ url_for('main.download_dept_csv',department_id=dept.id) }}>officers.csv</a> 
-
+       <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}>officers.csv</a> 
+       <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}>assignments.csv</a> 
        {% if dept.incidents %}
            <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}>incidents.csv</a>
        {% endif %}


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Wanting to work with the CPD data I noticed that some of the data I would like to get is not included in the csv-file generated in the "Download department data" files. Looking into it, I also noticed that instead of the python csv library a "home-grown" solution is used.

Changes proposed in this pull request:
 - Deprecating the existing officer-csv download (not removing in case there are any scripts directly accessing the page)
 - Adding a new officer-csv download that uses the python csv library and is therefore more robust (can deal with "," in strings for example)
 - Adding the unique internal identifier to the csv output
 - Replacing the assignments field with providing the (most recent) badge number and job title of each officer
 - Adding a field most recent salary to each officer
 - Finally also adding a separate assignments download that has more detailed historic information on all assignment information of the given department. Each row has officer id and unique identifier together with badge number, job title, start date, end date and unit.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
