### PR TITLE
Make the docker-compose reliance on DC_UID explicit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
-   user: "${DC_UID}"
+   user: "${DC_UID:?Docker-compose needs DC_UID set to the current user id number. Try 'export DC_UID=$(id -u)' and run docker-compose again}"
    links:
      - postgres:postgres
    expose:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In #714 we created a reliance on an environment variable called DC_UID to import the user id into docker-compose.  The Makefile populates that variable automatically, but for folks that invoke `docker-compose` directly, that variable wasn't getting set with frustrating results (root-owned files that couldn't be used or deleted).  

## Changes proposed in this pull request:

This PR makes sure that the right DC_UID variable is in scope, and if it's not docker-compose will exit with an error including the command to run to export the DC_UID variable like the makefile does.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
