### PR TITLE
Make the docker-compose reliance on UID explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export DC_UID=$(shell id -u)
+export UID=$(shell id -u)
 
 default: build start create_db populate test stop clean
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
-   user: "${DC_UID}"
+   user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID=$(id -u)' and run docker-compose again}"
    links:
      - postgres:postgres
    expose:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

In #714 we created a reliance on an environment variable called DC_UID to import the user id into docker-compose. The Makefile populates that variable automatically, but for folks that invoke docker-compose directly, that variable wasn't getting set with frustrating results (root-owned files that couldn't be used or deleted).

Changes proposed in this pull request:

This PR removes that custom variable and uses the shell-default UID variable.  That is able to be set by the Makefile, and appears to be the most common variable name for this function in docker-compose.  See https://github.com/docker/compose/issues/2380 where folks have been fighting this for at least 5 years now.  If for whatever reason docker-compose is started with a UID in the environment, it now errors with a suggestion instead of creating useless files.

## Notes for Deployment

Should be (more) transparent to developers (than #714 on its own).  No app changes.

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
