### PR TITLE
debug add officer form and test unit feature

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -130,7 +130,7 @@ def add_officer_profile(form, current_user):
     db.session.commit()
 
     if form.unit.data:
-        officer_unit = form.unit.data.id
+        officer_unit = form.unit.data
     else:
         officer_unit = None
 


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #744.

Changes proposed in this pull request:

 - Refactor the `add_officer_profile` method, called by the `add_officer()` method in `views.py`, so that it won't break when the new officer's unit is included
 - Test the bug fix
 

## Notes for Deployment
n/a

## Screenshots (if appropriate)
I didn't include screenshots, because I didn't change the display.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
