### PR TITLE
Fix leftover issues w/ $UID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
-   user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID=$(id -u)' and run docker-compose again}"
+   user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID' and run docker-compose again}"
    links:
      - postgres:postgres
    expose:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This is related to https://github.com/lucyparsons/OpenOversight/pull/739, which turned out to be an incomplete solution. This fixes an issue whereby, if the user tries to run docker-compose by hand (outside of the Makefile), they would run into an error:
```
int10h@maxwell ~/projects/OpenOversight $ docker-compose run --rm web flask bulk-add-officers --help
WARNING: The AWS_ACCESS_KEY_ID variable is not set. Defaulting to a blank string.
WARNING: The AWS_SECRET_ACCESS_KEY variable is not set. Defaulting to a blank string.
WARNING: The AWS_DEFAULT_REGION variable is not set. Defaulting to a blank string.
WARNING: The S3_BUCKET_NAME variable is not set. Defaulting to a blank string.
WARNING: The APPROVE_REGISTRATIONS variable is not set. Defaulting to a blank string.
ERROR: Missing mandatory value for "user" option interpolating ${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID=$(id -u)' and run docker-compose again} in service "web": Docker-compose needs UID set to the current user id number. Try 'export UID=$(id -u)' and run docker-compose again
int10h@maxwell ~/projects/OpenOversight $
```
This is unexpected since `$UID` is explicitly set in the user's shell environment. Also, the error message is not helpful because bash does not allow the user to overwrite `$UID`, which is what the message is suggesting the user try to do.

(I think what happened was, https://github.com/lucyparsons/OpenOversight/pull/739 was created as an improvement to https://github.com/lucyparsons/OpenOversight/pull/738, and so because of this iterative development process, we did not see that there was a more elegant solution.)

This PR simply reduces the changes we've made down to the simplest possible thing that works in all scenarios I can think of

Pinging @peculater since they worked on the original PR's.

## Notes for Deployment

None.

## Tests and linting

 - [x] I have rebased my changes on current `develop`
 - [x] pytests pass in the development environment on my local machine
 - [x] `flake8` checks pass
