### PR TITLE
Test the python versions we think we're testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ services:
 env:
   - DOCKER_COMPOSE_VERSION=1.24.0
 before_install:
-  - env
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 env:
   - DOCKER_COMPOSE_VERSION=1.24.0
 before_install:
+  - env
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       context: .
       args:
       - DOCKER_BUILD_ENV
+      - TRAVIS_PYTHON_VERSION
       dockerfile: ./dockerfiles/web/Dockerfile
    environment:
      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3-buster
+ARG TRAVIS_PYTHON_VERSION
+FROM python:${TRAVIS_PYTHON_VERSION:-3.5}-buster
 
 WORKDIR /usr/src/app
 
@@ -6,15 +7,13 @@ ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
 ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
-RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev
-RUN apt-get install -y -t stretch-backports libsqlite3-0
+RUN wget -O - https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && apt-get install -t stretch-backports libsqlite3-0 && apt-get clean
 
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 RUN mkdir geckodriver
 RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
-RUN wget -O - https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install -y nodejs npm
 RUN npm install -g yarn
 
 RUN mkdir /var/www ./node_modules /.cache /.yarn /.mozilla

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -8,7 +8,7 @@ ENV DISPLAY=:1
 ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
 RUN wget -O - https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && apt-get install -t stretch-backports libsqlite3-0 && apt-get clean
+RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs npm && apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
 
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 RUN mkdir geckodriver

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
 ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
-RUN wget -O - https://deb.nodesource.com/setup_10.x | bash -
+RUN wget -O - https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && apt-get install -t stretch-backports libsqlite3-0 && apt-get clean
 
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz


### PR DESCRIPTION
There's a regression in python 3.8.4, which broke all 3 of our builds despite the travis build matrix. This is because we weren't actually running the tests using those versions, because the tests run inside docker where the version was specified by the Dockerfile to be 3.8.

Luckily, flake8 was still running in the travis python version, so we caught things like f-strings not being supported in 3.5.

I expect this will fail on 3.8 and pass on 3.5, 3.6, and 3.7, but I won't know until it's pushed. Once that's verified to work, we can drop 3.8 support until we're running an OS somewhere that needs it or the image is fixed.

## Status

Ready for review

## Description of Changes

Fixes #754 .
