### PR TITLE
Upgrade Flask-SQLAlchemy to guard against #754

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ vagrant/puppet/.tmp
 
 # Editor files
 .idea/
+*.iml
 .vscode/
 .vscode/**
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_script:
   - sudo service postgresql stop
 script:
   - sudo make test
-  - flake8 --ignore=E501,E722
+  - flake8 --ignore=E501,E722,W504
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 services:
   - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - true
 before_script:
-  - pip install coveralls flake8==3.5.0
+  - pip install coveralls flake8==3.8.3
   - sudo service postgresql stop
 script:
   - sudo make test

--- a/OpenOversight/migrations/versions/114919b27a9f_.py
+++ b/OpenOversight/migrations/versions/114919b27a9f_.py
@@ -37,9 +37,9 @@ def downgrade():
     op.create_index('ix_officers_pd_id', 'officers', ['pd_id'], unique=False)
     op.drop_column('officers', 'department_id')
     op.create_table('migrate_version',
-    sa.Column('repository_id', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
-    sa.Column('repository_path', sa.TEXT(), autoincrement=False, nullable=True),
-    sa.Column('version', sa.INTEGER(), autoincrement=False, nullable=True),
-    sa.PrimaryKeyConstraint('repository_id', name=u'migrate_version_pkey')
+                    sa.Column('repository_id', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
+                    sa.Column('repository_path', sa.TEXT(), autoincrement=False, nullable=True),
+                    sa.Column('version', sa.INTEGER(), autoincrement=False, nullable=True),
+                    sa.PrimaryKeyConstraint('repository_id', name=u'migrate_version_pkey')
     )  # noqa
     # ### end Alembic commands ###

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.3
+flake8==3.8.3  # if changing this, update .travis.yml too
 selenium==3.14.0
 nose>=1.3.1
 pytest==5.2.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.5.0
+flake8==3.8.3
 selenium==3.14.0
 nose>=1.3.1
 pytest==5.2.2

--- a/flickrscraper/resize.and.detect.py
+++ b/flickrscraper/resize.and.detect.py
@@ -84,7 +84,7 @@ def highlight_faces(image, faces, output_filename):
 
     for face in faces:
         box = [(v.get('x', 0.0), v.get('y', 0.0))  # noqa
-        for v in face['fdBoundingPoly']['vertices']]
+               for v in face['fdBoundingPoly']['vertices']]
         # draw.line(box + [box[0]], width=5, fill='#00ff00')
 # removed the boxes, maybe they're useful later - josh
     # im.save(output_filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Limiter==1.0.1
 Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Migrate==2.1.1
-Flask-SQLAlchemy==2.4.3
+Flask-SQLAlchemy==2.4.4
 Flask-WTF==0.14.3
 Pillow==5.2.0
 psycopg2==2.8.5 --no-binary psycopg2


### PR DESCRIPTION
In looking at flask-sqlalchemy's github issue about the underlying issue from #754 / #758, I realized that:
a) they already pushed a fixed release of flask-sqlalchemy
b) this will affect anyone who happens to be running a 3.8.4, which
shouldn't be too many people, but may be nonzero

Let's just add the fixed package, just in case. And while I'm here, let's test against 3.8 again too.

## Status

Ready for review

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
