### PR TITLE
handle auth check for when request.endpoint is None

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -18,6 +18,7 @@ from ..utils import set_dynamic_default
 def before_request():
     if current_user.is_authenticated \
             and not current_user.confirmed \
+            and request.endpoint \
             and request.endpoint[:5] != 'auth.' \
             and request.endpoint != 'static':
         return redirect(url_for('auth.unconfirmed'))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #762 .

Changes proposed in this pull request:

 - Add a condition to the auth method `before_request()`, so that it doesn't err out when request.endpoint is `None`

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
