### PR TITLE
Use Flask-Sitemap to autogenerate an XML sitemap

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -10,6 +10,7 @@ from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_mail import Mail
 from flask_migrate import Migrate
+from flask_sitemap import Sitemap
 
 from .config import config
 
@@ -24,6 +25,8 @@ login_manager.login_view = 'auth.login'
 limiter = Limiter(key_func=get_remote_address,
                   default_limits=["100 per minute", "5 per second"])
 
+sitemap = Sitemap()
+
 
 def create_app(config_name='default'):
     app = Flask(__name__)
@@ -36,6 +39,7 @@ def create_app(config_name='default'):
     db.init_app(app)
     login_manager.init_app(app)
     limiter.init_app(app)
+    sitemap.init_app(app)
 
     from .main import main as main_blueprint  # noqa
     app.register_blueprint(main_blueprint)

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -5,6 +5,7 @@ from flask.views import MethodView
 from flask_login import login_user, logout_user, login_required, \
     current_user
 from . import auth
+from .. import sitemap
 from ..models import User, db
 from ..email import send_email
 from .forms import LoginForm, RegistrationForm, ChangePasswordForm,\
@@ -12,6 +13,19 @@ from .forms import LoginForm, RegistrationForm, ChangePasswordForm,\
     EditUserForm
 from .utils import admin_required
 from ..utils import set_dynamic_default
+
+sitemap_endpoints = []
+
+
+def sitemap_include(view):
+    sitemap_endpoints.append(view.__name__)
+    return view
+
+
+@sitemap.register_generator
+def static_routes():
+    for endpoint in sitemap_endpoints:
+        yield 'auth.' + endpoint, {}
 
 
 @auth.before_app_request
@@ -34,6 +48,7 @@ def unconfirmed():
         return render_template('auth/unconfirmed.html')
 
 
+@sitemap_include
 @auth.route('/login', methods=['GET', 'POST'])
 def login():
     form = LoginForm()
@@ -54,6 +69,7 @@ def logout():
     return redirect(url_for('main.index'))
 
 
+@sitemap_include
 @auth.route('/register', methods=['GET', 'POST'])
 def register():
     jsloads = ['js/zxcvbn.js', 'js/password.js']

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -52,6 +52,7 @@ class DevelopmentConfig(BaseConfig):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
     NUM_OFFICERS = 15000
+    SITEMAP_URL_SCHEME = 'http'
 
 
 class TestingConfig(BaseConfig):
@@ -60,10 +61,12 @@ class TestingConfig(BaseConfig):
     WTF_CSRF_ENABLED = False
     NUM_OFFICERS = 120
     APPROVE_REGISTRATIONS = False
+    SITEMAP_URL_SCHEME = 'http'
 
 
 class ProductionConfig(BaseConfig):
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
+    SITEMAP_URL_SCHEME = 'https'
 
     @classmethod
     def init_app(cls, app):  # pragma: no cover

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -13,7 +13,7 @@ from flask import (abort, render_template, request, redirect, url_for,
 from flask_login import current_user, login_required, login_user
 
 from . import main
-from .. import limiter
+from .. import limiter, sitemap
 from ..utils import (serve_image, compute_leaderboard_stats, get_random_image,
                      allowed_file, add_new_assignment, edit_existing_assignment,
                      add_officer_profile, edit_officer_profile,
@@ -41,23 +41,39 @@ from sqlalchemy.orm import contains_eager, joinedload
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0o077)
 
+sitemap_endpoints = []
+
+
+def sitemap_include(view):
+    sitemap_endpoints.append(view.__name__)
+    return view
+
+
+@sitemap.register_generator
+def static_routes():
+    for endpoint in sitemap_endpoints:
+        yield 'main.' + endpoint, {}
+
 
 def redirect_url(default='index'):
     return request.args.get('next') or request.referrer or url_for(default)
 
 
+@sitemap_include
 @main.route('/')
 @main.route('/index')
 def index():
     return render_template('index.html')
 
 
+@sitemap_include
 @main.route('/browse', methods=['GET'])
 def browse():
     departments = Department.query.filter(Department.officers.any())
     return render_template('browse.html', departments=departments)
 
 
+@sitemap_include
 @main.route('/find', methods=['GET', 'POST'])
 def get_officer():
     jsloads = ['js/find_officer.js']
@@ -92,6 +108,7 @@ def get_ooid():
     return render_template('input_find_ooid.html', form=form)
 
 
+@sitemap_include
 @main.route('/label', methods=['GET', 'POST'])
 def get_started_labeling():
     form = LoginForm()
@@ -121,6 +138,7 @@ def sort_images(department_id):
                            department_id=department_id)
 
 
+@sitemap_include
 @main.route('/tutorial')
 def get_tutorial():
     return render_template('tutorial.html')
@@ -173,6 +191,12 @@ def officer_profile(officer_id):
 
     return render_template('officer.html', officer=officer, paths=face_paths,
                            faces=faces, assignments=assignments, form=form)
+
+
+@sitemap.register_generator
+def sitemap_officers():
+    for officer in Officer.query.all():
+        yield 'main.officer_profile', {'officer_id': officer.id}
 
 
 @main.route('/officer/<int:officer_id>/assignment/new', methods=['POST'])
@@ -755,6 +779,7 @@ def submit_complaint():
                            officer_image=request.args.get('officer_image'))
 
 
+@sitemap_include
 @main.route('/submit', methods=['GET', 'POST'])
 @limiter.limit('5/minute')
 def submit_data():
@@ -950,6 +975,7 @@ def download_incidents_csv(department_id):
     return Response(csv, mimetype="text/csv", headers=csv_headers)
 
 
+@sitemap_include
 @main.route('/download/all', methods=['GET'])
 def all_data():
     departments = Department.query.all()
@@ -999,11 +1025,13 @@ def upload(department_id, officer_id=None):
         return jsonify(error="Server error encountered. Try again later."), 500
 
 
+@sitemap_include
 @main.route('/about')
 def about_oo():
     return render_template('about.html')
 
 
+@sitemap_include
 @main.route('/privacy')
 def privacy_oo():
     return render_template('privacy.html')
@@ -1141,6 +1169,12 @@ main.add_url_rule(
     '/incidents/<int:obj_id>/delete',
     view_func=incident_view,
     methods=['GET', 'POST'])
+
+
+@sitemap.register_generator
+def sitemap_incidents():
+    for incident in Incident.query.all():
+        yield 'main.incident_api', {'obj_id': incident.id}
 
 
 class TextApi(ModelView):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-Mail==0.9.1
 Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.4.4
 Flask-WTF==0.14.3
+Flask-Sitemap==0.3.0
 Pillow==5.2.0
 psycopg2==2.8.5 --no-binary psycopg2
 SQLAlchemy==1.3.0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This autogenerates a sitemap at `/sitemap.xml`. If there are more than 10,000 items, it will produce a sitemap index and paginated sitemaps. This will help search engines like Google when they crawl the site.

To test, `make dev`, then visit http://localhost:3000/sitemap.xml

## Notes for Deployment

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2007008/88829148-34d89780-d19a-11ea-8485-91606ac56630.png)

![image](https://user-images.githubusercontent.com/2007008/88829208-4a4dc180-d19a-11ea-8894-2b95efb4e370.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
