### PR TITLE
Confirm the confirmed users, allow fake email for devs

### DIFF
--- a/OpenOversight/app/email.py
+++ b/OpenOversight/app/email.py
@@ -10,11 +10,14 @@ def send_async_email(app, msg):
 
 
 def send_email(to, subject, template, **kwargs):
-    app = current_app._get_current_object()
-    msg = Message(app.config['OO_MAIL_SUBJECT_PREFIX'] + ' ' + subject,
-                  sender=app.config['OO_MAIL_SENDER'], recipients=[to])
+    msg = Message(current_app.config['OO_MAIL_SUBJECT_PREFIX'] + ' ' + subject,
+                  sender=current_app.config['OO_MAIL_SENDER'], recipients=[to])
     msg.body = render_template(template + '.txt', **kwargs)
     msg.html = render_template(template + '.html', **kwargs)
-    thr = Thread(target=send_async_email, args=[app, msg])
-    thr.start()
-    return thr
+    # Only send email if we're in prod or staging, otherwise log it so devs can see it
+    if current_app.env in ("staging", "production"):
+        thr = Thread(target=send_async_email, args=[current_app, msg])
+        thr.start()
+        return thr
+    else:
+        current_app.logger.info("simulated email:\n%s\n%s", subject, msg.body)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -418,12 +418,15 @@ class User(UserMixin, db.Model):
         s = Serializer(current_app.config['SECRET_KEY'])
         try:
             data = s.loads(token)
-        except (BadSignature, BadData):
+        except (BadSignature, BadData) as e:
+            current_app.logger.warning("failed to decrypt token: %s", e)
             return False
         if data.get('confirm') != self.id:
+            current_app.logger.warning("incorrect id here, expected %s, got %s", data.get('confirm'), self.id)
             return False
         self.confirmed = True
         db.session.add(self)
+        db.session.commit()
         return True
 
     def generate_reset_token(self, expiration=3600):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

The previous code path was missing a `commit()` in the db session that marked users as confirmed when accessing the /auth/confirm/<token> route, so add that.
Also, to make local testing of email not require a full SMTP server running, we can just log the email contents if our flask app environment is not production or staging.

Fixes #762 (in my local testing, at least).


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
