### PR TITLE
Upgrade to latest NodeJS LTS

### DIFF
--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,4 +1,5 @@
 ARG TRAVIS_PYTHON_VERSION
+ARG DOCKER_BUILD_ENV
 FROM python:${TRAVIS_PYTHON_VERSION:-3.5}-buster
 
 WORKDIR /usr/src/app
@@ -7,8 +8,9 @@ ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
 ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
-RUN wget -O - https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs npm && apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
+RUN wget -O - https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && \
+    apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
 
 RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 RUN mkdir geckodriver
@@ -24,7 +26,6 @@ RUN chmod -R 777 /usr/src/app/ /var/lib/xkb /.cache /.yarn /.mozilla
 COPY requirements.txt dev-requirements.txt /usr/src/app/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-ARG DOCKER_BUILD_ENV
 RUN test "${DOCKER_BUILD_ENV}" = production || pip3 install --no-cache-dir -r dev-requirements.txt
 
 COPY package.json /usr/src/app/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenOversight",
+  "name": "openoversight",
   "version": "1.0.0",
   "repository": "https://github.com/lucyparsons/OpenOversight",
   "scripts": {
@@ -7,7 +7,7 @@
     "watch": "node-sass --watch --recursive OpenOversight/app/static/scss/index.scss -o OpenOversight/app/static/dist"
   },
   "devDependencies": {
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.12.0",
     "jquery": "1.9.1 - 3",
     "popper.js": "^1.14.3"
   }


### PR DESCRIPTION
Docker was complaining about the version of nodejs we were running just because it stopped being supported in December. Upgrade to latest nodejs 12 LTS.
Also, upgrade the version of node-sass we use to a version compatible with nodejs 12.

No visible differences in our generated CSS, though I did not do a before/after CSS diff.

## Status

Ready for review

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
