### PR TITLE
Fix activation emails, this time for sure

### DIFF
--- a/OpenOversight/app/email.py
+++ b/OpenOversight/app/email.py
@@ -10,14 +10,16 @@ def send_async_email(app, msg):
 
 
 def send_email(to, subject, template, **kwargs):
-    msg = Message(current_app.config['OO_MAIL_SUBJECT_PREFIX'] + ' ' + subject,
-                  sender=current_app.config['OO_MAIL_SENDER'], recipients=[to])
+    app = current_app._get_current_object()
+    msg = Message(app.config['OO_MAIL_SUBJECT_PREFIX'] + ' ' + subject,
+                  sender=app.config['OO_MAIL_SENDER'], recipients=[to])
     msg.body = render_template(template + '.txt', **kwargs)
     msg.html = render_template(template + '.html', **kwargs)
     # Only send email if we're in prod or staging, otherwise log it so devs can see it
-    if current_app.env in ("staging", "production"):
-        thr = Thread(target=send_async_email, args=[current_app, msg])
+    if app.env in ("staging", "production"):
+        thr = Thread(target=send_async_email, args=[app, msg])
+        app.logger.info("Sent email.")
         thr.start()
         return thr
     else:
-        current_app.logger.info("simulated email:\n%s\n%s", subject, msg.body)
+        app.logger.info("simulated email:\n%s\n%s", subject, msg.body)


### PR DESCRIPTION
I got greedy and removed the access to the protected
_get_current_object() without understanding why it was there in the
first place.

Fixes this stacktrace:
Exception in thread Thread-21:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/home/nginx/oovirtenv/venv/OpenOversight/OpenOversight/app/email.py", line 8, in send_async_email
    with app.app_context():
  File "/home/nginx/oovirtenv/venv/lib/python3.5/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/home/nginx/oovirtenv/venv/lib/python3.5/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/home/nginx/oovirtenv/venv/lib/python3.5/site-packages/flask/globals.py", line 51, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.
This typically means that you attempted to use functionality that needed
to interface with the current application object in some way. To solve
this, set up an application context with app.app_context().  See the
documentation for more information.
cc @redshiftzero 