### PR TITLE
ensure that star_no doesn't 500 if assignment sort returns None

### DIFF
--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -136,11 +136,13 @@
           {% else %}
             {% set officer_image = officer.face.first().image.filepath %}
           {% endif %}
-	{% if officer.assignments.all() %}
-          {% set assignment = officer.assignments.order_by(officer.assignments[0].__table__.c.star_date.desc()).first() %}
-	  {% set star_no = "#" + assignment.star_no %}
-	  {% set job_title = assignment.job.job_title %}
-	{% endif %}
+          {% if officer.assignments.all() %}
+            {% set assignment = officer.assignments.order_by(officer.assignments[0].__table__.c.star_date.desc()).first() %}
+            {% if assignment is not none %}
+                {% set star_no = "#" + assignment.star_no %}
+                {% set job_title = assignment.job.job_title %}
+            {% endif %}
+          {% endif %}
         <li class="list-group-item">
             <div class="row">
               <div class="col-md-6 col-xs-12">


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #793.

CPD's browse page threw a 500 on prod and staging because in the below line in `list_officer.html`,
```
{% set star_no = "#" + assignment.star_no %}
```
`assignment` was `none`.  I initially thought this was because assignments were missing from the database for CPD.  However, when I deleted all assignments for a department on my local instance, I wasn't able to reproduce the error.  Also, I realize that the below line
```
{% if officer.assignments.all() %}
````
should prevent the template from attempting to set `star_no` when an officer has no assignments.

I think the error occurs when the below line 
```
{% set assignment = officer.assignments.order_by(officer.assignments[0].__table__.c.star_date.desc()).first() %}
```
sets assignment to equal `none`.  I added a check that should prevent the 500.

In the future, we probably shouldn't have this much logic in the jinja template.  It would be easier to test the logic if it were in the view.

Changes proposed in this pull request:

 - Add a check in `list_officer.html` to prevent a 500

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
