### PR TITLE
fixing #799

### DIFF
--- a/db_backup.py
+++ b/db_backup.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from app.config import config
+from OpenOversight.app import config
 import os
 
 db = config['default'].SQLALCHEMY_DATABASE_URI

--- a/fabfile.py
+++ b/fabfile.py
@@ -67,7 +67,7 @@ def migrate():
 def backup():
     with cd(env.backup_dir):
         backup_datetime = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
-        run('%s/bin/python %s/OpenOversight/db_backup.py' % (env.venv_dir, env.code_dir))
+        run('%s/bin/python %s/db_backup.py' % (env.venv_dir, env.code_dir))
         run('mv backup.sql backup.sql_%s' % backup_datetime)
         run('su %s -c "aws s3 sync s3://%s /home/nginx/openoversight_backup/s3/%s"'
             % (env.unprivileged_user, env.s3bucket, env.s3bucket))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #799.

Changes proposed in this pull request:

Re-enabling the db-backup functionality by moving the script into the root dir and changing the fab-file that calls the script.
This should allow us to use absolute imports again.

I am not familiar with the circleci + fab stuff and don't know how to test it. So I was only able to test running the script itself, which worked.

## Notes for Deployment

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
