### PR TITLE
relative imports to fix staging

### DIFF
--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -12,7 +12,7 @@ from flask import current_app
 from .models import db, Assignment, Department, Officer, User, Salary, Job
 from .utils import get_officer, str_is_true
 
-from OpenOversight.app.csv_imports import import_csv_files
+from .csv_imports import import_csv_files
 
 
 @click.command()

--- a/OpenOversight/app/csv_imports.py
+++ b/OpenOversight/app/csv_imports.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from OpenOversight.app.model_imports import (
+from .model_imports import (
     create_assignment_from_dict,
     create_incident_from_dict,
     create_link_from_dict,
@@ -18,7 +18,7 @@ from OpenOversight.app.model_imports import (
     update_officer_from_dict,
     update_salary_from_dict,
 )
-from OpenOversight.app.models import (
+from .models import (
     Assignment,
     Department,
     Incident,

--- a/OpenOversight/app/model_imports.py
+++ b/OpenOversight/app/model_imports.py
@@ -2,8 +2,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 
 import dateutil
 
-from OpenOversight.app.main import choices
-from OpenOversight.app.models import (
+from .main import choices
+from .models import (
     Assignment,
     Incident,
     LicensePlate,
@@ -13,8 +13,8 @@ from OpenOversight.app.models import (
     Salary,
     db,
 )
-from OpenOversight.app.utils import get_or_create, str_is_true
-from OpenOversight.app.validators import state_validator, url_validator
+from .utils import get_or_create, str_is_true
+from .validators import state_validator, url_validator
 
 if TYPE_CHECKING:
     import datetime  # noqa


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes staging

Changes proposed in this pull request:

 - Fixing staging by changing absolute imports to relative imports
 
I tested the changes by exec'ing into the running web-container and running `gunicorn -w 4 -b 127.0.0.1:4000 app:app` which seems to be the command used on staging/production according to https://github.com/lucyparsons/OpenOversight/blob/develop/DEPLOY.md and the command failed before the changes similarly to the staging error message.


## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
