### PR TITLE
When imghdr fails to deduce the image type, use file extension

### DIFF
--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -482,6 +482,14 @@ def crop_image(image, crop_data=None, department_id=None):
 
     image_buf.seek(0)
     image_type = imghdr.what(image_buf)
+    if not image_type:
+        image_type = os.path.splitext(image.filepath)[1].lower()[1:]
+        if image_type in ('jp2', 'j2k', 'jpf', 'jpx', 'jpm', 'mj2'):
+            image_type = 'jpeg2000'
+        elif image_type in ('jpg', 'jpeg', 'jpe', 'jif', 'jfif', 'jfi'):
+            image_type = 'jpeg'
+        elif image_type in ('tif', 'tiff'):
+            image_type = 'tiff'
     pimage = Pimage.open(image_buf)
 
     SIZE = 300, 300


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

I ran into what might be an edge case, where `imghdr.what()` failed to figure out the filetype of a submitted photo. So I added in this little snippet in case imghdr fails, to determine image type using the filename.

I'm not really sure what a good way to add tests for this is, since I don't really know why `imghdr` failed for this particular image. For reference, the image was https://bpdwatch.s3.amazonaws.com/8d/095b8184d1d4abd90e867a8b2d41961bcc4fbd2b42e2af6f0ad8c80ca44fc7.jpg

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
