### PR TITLE
Prompt before committing with bulk-add-officers command

### DIFF
--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -10,7 +10,7 @@ from flask.cli import with_appcontext
 from flask import current_app
 
 from .models import db, Assignment, Department, Officer, User, Salary, Job
-from .utils import get_officer, str_is_true
+from .utils import get_officer, str_is_true, prompt_yes_no
 
 from .csv_imports import import_csv_files
 
@@ -158,9 +158,12 @@ def set_field_from_row(row, obj, attribute, allow_blank=True, fieldname=None):
 
 
 def update_officer_from_row(row, officer, update_static_fields=False):
-    def update_officer_field(fieldname, allow_blank=True):
-        if fieldname in row and (row[fieldname] or allow_blank) and \
-                getattr(officer, fieldname) != row[fieldname]:
+    def update_officer_field(fieldname):
+        if fieldname not in row:
+            return
+        if row[fieldname] == '':
+            row[fieldname] = None
+        if row[fieldname] and getattr(officer, fieldname) != row[fieldname]:
             ImportLog.log_change(
                 officer,
                 'Updated {}: {} --> {}'.format(
@@ -168,10 +171,10 @@ def update_officer_from_row(row, officer, update_static_fields=False):
             setattr(officer, fieldname, row[fieldname])
 
     # Name and gender are the only potentially changeable fields, so update those
-    update_officer_field('last_name', allow_blank=False)
-    update_officer_field('first_name', allow_blank=False)
+    update_officer_field('last_name')
+    update_officer_field('first_name')
     update_officer_field('middle_initial')
-    update_officer_field('suffix', allow_blank=False)
+    update_officer_field('suffix')
     update_officer_field('gender')
 
     # The rest should be static
@@ -188,7 +191,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
             old_value = getattr(officer, fieldname)
             new_value = row[fieldname]
             if old_value is None:
-                update_officer_field(fieldname, new_value)
+                update_officer_field(fieldname)
             elif str(old_value) != str(new_value):
                 msg = 'Officer {} {} has differing {} field. Old: {}, new: {}'.format(
                     officer.first_name,
@@ -199,7 +202,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                 )
                 if update_static_fields:
                     print(msg)
-                    update_officer_field(fieldname, new_value)
+                    update_officer_field(fieldname)
                 else:
                     raise Exception(msg)
 
@@ -435,9 +438,14 @@ def bulk_add_officers(filename, no_create, update_by_name, update_static_fields)
             elif not no_create:
                 create_officer_from_row(row, department_id)
 
-        db.session.commit()
-
         ImportLog.print_logs()
+        if current_app.config['ENV'] == 'testing' or prompt_yes_no("Do you want to commit the above changes?"):
+            print("Commiting changes.")
+            db.session.commit()
+        else:
+            print("Aborting changes.")
+            db.session.rollback()
+            return 0, 0
 
         return len(ImportLog.created_officers), len(ImportLog.updated_officers)
 

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -14,6 +14,7 @@ import os
 import random
 import sys
 from traceback import format_exc
+from distutils.util import strtobool
 
 from sqlalchemy import func
 from sqlalchemy.sql.expression import cast
@@ -583,4 +584,28 @@ def merge_dicts(*dict_args):
 
 
 def str_is_true(str_):
-    return str_.lower() in ['true', 't', 'yes', 'y']
+    return strtobool(str_.lower())
+
+
+def prompt_yes_no(prompt, default="no"):
+    if default is None:
+        yn = " [y/n] "
+    elif default == "yes":
+        yn = " [Y/n] "
+    elif default == "no":
+        yn = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: {}".format(default))
+
+    while True:
+        sys.stdout.write(prompt + yn)
+        choice = input().lower()
+        if default is not None and choice == '':
+            return strtobool(default)
+        try:
+            ret = strtobool(choice)
+        except ValueError:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")
+            continue
+        return ret


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

I realized some of the logic I originally wrote in the `update_officer_from_row()` function of the `bulk-add-officers` command didn't make any sense. I removed the `allowed_blank` parameter since there isn't a situation where you would _update_ an officer field to be blank if it wasn't already. Plus the way it was written caused an issue when I was importing the latest roster CSV for bpdwatch.com: the middle initial column was blank for many officers and subsequently importing the CSV blanked out the middle initials in the database for many officers that had existing non-null middle initials. Not today, Satan!

This also updates the command to prompt the user to confirm the proposed changes _before_ committing them to the database, allowing you to actually review that long list of proposed changes to make sure nothing bad happens (like middle initials getting blanked out).

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
