### PR TITLE
237: improve identification UI

### DIFF
--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -119,7 +119,7 @@
 	<hr>
 
 	<div class="text-center button-explanation">
-          <div class="text done-button-explanation"><b>Explanation</b>: click this button ONLY when all officers in it have been identified. This will remove it from the identification queue for ALL users.</div>
+	  <div class="text done-button-explanation"><b>Explanation</b>: click this button ONLY when all officers in it have been identified. This will remove it from the identification queue for ALL users.</div>
 	  <div class="text skip-button-explanation"><b>Explanation</b>: click this button if you would like to move on to the next image, without saving any info about this image.</div>
 	  <div class="text launchroster-button-explanation"><b>Explanation</b>: click this button to open the police roster.  Use the roster to find the officer's OpenOversight ID.</div>
 	</div>

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -108,18 +108,18 @@
           {% else %}
           <a href="{{ url_for('main.label_data')}}" class="btn btn-lg btn-primary" role="button">
           {% endif %}
-            <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Skip</a>
+            <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Next Photo</a>
         </div>
         <div class="col-sm-2 text-center done-button">
           <a href="{{ url_for('main.complete_tagging', image_id=image.id, department_id=department.id, contains_cops=0) }}" class="btn btn-sm btn-success">
             <span class="glyphicon glyphicon glyphicon-ok" aria-hidden="true"></span>
-            Done with this image!
+            All officers have been identified!
           </a>
         </div>
 	<hr>
 
 	<div class="text-center button-explanation">
-	  <div class="text done-button-explanation"><b>Explanation</b>: click this button if you are done identifying officers in this image and would like to save OR if you cannot identify any officers.</div>
+          <div class="text done-button-explanation"><b>Explanation</b>: click this button ONLY when all officers in it have been identified. This will remove it from the identification queue for ALL users.</div>
 	  <div class="text skip-button-explanation"><b>Explanation</b>: click this button if you would like to move on to the next image, without saving any info about this image.</div>
 	  <div class="text launchroster-button-explanation"><b>Explanation</b>: click this button to open the police roster.  Use the roster to find the officer's OpenOversight ID.</div>
 	</div>

--- a/OpenOversight/app/templates/tutorial.html
+++ b/OpenOversight/app/templates/tutorial.html
@@ -29,7 +29,7 @@
     <p>When an image is displayed, look to see if any faces
       of law enforcement officers are visible. If you do, simply click <b>Yes</b>. If you don't, click <b>No</b>.
       A message will display letting you know that your classification has been saved.
-      If you prefer to skip an image, just click </b>Next Photo</b>.</p>
+      If you prefer to skip an image, just click <b>Next Photo</b>.</p>
 
     <div class="row">
       <div class="col-sm-6 col-md-6">

--- a/OpenOversight/app/templates/tutorial.html
+++ b/OpenOversight/app/templates/tutorial.html
@@ -29,7 +29,7 @@
     <p>When an image is displayed, look to see if any faces
       of law enforcement officers are visible. If you do, simply click <b>Yes</b>. If you don't, click <b>No</b>.
       A message will display letting you know that your classification has been saved.
-      If you prefer to skip an image, just click <b>Skip</b>.</p>
+      If you prefer to skip an image, just click </b>Next Photo</b>.</p>
 
     <div class="row">
       <div class="col-sm-6 col-md-6">
@@ -78,7 +78,7 @@
       </div>
 
     <p>Follow this process for each officer in the image. Once you've identified every
-    officer from the image you are able to, click <b>Done with this image</b>:</p>
+    officer from the image you are able to, click <b>All officers have been identified</b>:</p>
 
       <div class="row">
         <div class="col-sm-6 col-md-6">


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Related to #237, but does not complete that issue. These changes aim to ensure users understand the gravity and permanence of triggering `main.complete_tagging` for a photo. I’ve seen users thinking it only dismisses that photo from _their individual_ identification queue.

Changes proposed in this pull request:

 - Improve **text** of two buttons
 - Improve **explanation** for one button

## Screenshots (if appropriate)

<img width="1552" alt="Screen Shot 2020-08-22 at 10 21 14" src="https://user-images.githubusercontent.com/177123/90961948-45122880-e461-11ea-97ce-975754c6e39d.png">


## Tests and linting

 - [X] I have rebased my changes on current `develop`

```
% git rebase develop
Current branch 237-improve-identification-ui is up to date.
```

 - [X] pytests pass in the development environment on my local machine

```
359 passed, 19 warnings in 331.29s (0:05:31)
```

 - [X] `flake8` checks pass

```
% flake8 --ignore=E501,E722,W504,W503
% echo $?
0
```