### PR TITLE
811: remove underscore in 'Job Title' in assignment form

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -91,7 +91,7 @@ class FaceTag(Form):
 class AssignmentForm(Form):
     star_no = StringField('Badge Number', default='', validators=[
         Regexp(r'\w*'), Length(max=50)])
-    job_title = QuerySelectField('job_title', validators=[DataRequired()],
+    job_title = QuerySelectField('Job Title', validators=[DataRequired()],
                                  get_label='job_title', get_pk=lambda x: x.id)  # query set in view function
     unit = QuerySelectField('Unit', validators=[Optional()],
                             query_factory=unit_choices, get_label='descrip',


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #811. 

Changes proposed in this pull request:

 - Remove superfluous underscore in 'Job Title' heading of the 'Edit Assignment' form

## Screenshots (if appropriate)

After the change:

> <img width="430" alt="Screen Shot 2020-08-22 at 11 09 07" src="https://user-images.githubusercontent.com/177123/90962857-09c72800-e468-11ea-8f71-6f80c7f9fc61.png">

------

## Tests and linting

 - [X] I have rebased my changes on current `develop`

 - [X] pytests pass in the development environment on my local machine

 - [X] `flake8` checks pass
