### PR TITLE
814: ensure NULL race or gender in edit officer form are coerced to 'Not Sure'

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -620,6 +620,12 @@ def edit_officer(officer_id):
         if not link.user_id.data:
             link.user_id.data = current_user.get_id()
 
+    if request.method == 'GET':
+        if officer.race == None:
+            form.race.data = 'Not Sure'
+        if officer.gender == None:
+            form.gender.data = 'Not Sure'
+
     if current_user.is_area_coordinator and not current_user.is_administrator:
         if not ac_can_edit_officer(officer, current_user):
             abort(403)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -621,9 +621,9 @@ def edit_officer(officer_id):
             link.user_id.data = current_user.get_id()
 
     if request.method == 'GET':
-        if officer.race == None:
+        if officer.race is None:
             form.race.data = 'Not Sure'
-        if officer.gender == None:
+        if officer.gender is None:
             form.gender.data = 'Not Sure'
 
     if current_user.is_area_coordinator and not current_user.is_administrator:

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -260,6 +260,7 @@ def test_click_to_read_more_hides_the_read_more_button(mockdata, browser):
     buttonRow = browser.find_element_by_id("description-overflow-row_" + incident_id)
     assert not buttonRow.is_displayed()
 
+
 def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, browser):
     # Set NULL race and gender for officer 2
     db.session.execute(
@@ -268,7 +269,7 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, bro
     # Nagivate to edit officer page for officer having NULL race and gender
     # NOTE: special test setup -- only the first officer gets this
     browser.get("http://localhost:5000/officer/2/edit")
-    wait_for_page_load(browser):
+    wait_for_page_load(browser)
     wait_for_element(browser, By.ID, "gender")
 
     select = browser.find_element_by_id("gender")
@@ -280,4 +281,3 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, bro
     selected_option = select.first_selected_option
     selected_text = selected_option.text
     assert selected_text == 'Not Sure'
-

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -4,6 +4,7 @@ import pytest
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.select import Select
 from selenium.webdriver.common.by import By
 from sqlalchemy.sql.expression import func
 from OpenOversight.app.models import db, Officer, Incident, Department
@@ -256,7 +257,7 @@ def test_click_to_read_more_hides_the_read_more_button(mockdata, browser):
 
 
 def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, browser):
-    # Set NULL race and gender for officer 2
+    # Set NULL race and gender for officer 1
     db.session.execute(
         Officer.__table__.update().where(Officer.id == 1).values(race=None, gender=None))
     db.session.commit()
@@ -265,16 +266,15 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, bro
 
     # Nagivate to edit officer page for officer having NULL race and gender
     browser.get("http://localhost:5000/officer/1/edit")
-    wait_for_page_load(browser)
 
-    with wait_for_element(browser, By.ID, "gender"):
-        select = browser.find_element_by_id("gender")
-        selected_option = select.first_selected_option
-        selected_text = selected_option.text
-        assert selected_text == 'Not Sure'
+    wait_for_element(browser, By.ID, "gender")
+    select = Select(browser.find_element_by_id("gender"))
+    selected_option = select.first_selected_option
+    selected_text = selected_option.text
+    assert selected_text == 'Not Sure'
 
-    with wait_for_element(browser, By.ID, "race"):
-        select = browser.find_element_by_id("race")
-        selected_option = select.first_selected_option
-        selected_text = selected_option.text
-        assert selected_text == 'Not Sure'
+    wait_for_element(browser, By.ID, "race")
+    select = Select(browser.find_element_by_id("race"))
+    selected_option = select.first_selected_option
+    selected_text = selected_option.text
+    assert selected_text == 'Not Sure'

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -19,6 +19,20 @@ def wait_for_page_load(browser, timeout=10):
     )
 
 
+def login_admin(browser):
+    browser.get("http://localhost:5000/auth/login")
+    with wait_for_page_load(browser):
+        elem = browser.find_element_by_id("email")
+        elem.clear()
+        elem.send_keys("test@example.org")
+        elem = browser.find_element_by_id("password")
+        elem.clear()
+        elem.send_keys("testtest")
+        with wait_for_page_load(browser):
+            browser.find_element_by_id("submit").click()
+            wait_for_element(browser, By.TAG_NAME, "body")
+
+
 def wait_for_element(browser, locator, text, timeout=10):
     try:
         element_present = expected_conditions.presence_of_element_located(
@@ -100,17 +114,7 @@ def test_officer_browse_pagination(mockdata, browser):
 
 
 def test_last_name_capitalization(mockdata, browser):
-    browser.get("http://localhost:5000/auth/login")
-
-    # get past the login page
-    elem = browser.find_element_by_id("email")
-    elem.clear()
-    elem.send_keys("test@example.org")
-    elem = browser.find_element_by_id("password")
-    elem.clear()
-    elem.send_keys("testtest")
-    with wait_for_page_load(browser):
-        browser.find_element_by_id("submit").click()
+    login_admin(browser)
     wait_for_element(browser, By.ID, "cpd")
 
     test_pairs = [("mcDonald", "McDonald"), ("Mei-Ying", "Mei-Ying")]
@@ -142,17 +146,7 @@ def test_last_name_capitalization(mockdata, browser):
 
 
 def test_last_name_capitalization_short_name(mockdata, browser):
-    browser.get("http://localhost:5000/auth/login")
-
-    # get past the login page
-    elem = browser.find_element_by_id("email")
-    elem.clear()
-    elem.send_keys("test@example.org")
-    elem = browser.find_element_by_id("password")
-    elem.clear()
-    elem.send_keys("testtest")
-    with wait_for_page_load(browser):
-        browser.find_element_by_id("submit").click()
+    login_admin(browser)
     wait_for_element(browser, By.ID, "cpd")
 
     test_pairs = [("G", "G"), ("oh", "Oh")]
@@ -264,20 +258,23 @@ def test_click_to_read_more_hides_the_read_more_button(mockdata, browser):
 def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(mockdata, browser):
     # Set NULL race and gender for officer 2
     db.session.execute(
-        Officer.__table__.update().where(Officer.id == 2).values(race=None, gender=None))
+        Officer.__table__.update().where(Officer.id == 1).values(race=None, gender=None))
     db.session.commit()
+
+    login_admin(browser)
+
     # Nagivate to edit officer page for officer having NULL race and gender
-    # NOTE: special test setup -- only the first officer gets this
-    browser.get("http://localhost:5000/officer/2/edit")
+    browser.get("http://localhost:5000/officer/1/edit")
     wait_for_page_load(browser)
-    wait_for_element(browser, By.ID, "gender")
 
-    select = browser.find_element_by_id("gender")
-    selected_option = select.first_selected_option
-    selected_text = selected_option.text
-    assert selected_text == 'Not Sure'
+    with wait_for_element(browser, By.ID, "gender"):
+        select = browser.find_element_by_id("gender")
+        selected_option = select.first_selected_option
+        selected_text = selected_option.text
+        assert selected_text == 'Not Sure'
 
-    select = browser.find_element_by_id("race")
-    selected_option = select.first_selected_option
-    selected_text = selected_option.text
-    assert selected_text == 'Not Sure'
+    with wait_for_element(browser, By.ID, "race"):
+        select = browser.find_element_by_id("race")
+        selected_option = select.first_selected_option
+        selected_text = selected_option.text
+        assert selected_text == 'Not Sure'

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -2,7 +2,7 @@ from __future__ import division
 from contextlib import contextmanager
 import pytest
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.support.ui import WebDriverWait, Select
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.common.by import By


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #814.

Changes proposed in this pull request:

 - Set race to 'Not Sure' in edit officer form when officer has NULL value for race (was previously defaulting to 'Black')
 - Set gender to 'Not Sure' in edit officer form when officer has NULL value for gender (was previously defaulting to 'Male')
 - DRY up the admin login routines for functional tests

## Screenshots (if appropriate)

First, set race and gender to `NULL` for an officer in `psql`:

<img width="1440" alt="Screen Shot 2020-08-23 at 12 58 23" src="https://user-images.githubusercontent.com/177123/90987562-b5dc4200-e540-11ea-9c87-75733390d078.png">

------

Then, load the edit officer form and see 'Not Sure' is now the default value for race and gender:

<img width="574" alt="Screen Shot 2020-08-23 at 12 57 05" src="https://user-images.githubusercontent.com/177123/90987485-2fbffb80-e540-11ea-9f1d-bb7b62e58062.png">

------

## Tests and linting

 - [X] I have rebased my changes on current `develop`
```
% git rebase develop
Current branch 814-not-sure-race-and-gender-defaults is up to date.
```
 - [X] pytests pass in the development environment on my local machine
```
360 passed, 20 warnings in 363.65s (0:06:03)
```
 - [X] `flake8` checks pass
```
docker-compose run --rm web flake8
Starting openoversight_postgres_1 ... done
reidparham@Reids-MBP OpenOversight % echo $?
0
```