### PR TITLE
810: alpha sort the options for 'Unit' select

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -532,7 +532,7 @@ def list_officer(department_id, page=1, race=[], gender=[], rank=[], min_age='16
     if request.args.get('gender') and all(gender in [gc[0] for gc in GENDER_CHOICES] for gender in request.args.getlist('gender')):
         form_data['gender'] = request.args.getlist('gender')
 
-    unit_choices = [(unit.id, unit.descrip) for unit in Unit.query.filter_by(department_id=department_id).all()]
+    unit_choices = [(unit.id, unit.descrip) for unit in Unit.query.filter_by(department_id=department_id).order_by(Unit.descrip.asc()).all()]
     rank_choices = [jc[0] for jc in db.session.query(Job.job_title, Job.order).filter_by(department_id=department_id, is_sworn_officer=True).order_by(Job.order).all()]
     if request.args.get('rank') and all(rank in rank_choices for rank in request.args.getlist('rank')):
         form_data['rank'] = request.args.getlist('rank')

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -192,7 +192,7 @@ class Unit(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     descrip = db.Column(db.String(120), index=True, unique=False)
     department_id = db.Column(db.Integer, db.ForeignKey('departments.id'))
-    department = db.relationship('Department', backref='unit_types')
+    department = db.relationship('Department', backref='unit_types', order_by='Unit.descrip.asc()')
 
     def __repr__(self):
         return 'Unit: {}'.format(self.descrip)

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -74,8 +74,8 @@ def get_or_create(session, model, defaults=None, **kwargs):
 
 def unit_choices(department_id: Optional[int] = None):
     if department_id is not None:
-        return db.session.query(Unit).filter_by(department_id=department_id).all()
-    return db.session.query(Unit).all()
+        return db.session.query(Unit).filter_by(department_id=department_id).order_by(Unit.descrip.asc()).all()
+    return db.session.query(Unit).order_by(Unit.descrip.asc()).all()
 
 
 def dept_choices():
@@ -383,9 +383,9 @@ def add_department_query(form, current_user):
 def add_unit_query(form, current_user):
     if not current_user.is_administrator:
         form.unit.query = Unit.query.filter_by(
-            department_id=current_user.ac_department_id)
+            department_id=current_user.ac_department_id).order_by(Unit.descrip.asc())
     else:
-        form.unit.query = Unit.query.all()
+        form.unit.query = Unit.query.order_by(Unit.descrip.asc()).all()
 
 
 def replace_list(items, obj, attr, model, db):

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -2,11 +2,12 @@ from __future__ import division
 from contextlib import contextmanager
 import pytest
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.support.ui import WebDriverWait, Select
+from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.select import Select
 from selenium.webdriver.common.by import By
 from sqlalchemy.sql.expression import func
-from OpenOversight.app.models import Officer, Incident, Department
+from OpenOversight.app.models import db, Officer, Incident, Department, Unit
 from OpenOversight.app.config import BaseConfig
 
 
@@ -17,6 +18,20 @@ def wait_for_page_load(browser, timeout=10):
     WebDriverWait(browser, timeout).until(
         expected_conditions.staleness_of(old_page)
     )
+
+
+def login_admin(browser):
+    browser.get("http://localhost:5000/auth/login")
+    with wait_for_page_load(browser):
+        elem = browser.find_element_by_id("email")
+        elem.clear()
+        elem.send_keys("test@example.org")
+        elem = browser.find_element_by_id("password")
+        elem.clear()
+        elem.send_keys("testtest")
+        with wait_for_page_load(browser):
+            browser.find_element_by_id("submit").click()
+            wait_for_element(browser, By.TAG_NAME, "body")
 
 
 def wait_for_element(browser, locator, text, timeout=10):
@@ -100,17 +115,7 @@ def test_officer_browse_pagination(mockdata, browser):
 
 
 def test_last_name_capitalization(mockdata, browser):
-    browser.get("http://localhost:5000/auth/login")
-
-    # get past the login page
-    elem = browser.find_element_by_id("email")
-    elem.clear()
-    elem.send_keys("test@example.org")
-    elem = browser.find_element_by_id("password")
-    elem.clear()
-    elem.send_keys("testtest")
-    with wait_for_page_load(browser):
-        browser.find_element_by_id("submit").click()
+    login_admin(browser)
     wait_for_element(browser, By.ID, "cpd")
 
     test_pairs = [("mcDonald", "McDonald"), ("Mei-Ying", "Mei-Ying")]
@@ -142,17 +147,7 @@ def test_last_name_capitalization(mockdata, browser):
 
 
 def test_last_name_capitalization_short_name(mockdata, browser):
-    browser.get("http://localhost:5000/auth/login")
-
-    # get past the login page
-    elem = browser.find_element_by_id("email")
-    elem.clear()
-    elem.send_keys("test@example.org")
-    elem = browser.find_element_by_id("password")
-    elem.clear()
-    elem.send_keys("testtest")
-    with wait_for_page_load(browser):
-        browser.find_element_by_id("submit").click()
+    login_admin(browser)
     wait_for_element(browser, By.ID, "cpd")
 
     test_pairs = [("G", "G"), ("oh", "Oh")]
@@ -259,3 +254,24 @@ def test_click_to_read_more_hides_the_read_more_button(mockdata, browser):
 
     buttonRow = browser.find_element_by_id("description-overflow-row_" + incident_id)
     assert not buttonRow.is_displayed()
+
+
+def test_officer_form_has_units_alpha_sorted(mockdata, browser):
+    login_admin(browser)
+
+    # get the units from the DB in the sort we expect
+    db_units_sorted = list(map(lambda x: x.descrip, db.session.query(Unit).order_by(Unit.descrip.asc()).all()))
+    # the Select tag in the interface has a 'None' value at the start
+    db_units_sorted.insert(0, 'None')
+
+    # Check for the Unit sort on the 'add officer' form
+    browser.get("http://localhost:5000/officer/new")
+    unit_select = Select(browser.find_element_by_id("unit"))
+    select_units_sorted = list(map(lambda x: x.text, unit_select.options))
+    assert db_units_sorted == select_units_sorted
+
+    # Check for the Unit sort on the 'add assignment' form
+    browser.get("http://localhost:5000/officer/1")
+    unit_select = Select(browser.find_element_by_id("unit"))
+    select_units_sorted = list(map(lambda x: x.text, unit_select.options))
+    assert db_units_sorted == select_units_sorted


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #810.

Changes proposed in this pull request:

 - Alpha sort `Unit` within models, forms, utils, and views
 - Test the sorting

## Screenshots

This looks like the 'correct' sort order:

<img width="541" alt="Screen Shot 2020-08-24 at 09 42 22" src="https://user-images.githubusercontent.com/177123/91072312-2a20ef00-e5ee-11ea-9500-62be2ea30442.png">

------

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine
```
360 passed, 20 warnings in 356.49s (0:05:56)
```
 - [x] `flake8` checks pass
