### PR TITLE
Change SelectField to StringField

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -46,7 +46,7 @@ class FindOfficerForm(Form):
     unique_internal_identifier = StringField('unique_internal_identifier', default='', validators=[Regexp(r'\w*'), Length(max=55)])
     dept = QuerySelectField('dept', validators=[DataRequired()],
                             query_factory=dept_choices, get_label='name')
-    unit = SelectField('unit', default='Not Sure', validators=[Optional()])
+    unit = StringField('unit', default='Not Sure', validators=[Optional()])
     rank = StringField('rank', default='Not Sure', validators=[Optional()])  # Gets rewritten by Javascript
     race = SelectField('race', default='Not Sure', choices=RACE_CHOICES,
                        validators=[AnyOf(allowed_values(RACE_CHOICES))])


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #818  .

Changes proposed in this pull request:

- Change SelectField to StringField since the SelectField has no `choice` set which breaks the form-validation in wtforms `2.2.1` the version that is running on staging.
- I observed that the field is still displayed as a html select element in the search-officer form.
- I tested the change by adding a requirement for wtforms 2.2.1 locally and reproducing the error on staging. The error disappeared with the proposed change

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
