### PR TITLE
827: fix pagination/change ordering criteria for search results

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -537,7 +537,7 @@ def list_officer(department_id, page=1, race=[], gender=[], rank=[], min_age='16
     if request.args.get('rank') and all(rank in rank_choices for rank in request.args.getlist('rank')):
         form_data['rank'] = request.args.getlist('rank')
 
-    officers = filter_by_form(form_data, Officer.query, department_id).filter(Officer.department_id == department_id).order_by(Officer.last_name).paginate(page, OFFICERS_PER_PAGE, False)
+    officers = filter_by_form(form_data, Officer.query, department_id).filter(Officer.department_id == department_id).order_by(Officer.last_name, Officer.first_name, Officer.id).paginate(page, OFFICERS_PER_PAGE, False)
     for officer in officers.items:
         officer_face = officer.face.order_by(Face.featured.desc()).first()
         if officer_face:


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #827.

Changes proposed in this pull request:

 - Change 'order by' criteria for search results from (last name) to (last name, first name, id). (last name) doesn't uniquely identify officers, so the order by clause doesn't give a deterministic row sequence, breaking pagination. (last name, first name, id) fixes the issue by uniquely identifies officers.

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
