### PR TITLE
737A Add dev dependencies for mypy and add to lint make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ test: start  ## Run tests
 	fi
 
 .PHONY: lint
-lint: start
-	docker-compose run --rm web flake8
+lint: 
+	docker-compose run --rm web /bin/bash -c 'flake8; mypy app --config="../mypy.ini"'
 
 .PHONY: cleanassets
 cleanassets:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,7 @@ pytest-cov==2.4.0
 pytest-pep8==1.0.6
 xvfbwrapper==0.2.9
 mock==2.0.0
+mypy==0.782
 sphinx==1.7.8
 sphinx-autobuild==0.7.1
 pandas>=0.23.4

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -33,6 +33,7 @@ RUN yarn
 
 COPY create_db.py test_data.py /usr/src/app/
 COPY .flake8 /usr/src/app/
+COPY mypy.ini /usr/src/app/
 EXPOSE 3000
 
 ENV PATH="/usr/src/app/geckodriver:${PATH}"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,57 @@
+[mypy]
+no_implicit_optional = True
+
+
+[mypy-boto3]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-dotenv.*]
+ignore_missing_imports = True
+
+[mypy-flickrapi.*]
+ignore_missing_imports = True
+
+[mypy-flask_bootstrap.*]
+ignore_missing_imports = True
+
+[mypy-flask_limiter.*]
+ignore_missing_imports = True
+
+[mypy-flask_login.*]
+ignore_missing_imports = True
+
+[mypy-flask_mail.*]
+ignore_missing_imports = True
+
+[mypy-flask_migrate.*]
+ignore_missing_imports = True
+
+[mypy-flask_sitemap.*]
+ignore_missing_imports = True
+
+[mypy-flask_sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-flask_wtf.*]
+ignore_missing_imports = True
+
+[mypy-future.utils.*]
+ignore_missing_imports = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-wgetter.*]
+ignore_missing_imports = True
+
+[mypy-wtforms.*]
+ignore_missing_imports = True
+
+[mypy-us.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Status

Ready for review!

## Description of Changes

Adds mypy to the dev-requirements
Adds mypy.ini file and copies it in to container in Dockerfile
Adds mypy check to `make lint` 

This is the first step outlined in issue 737, specifically mentioned in this comment
https://github.com/lucyparsons/OpenOversight/issues/737#issuecomment-685209038

## Tests and linting

Note: flake8 tests pass but the (new) mypy tests DO NOT. Also I would like to note that the way the `make lint` command is written that both `flake8` and `mypy` should run, even if the `flake8` check brings up errors. 

In another PR (on the not yet pushed branch `737_resolve_mypy_errors`) I will push changes to the actual Python files that will resolve the mypy errors currently being raised. 



## Question
Do we actually need the `start` command to be called within `make lint`?  https://github.com/lucyparsons/OpenOversight/blob/develop/Makefile#L53

Should it be empty, or `make: build` instead? I don't think we need the services running to do the linting, but maybe we do need to build first?