### PR TITLE
Use ubuntu image for backup script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
   production_backup_only:
     docker:
-      - image: circleci/python:3.6
+      - image: ubuntu-1604
     steps:
       - checkout
       - *setup_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,9 @@ jobs:
             fab production migrate
 
   production_backup_only:
-    docker:
-      - image: ubuntu-1604
+    machine:
+      enabled: true
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
       - *setup_dependencies


### PR DESCRIPTION
I _think_ this is broken because we attempt to do the backup in an image
that doesn't have pyenv but just has python 3.6.

@redshiftzero is there a way to test this config.yml before it gets to the main branch? I can't see anywhere in circleci that would make it possible.

## Status

Ready for review

## Description of Changes

Fixes #740 maybe? or at least moves it closer to happening.
