### PR TITLE
Quick follow up on #845

### DIFF
--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -67,7 +67,7 @@
       url: getURL,
       uploadMultiple: false,
       parallelUploads: 50,
-      acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg",
+      acceptedFiles: "image/png, image/jpeg, image/gif, image/jpg, image/webp",
       maxFiles: 50,
       init: function() {
          this.on("error", function(file, responseText) {


### PR DESCRIPTION
## Status

add 'image/webp' to acceptedFiles for Dropzone, so the front-end part of the file upload page allows `*.webp` images.

## Description of Changes

Fixes #844 .

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
