### PR TITLE
Update Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Migrate==2.1.1
 Flask-SQLAlchemy==2.4.4
 Flask-WTF==0.14.3
 Flask-Sitemap==0.3.0
-Pillow==5.2.0
+Pillow==7.2.0
 psycopg2==2.8.5 --no-binary psycopg2
 python-dateutil==2.8.1
 SQLAlchemy==1.3.0


### PR DESCRIPTION
A couple low-priority CVEs have been found, and also we're running a
pretty old release.

We're gonna lose support for python 3.5 if we upgrade past 8.0 though.

## Status

Ready for review

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
