### PR TITLE
fix link from image sorting to image tagging

### DIFF
--- a/OpenOversight/app/templates/sort.html
+++ b/OpenOversight/app/templates/sort.html
@@ -71,7 +71,7 @@ $(document).bind('keydown', 's', function(){
       {% else %}
       <h3>All images have been classfied!</h3>
       <p><a href="{{ url_for('main.submit_data')}}" class="btn btn-lg btn-primary" role="button">Submit officer pictures to us</a></p>
-      <p><a href="{{ url_for('main.label_data')}}" class="btn btn-lg btn-primary" role="button">identify officers in the classified images</a></p>
+      <p><a href="{{ url_for('main.label_data', department_id=department_id)}}" class="btn btn-lg btn-primary" role="button">identify officers in the classified images</a></p>
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes an issue where the link from the image classification page when there are no more images to classify, like https://openoversight.com/sort/department/7 to the image tagging is not forwarding the selected department. The expectation (at least for me) is that after finishing classifying the images  submitted for one department a user expects to tag the images for the department they just classified not for all departments.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
