### PR TITLE
change migration to use LOWER not citext

### DIFF
--- a/OpenOversight/migrations/versions/cd39b33b5360_constrain_officer_gender_options.py
+++ b/OpenOversight/migrations/versions/cd39b33b5360_constrain_officer_gender_options.py
@@ -20,7 +20,7 @@ def get_update_statement(normalized, options):
     template = """
     UPDATE officers
     SET gender = '{normalized}'
-    WHERE gender::citext in ({options});
+    WHERE LOWER(gender) in ({options});
     """
     options = ', '.join(["'" + o + "'" for o in options])
     return template.format(normalized=normalized, options=options)
@@ -28,8 +28,6 @@ def get_update_statement(normalized, options):
 
 def upgrade():
     conn = op.get_bind()
-    create_extn = "create extension IF NOT EXISTS citext;"
-    conn.execute(create_extn)
 
     genders = {
         "M": ('male', 'm', 'man'),


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Staging still uses postgres 9.2 and therefore doesn't support the `citext` module.
This PR will replace the use of `citext` by the `LOWER` function which is sufficient for our purpose here.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
