### PR TITLE
simplify and streamline officer filtering

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -50,6 +50,7 @@ class BaseConfig(object):
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
+    SQLALCHEMY_ECHO = True
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
     NUM_OFFICERS = 15000
     SITEMAP_URL_SCHEME = 'http'

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -163,7 +163,7 @@
                       <dt>Gender</dt>
                       <dd>{{ officer.gender_label()|default('Unknown') }}</dd>
                       <dt>Number of Photos</dt>
-                      <dd>{{ officer.face.count() }}</dd>
+                      <dd>{{ officer.face | count }}</dd>
                     </dl>
                   </div>
                 </div>

--- a/OpenOversight/app/templates/tagger_gallery.html
+++ b/OpenOversight/app/templates/tagger_gallery.html
@@ -23,10 +23,10 @@
         <div class="carousel-inner" role="listbox">
         {% for officer in officers.items %}
 
-        {% if officer.face.first() is none %}
+        {% if officer.face | count == 0 %}
           {% set officer_image = '/static/images/placeholder.png' %}
         {% else %}
-          {% set officer_image = officer.face.first().image.filepath %}
+          {% set officer_image = officer.face[0].image.filepath %}
         {% endif %}
 
         {% if loop.index == 1 %}

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -18,6 +18,7 @@ from distutils.util import strtobool
 
 from sqlalchemy import func, or_
 from sqlalchemy.sql.expression import cast
+from sqlalchemy.orm import selectinload
 import imghdr as imghdr
 from flask import current_app, url_for
 from flask_login import current_user
@@ -251,66 +252,65 @@ def upload_obj_to_s3(file_obj, dest_filename):
     return url
 
 
-def filter_by_form(form, officer_query, department_id=None):
-    # Some SQL acrobatics to left join only the most recent assignment per officer
-    row_num_col = func.row_number().over(
-        partition_by=Assignment.officer_id, order_by=Assignment.star_date.desc()
-    ).label('row_num')
-    subq = db.session.query(
-        Assignment.officer_id,
-        Assignment.job_id,
-        Assignment.star_date,
-        Assignment.star_no,
-        Assignment.unit_id
-    ).add_columns(row_num_col).from_self().filter(row_num_col == 1).subquery()
-    officer_query = officer_query.outerjoin(subq)
-
-    if form.get('name'):
+def filter_by_form(form_data, officer_query, department_id=None):
+    if form_data.get('name'):
         officer_query = officer_query.filter(
-            Officer.last_name.ilike('%%{}%%'.format(form['name']))
+            Officer.last_name.ilike('%%{}%%'.format(form_data['name']))
         )
-    if not department_id and form.get('dept'):
-        department_id = form['dept'].id
+    if not department_id and form_data.get('dept'):
+        department_id = form_data['dept'].id
         officer_query = officer_query.filter(
             Officer.department_id == department_id
         )
-    if form.get('badge'):
+
+    if form_data.get('unique_internal_identifier'):
         officer_query = officer_query.filter(
-            subq.c.assignments_star_no.like('%%{}%%'.format(form['badge']))
-        )
-    if form.get('unit'):
-        officer_query = officer_query.filter(
-            subq.c.assignments_unit_id == form['unit']
+            Officer.unique_internal_identifier.ilike('%%{}%%'.format(form_data['unique_internal_identifier']))
         )
 
-    if form.get('unique_internal_identifier'):
-        officer_query = officer_query.filter(
-            Officer.unique_internal_identifier.ilike('%%{}%%'.format(form['unique_internal_identifier']))
-        )
     race_values = [x for x, _ in RACE_CHOICES]
-    if form.get('race') and all(race in race_values for race in form['race']):
-        if 'Not Sure' in form['race']:
-            form['race'].append(None)
-        officer_query = officer_query.filter(Officer.race.in_(form['race']))
-    gender_values = [x for x, _ in GENDER_CHOICES]
-    if form.get('gender') and all(gender in gender_values for gender in form['gender']):
-        if 'Not Sure' not in form['gender']:
-            officer_query = officer_query.filter(or_(Officer.gender.in_(form['gender']), Officer.gender.is_(None)))
+    if form_data.get('race') and all(race in race_values for race in form_data['race']):
+        if 'Not Sure' in form_data['race']:
+            form_data['race'].append(None)
+        officer_query = officer_query.filter(Officer.race.in_(form_data['race']))
 
-    if form.get('min_age') and form.get('max_age'):
+    gender_values = [x for x, _ in GENDER_CHOICES]
+    if form_data.get('gender') and all(gender in gender_values for gender in form_data['gender']):
+        if 'Not Sure' not in form_data['gender']:
+            officer_query = officer_query.filter(or_(Officer.gender.in_(form_data['gender']), Officer.gender.is_(None)))
+
+    if form_data.get('min_age') and form_data.get('max_age'):
         current_year = datetime.datetime.now().year
-        min_birth_year = current_year - int(form['min_age'])
-        max_birth_year = current_year - int(form['max_age'])
+        min_birth_year = current_year - int(form_data['min_age'])
+        max_birth_year = current_year - int(form_data['max_age'])
         officer_query = officer_query.filter(db.or_(db.and_(Officer.birth_year <= min_birth_year,
                                                             Officer.birth_year >= max_birth_year),
                                                     Officer.birth_year == None))  # noqa
 
-    officer_query = officer_query.outerjoin(Job, Assignment.job)
-    rank_values = [x[0] for x in db.session.query(Job.job_title).filter_by(department_id=department_id, is_sworn_officer=True).all()]
-    if form.get('rank') and all(rank in rank_values for rank in form['rank']):
-        if 'Not Sure' in form['rank']:
-            form['rank'].append(None)
-        officer_query = officer_query.filter(Job.job_title.in_(form['rank']))
+    job_ids = []
+    if form_data.get('rank'):
+        job_ids = [job.id for job in Job.query.filter_by(department_id=department_id).filter(Job.job_title.in_(form_data.get("rank"))).all()]
+
+        print(form_data)
+        if 'Not Sure' in form_data['rank']:
+            form_data['rank'].append(None)
+
+    if form_data.get('badge') or form_data.get('unit') or job_ids:
+        officer_query = officer_query.join(Officer.assignments)
+        if form_data.get('badge'):
+            officer_query = officer_query.filter(
+                Assignment.star_no.like('%%{}%%'.format(form_data['badge']))
+            )
+        if form_data.get('unit'):
+            officer_query = officer_query.filter(
+                Assignment.unit_id == form_data['unit']
+            )
+        if job_ids:
+            officer_query = officer_query.filter(Assignment.job_id.in_(job_ids))
+    officer_query = (
+        officer_query
+        .options(selectinload(Officer.assignments_lazy))
+    )
 
     return officer_query
 

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1527,7 +1527,7 @@ def test_admin_can_upload_photos_of_dept_officers(mockdata, client, session, tes
 
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[3]
-        officer_face_count = officer.face.count()
+        officer_face_count = len(officer.face)
 
         crop_mock = MagicMock(return_value=Image.query.first())
         upload_mock = MagicMock(return_value=Image.query.first())
@@ -1541,7 +1541,7 @@ def test_admin_can_upload_photos_of_dept_officers(mockdata, client, session, tes
                 assert rv.status_code == 200
                 assert b'Success' in rv.data
                 # check that Face was added to database
-                assert officer.face.count() == officer_face_count + 1
+                assert len(officer.face) == officer_face_count + 1
 
 
 def test_upload_photo_sends_500_on_s3_error(mockdata, client, session, test_png_BytesIO):
@@ -1553,7 +1553,7 @@ def test_upload_photo_sends_500_on_s3_error(mockdata, client, session, test_png_
         department = Department.query.filter_by(id=AC_DEPT).first()
         mock = MagicMock(return_value=None)
         officer = department.officers[0]
-        officer_face_count = officer.face.count()
+        officer_face_count = len(officer.face)
         with patch('OpenOversight.app.main.views.upload_image_to_s3_and_store_in_db', mock):
             rv = client.post(
                 url_for('main.upload', department_id=department.id, officer_id=officer.id),
@@ -1563,7 +1563,7 @@ def test_upload_photo_sends_500_on_s3_error(mockdata, client, session, test_png_
             assert rv.status_code == 500
             assert b'error' in rv.data
             # check that Face was not added to database
-            assert officer.face.count() == officer_face_count
+            assert len(officer.face) == officer_face_count
 
 
 def test_upload_photo_sends_415_for_bad_file_type(mockdata, client, session):
@@ -1604,7 +1604,7 @@ def test_ac_can_upload_photos_of_dept_officers(mockdata, client, session, test_p
         data = dict(file=(test_png_BytesIO, '204Cat.png'),)
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[4]
-        officer_face_count = officer.face.count()
+        officer_face_count = len(officer.face)
 
         crop_mock = MagicMock(return_value=Image.query.first())
         upload_mock = MagicMock(return_value=Image.query.first())
@@ -1618,7 +1618,7 @@ def test_ac_can_upload_photos_of_dept_officers(mockdata, client, session, test_p
                 assert rv.status_code == 200
                 assert b'Success' in rv.data
                 # check that Face was added to database
-                assert officer.face.count() == officer_face_count + 1
+                assert len(officer.face) == officer_face_count + 1
 
 
 def test_edit_officers_with_blank_uids(mockdata, client, session):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -110,7 +110,7 @@ def test_filter_by_full_unique_internal_identifier_returns_officers(mockdata):
     department = OpenOversight.app.models.Department.query.first()
     target_unique_internal_id = OpenOversight.app.models.Officer.query.first().unique_internal_identifier
     results = OpenOversight.app.utils.grab_officers(
-        {'race': 'Not Sure', 'gender': 'Not Sure', 'rank': 'Not Sure',
+        {'race': ['Not Sure'], 'gender': ['Not Sure'], 'rank': ['Not Sure'],
          'min_age': 16, 'max_age': 85, 'name': '', 'badge': '',
          'dept': department, 'unique_internal_identifier': target_unique_internal_id}
     )
@@ -124,7 +124,7 @@ def test_filter_by_partial_unique_internal_identifier_returns_officers(mockdata)
     identifier = OpenOversight.app.models.Officer.query.first().unique_internal_identifier
     partial_identifier = identifier[:len(identifier) // 2]
     results = OpenOversight.app.utils.grab_officers(
-        {'race': 'Not Sure', 'gender': 'Not Sure', 'rank': 'Not Sure',
+        {'race': ['Not Sure'], 'gender': ['Not Sure'], 'rank': ['Not Sure'],
          'min_age': 16, 'max_age': 85, 'name': '', 'badge': '',
          'dept': department, 'unique_internal_identifier': partial_identifier}
     )


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #857.

Changes proposed in this pull request:

 - Rewriting parts of `filter_by_form`. The SQL queried emitted by the current form leads to inefficient results and produces a lot of queries
 - This will load all assignments for all selected officers in one query via a SELECT IN query (https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#selectin-eager-loading)
 - Setting `SQLALCHEMY_ECHO = True` for the development environment to make it easier for people to see the generated SQL code. Might be a little verbose

## Notes for deployment

This should be tested thoroughly on staging, since the changes potentially touch a lot of different views and functionality

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
