### PR TITLE
Update deployment docs to use JSON for CORS policy

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -38,14 +38,20 @@ You'll need to create an AWS account, if you don't already have one. Then, you'l
 For the officer identification UI to work, you'll need to create a CORS policy for the S3 bucket used with OpenOversight. In the AWS UI, this is done by navigating to the listing of buckets, clicking on the name of your bucket, and choosing the Permissions tab, and then "CORS configuration". Since we're not doing anything fancier than making a web browser GET it, we can just use the default policy:
 
 ```
-<CORSConfiguration>
-	<CORSRule>
-		<AllowedOrigin>*</AllowedOrigin>
-		<AllowedMethod>GET</AllowedMethod>
-		<MaxAgeSeconds>3000</MaxAgeSeconds>
-		<AllowedHeader>Authorization</AllowedHeader>
-	</CORSRule>
-</CORSConfiguration>
+[
+    {
+        "AllowedOrigins": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET"
+        ],
+        "MaxAgeSeconds": 3000,
+        "AllowedHeaders": [
+            "Authorizations"
+        ]
+    }
+]
 ```
 
 If you don't click "Save" on that policy, however, the policy will not actually be applied.


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commit are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md 

-->

## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

This PR updates the CORS configuration in the deployment instructions to use JSON rather than XML. When I tried setting this up myself, AWS would only accept JSON in the CORS configuration field.

## Notes for Deployment

## Screenshots (if appropriate)
![Screenshot_2021-03-13_17-43-28](https://user-images.githubusercontent.com/10214785/111054740-bcba9b80-8423-11eb-89d7-d839706689aa.png)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [ ] `flake8` checks pass
