### PR TITLE
FIX issue #841: Use the right model fields for Note and Description w…

### DIFF
--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -34,6 +34,7 @@
    </div>
 
    <h3>Drop images here to submit photos of officers:</h3>
+   <div id="upload-status" class="alert alert-danger">There was an error uploading file.</div>
 
    <form id="my-cop-dropzone" action="/upload/department/1" class='dropzone'>
    </form>
@@ -43,6 +44,10 @@
    <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
 
    <script>
+   // Hide image upload error div when document ready
+   $(document).ready(function() {
+      $("#upload-status").hide();
+   }); 
    // Select user's preferred department by default
    document.getElementById("department").selectedIndex = {{preferred_dept_id}} - 1;
    // Save the preferred department in dept_id
@@ -71,7 +76,7 @@
       maxFiles: 50,
       init: function() {
          this.on("error", function(file, responseText) {
-            file.previewTemplate.appendChild(document.createTextNode(responseText));
+            $("#upload-status").show();
          });
       }
    });

--- a/OpenOversight/app/templates/submit_officer_image.html
+++ b/OpenOversight/app/templates/submit_officer_image.html
@@ -15,6 +15,7 @@
   <div class='header'>
     <h3>Drop images here to submit photos of {{ officer.full_name() }} in {{ officer.department.name }}:</h3>
   </div>
+  <div id="upload-status" class="alert alert-danger">There was an error uploading file.</div>
   <form action="/upload/department/{{ officer.department_id }}/officer/{{ officer.id }}" class="dropzone" id="my-cop-dropzone">
   </form>
     <p>Drag photographs from your computer directly into the box above or click the box to launch a finder window. If you are on mobile, you can click the box above to select pictures from your photo library or camera roll.</p>
@@ -29,6 +30,10 @@
   <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
   <script src="{{ url_for('static', filename='js/dropzone.js') }}"></script>
   <script>
+    $(document).ready(function() {
+      $("#upload-status").hide();
+    }); 
+    
     Dropzone.autoDiscover = false;
     let myDropzone = new Dropzone("#my-cop-dropzone", {
       url: "/upload/department/{{ officer.department_id }}/officer/{{ officer.id }}",
@@ -39,7 +44,7 @@
       maxFiles: 50,
       init: function() {
         this.on("error", function(file, responseText) {
-          file.previewTemplate.appendChild(document.createTextNode(responseText));
+          $("#upload-status").show();
         });
       }
     });

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -160,8 +160,8 @@ def add_officer_profile(form, current_user):
             # don't try to create with a blank string
             if note['text_contents']:
                 new_note = Note(
-                    note=note['text_contents'],
-                    user_id=current_user.get_id(),
+                    text_contents=note['text_contents'],
+                    creator_id=current_user.get_id(),
                     officer=officer,
                     date_created=datetime.datetime.now(),
                     date_updated=datetime.datetime.now())
@@ -171,8 +171,8 @@ def add_officer_profile(form, current_user):
             # don't try to create with a blank string
             if description['text_contents']:
                 new_description = Description(
-                    description=description['text_contents'],
-                    user_id=current_user.get_id(),
+                    text_contents=description['text_contents'],
+                    creator_id=current_user.get_id(),
                     officer=officer,
                     date_created=datetime.datetime.now(),
                     date_updated=datetime.datetime.now())


### PR DESCRIPTION
## Status

Ready for review / in progress

## Description of Changes

Fixes #841

Changes proposed in this pull request:

 - replace user_id with creator_id that is the defined model when saving a Note and Description
 - replace note with text_contents that is the defined model when saving a Note and Description

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
