### PR TITLE
Fix two small bugs in officer search

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -552,7 +552,7 @@ def list_officer(department_id, page=1, race=[], gender=[], rank=[], min_age='16
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
     officers = officers.paginate(page, OFFICERS_PER_PAGE, False)
     for officer in officers.items:
-        officer_face = sorted(officer.face, key=lambda x: x.featured)
+        officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
 
         # could do some extra work to not lazy load images but load them all together
         # but we would want to ensure to only load the first picture of each officer

--- a/OpenOversight/app/utils.py
+++ b/OpenOversight/app/utils.py
@@ -309,7 +309,7 @@ def filter_by_form(form_data, officer_query, department_id=None):
             officer_query = officer_query.filter(Assignment.job_id.in_(job_ids))
     officer_query = (
         officer_query
-        .options(selectinload(Officer.assignments_lazy))
+        .options(selectinload(Officer.assignments_lazy)).distinct()
     )
 
     return officer_query


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commit are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md 

-->

## Status

Ready for review / in progress

## Description of Changes

Fixes two bugs in officer search:
1. Pagination currently depends on officer assignments instead of distinct officers. That is, each page has 20 historical assignments instead of 20 cops.
2. Featured tags aren't shown in officer search.

Changes proposed in this pull request:

 - Modify the officer query in the filter_by_form function to only pull distinct officers
 - Reverse sorting of officer images so the 0th index is the feature tag

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [X] I have rebased my changes on current `develop`

 - [X] pytests pass in the development environment on my local machine

 - [X] `flake8` checks pass
