### PR TITLE
Verify two dependencies

### DIFF
--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -8,25 +8,36 @@ ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf -L --max-redirs 1 -O"
 
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
+
+# install apt dependencies
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
-RUN wget -O - https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && \
     apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
 
+# install node
+ENV NODE_SETUP_SHA=5d07994f59e3edc2904c547e772b818d10abb066f6ff36ab3db5d686b0fe9a73
+RUN curl ${CURL_FLAGS} \
+      https://raw.githubusercontent.com/nodesource/distributions/b8510857fb4ce4b023161be8490b00119884974c/deb/setup_12.x
+RUN echo "${NODE_SETUP_SHA}  setup_12.x" | sha256sum --check -
+RUN bash setup_12.x
+
+# install geckodriver
 ENV GECKODRIVER_VERSION="v0.26.0"
 ENV GECKODRIVER_SHA=d59ca434d8e41ec1e30dd7707b0c95171dd6d16056fb6db9c978449ad8b93cc0
 ENV GECKODRIVER_BASE_URL="https://github.com/mozilla/geckodriver/releases/download"
-RUN curl ${CURL_FLAGS} ${GECKODRIVER_BASE_URL}/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
+RUN curl ${CURL_FLAGS} \
+      ${GECKODRIVER_BASE_URL}/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
 RUN echo "${GECKODRIVER_SHA}  geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz" | sha256sum --check -
 RUN mkdir geckodriver
 RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
+# install yarn
 RUN npm install -g yarn
-
 RUN mkdir /var/www ./node_modules /.cache /.yarn /.mozilla
 RUN touch /usr/src/app/yarn-error.log
 COPY yarn.lock /usr/src/app/
 RUN chmod -R 777 /usr/src/app/ /var/lib/xkb /.cache /.yarn /.mozilla
+
 
 COPY requirements.txt dev-requirements.txt /usr/src/app/
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -11,7 +11,7 @@ ENV DISPLAY=:1
 
 # install apt dependencies
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
-RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && \
+RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev && \
     apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
 
 # install node
@@ -20,6 +20,7 @@ RUN curl ${CURL_FLAGS} \
       https://raw.githubusercontent.com/nodesource/distributions/b8510857fb4ce4b023161be8490b00119884974c/deb/setup_12.x
 RUN echo "${NODE_SETUP_SHA}  setup_12.x" | sha256sum --check -
 RUN bash setup_12.x
+RUN apt-get install -y nodejs
 
 # install geckodriver
 ENV GECKODRIVER_VERSION="v0.26.0"

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -4,15 +4,20 @@ FROM python:${TRAVIS_PYTHON_VERSION:-3.5}-buster
 
 WORKDIR /usr/src/app
 
+ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf -L --max-redirs 1 -O"
+
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
-ENV GECKODRIVER_VERSION="v0.26.0"
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
 RUN wget -O - https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev nodejs && \
     apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
 
-RUN wget https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
+ENV GECKODRIVER_VERSION="v0.26.0"
+ENV GECKODRIVER_SHA=d59ca434d8e41ec1e30dd7707b0c95171dd6d16056fb6db9c978449ad8b93cc0
+ENV GECKODRIVER_BASE_URL="https://github.com/mozilla/geckodriver/releases/download"
+RUN curl ${CURL_FLAGS} ${GECKODRIVER_BASE_URL}/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
+RUN echo "${GECKODRIVER_SHA}  geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz" | sha256sum --check -
 RUN mkdir geckodriver
 RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 


### PR DESCRIPTION
Add checksum verifications for two dependencies downloaded in a Dockerfile. I've computed the hashes locally using `sha256sum`. They will have to be recomputed when updated. This also pulls the node setup script from version control to avoid breaking the verification if the upstream version is updated.

Looks like Mozilla actually does [publish](https://github.com/mozilla/geckodriver/releases) cryptographic signatures for gecko releases. We can use the checksum method in this PR for simplicity, or I'm happy to update this to use the signature.