### PR TITLE
867/add markdown incident description

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -3,6 +3,8 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 
+import bleach
+from bleach_allowlist import markdown_tags, markdown_attrs
 from flask import Flask, render_template
 from flask_bootstrap import Bootstrap
 from flask_limiter import Limiter
@@ -12,6 +14,8 @@ from flask_mail import Mail
 from flask_migrate import Migrate
 from flask_sitemap import Sitemap
 from flask_wtf.csrf import CSRFProtect
+import markdown as _markdown
+from markupsafe import Markup
 
 from .config import config
 
@@ -94,6 +98,11 @@ def create_app(config_name='default'):
     def get_age_from_birth_year(birth_year):
         if birth_year:
             return int(datetime.datetime.now().year - birth_year)
+
+    @app.template_filter('markdown')
+    def markdown(text):
+        html = bleach.clean(_markdown.markdown(text), markdown_tags, markdown_attrs)
+        return Markup(html)
 
     # Add commands
     Migrate(app, db, os.path.join(os.path.dirname(__file__), '..', 'migrations'))  # Adds 'db' command

--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -46,8 +46,7 @@
 				{% endwith %}
 			</div>
 			<div class="col-sm-12 col-md-6">
-				<h5>Description</h5>
-				<p>{{ incident.description }}</p>
+				<p>{{ incident.description | markdown}}</p>
 			</div>
 		</div>
 		{% include 'partials/links_and_videos_row.html' %}

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -42,7 +42,7 @@
 			<tr>
 				<td><strong>Description</strong></td>
 				<td class="incident-description" id="incident-description_{{incident.id}}" data-incident='{{incident.id | tojson}}'>
-					{{ incident.description }}
+					{{ incident.description | markdown}}
 				</td>
 			</tr>
 			<tr id="description-overflow-row_{{ incident.id }}" >

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -403,7 +403,7 @@ def add_mockdata(session):
             date=datetime.date(2016, 3, 16),
             time=datetime.time(4, 20),
             report_number='42',
-            description='A thing happened',
+            description='### A thing happened\n **Markup** description',
             department_id=1,
             address=test_addresses[0],
             license_plates=test_license_plates,

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -601,3 +601,11 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
         officer_id = '1234'
         rv = client.get(url_for('main.incident_api') + 'new?officer_id={}'.format(officer_id))
         assert officer_id in rv.data.decode('utf-8')
+
+
+def test_incident_markdown(mockdata, client, session):
+    with current_app.test_request_context():
+        rv = client.get(url_for('main.incident_api'))
+        html = rv.data.decode()
+        assert "<h3>A thing happened</h3>" in html
+        assert "<p><strong>Markup</strong> description</p>" in html

--- a/mypy.ini
+++ b/mypy.ini
@@ -55,3 +55,9 @@ ignore_missing_imports = True
 
 [mypy-us.*]
 ignore_missing_imports = True
+
+[mypy-bleach_allowlist.*]
+ignore_missing_imports = True
+
+[mypy-markdown.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ itsdangerous==0.24
 us==1.0
 future==0.18.2
 email-validator==1.0.5
+bleach==3.3.1
+bleach-allowlist==1.0.3
+Markdown==3.2.2


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #867.

Changes proposed in this pull request:

 - Incident description accepts markdown and some html while making sure that unsafe html cannot be introduced

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
