### PR TITLE
make some improvements to incident formatting

### DIFF
--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -38,17 +38,23 @@
 				<a href="{{ url_for('main.incident_api', department_id=incident.department_id)}}">More incidents in the {{ incident.department.name }}</a>
 			</p>
 		{% endif %}
+		<div class="col-sm-12 col-md-6">
 		<h1>Incident {% if incident.report_number %}{{incident.report_number}}{% endif %}</h1>
-		<div class='row'>
-			<div class="col-sm-12 col-md-6">
+			<div>
+				<table class='table table-hover table-responsive'>
+					<tbody>
 				{% with detail=True %}
 					{% include 'partials/incident_fields.html' %}
 				{% endwith %}
-			</div>
-			<div class="col-sm-12 col-md-6">
-				{{ incident.description | markdown}}
+			</tbody>
+		</table>
 			</div>
 		</div>
+		<div class="col-sm-12 col-md-6">
+				<h1>Incident Description</h1>
+				{{ incident.description | markdown}}
+			</div>
+		
 		{% include 'partials/links_and_videos_row.html' %}
 		{% if current_user.is_administrator
               or (current_user.is_area_coordinator and current_user.ac_department_id == incident.department_id) %}

--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -14,19 +14,30 @@
 	{% endif %}
 	<ul class="list-group">
 		{% if objects.items %}
+		<table class='table table-hover table-responsive'>
+			<tbody>
 		  {% for incident in objects.items %}
-		  	<li class="list-group-item">
+		  {% if not loop.first %}
+		  <tr class="border:none"><td colspan="2">&nbsp;</td></tr>
+		  {% endif %}
+		  	<tr>
+				  <td colspan="2" style="border-top: 0; ">
 		  		<h3>
 		  				<a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
 		  				Incident
               {% if incident.report_number %}
                 {{ incident.report_number }}
+				{% else %}
+				{{ incident.id}}
               {% endif %}
 		  			</a>
 		  		</h3>
-		    	{% include 'partials/incident_fields.html' %}
-		    </li>
+			</td>
+		    </tr>
+		    {% include 'partials/incident_fields.html' %}
 		  {% endfor %}
+		  </tbody>
+		  </table>
 		{% else %}
 			<p>There are no incidents.</p>
 		{% endif %}

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -360,24 +360,35 @@
   	<div class='col-sm-12 col-md-6'>
     	<h3>Incidents</h3>
       {% if officer.incidents %}
-    	<ul class="list-group">
+        <table class='table table-hover table-responsive'>
+          <tbody>
       	{% for incident in officer.incidents %}
-        	<li class="list-group-item">
-          	<h4>
-              	<a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
-              	  Incident {{ incident.report_number }}
-            	  </a>
-            	{% if current_user.is_administrator
+          {% if not loop.first %}
+          <tr class="border:none"><td colspan="2">&nbsp;</td></tr>
+          {% endif %}
+          <tr>
+            <td colspan="2" style="border-top: 0; ">
+            <h4>
+                <a href="{{ url_for('main.incident_api', obj_id=incident.id)}}">
+                Incident
+                {% if incident.report_number %}
+                  {{ incident.report_number }}
+          {% else %}
+          {{ incident.id}}
+                {% endif %}
+              </a>
+              {% if current_user.is_administrator
               	or (current_user.is_area_coordinator and current_user.ac_department_id == incident.department_id) %}
              	<a href="{{ url_for('main.incident_api', obj_id=incident.id) + '/edit' }}">
               	<i class="fa fa-pencil-square-o" aria-hidden="true"></i>
             	</a>
             	{% endif %}
             </h4>
+        </td>
+          </tr>
           	{% include 'partials/incident_fields.html' %}
-        	</li>
       	{% endfor %}
-    	</ul>
+          </tbody></table>
       {% endif %}
     	{% if current_user.is_administrator
         	or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id) %}

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -1,13 +1,15 @@
-<table class='table table-hover table-responsive'>
-	<tbody>
+
+
 		<tr>
 			<td><strong>Date</strong></td>
 			<td>{{ incident.date.strftime('%b %d, %Y') }}</td>
 		</tr>
+		{% if incident.time %}
 		<tr>
 			<td><strong>Time</strong></td>
-			<td>{% if incident.time %}{{ incident.time.strftime('%l:%M %p') }}{% endif %}</td>
+			<td>{{ incident.time.strftime('%l:%M %p') }}</td>
 		</tr>
+		{% endif %}
 		{% if incident.report_number %}
 		<tr>
 			<td><strong>Report #</strong></td>
@@ -59,13 +61,17 @@
 				<tr>
 					<td><strong>Address</strong></td>
 						<td>
-							{{ address.street_name }}
-							{% if address.cross_street1 and address.cross_street2 %}
-								<em>between</em> {{ address.cross_street1 }} <em>and</em> {{ address.cross_street2 }}
-								{% else %}
-								 <em>near</em> {{ address.cross_street1 }}
+							{% if address.street_name %}
+								{{ address.street_name }}
+								{% if address.cross_street1%}
+									{% if address.cross_street2%}
+									<em>between</em> {{ address.cross_street1 }} <em>and</em> {{ address.cross_street2 }}
+									{% else %}
+									<em>near</em> {{ address.cross_street1 }}
+									{% endif %}
+								{% endif %}
+								<br/>
 							{% endif %}
-							<br/>
 							{{ address.city }}, {{ address.state }} {% if address.zipcode %} {{ address.zip_code }} {% endif %}
 						</td>
 				</tr>
@@ -85,8 +91,7 @@
 				</tr>
 			{% endif %}
 		{% endif %}
-	</tbody>
-</table>
+
 
 {% block js_footer %}
 	<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==1.0.2
 python-dotenv==0.7.1
 boto3==1.5.10
 werkzeug==1.0.1
+wtforms==2.3.3
 Flask-Bootstrap==3.3.7.1
 Flask-Limiter==1.0.1
 Flask-Login==0.4.1


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - Improve the layout of the incident formatting a little bit, specifically
   - Make the tables in the incident list vertically aligned
   - Do not display a "None" street in the address, instead omit if any street field is NULL (including only showing the city, if no street was added at all)
   - Do not show a "time" field if no time was provided
   - If the incident has no report number label it with our internal id (this doesn't seem super useful, but better than just having a list of incidents all with the headline "Incident" I think
## Notes
 This is just a start, especially allowing markdown for the description makes it hard to look acceptable for all different formats. Additional improvements very welcome!

## Screenshots
Incident list before:
![incidents_list_before](https://user-images.githubusercontent.com/41744410/148503081-22a86690-7c8e-4985-93ba-fba2fa81d2a1.png)
Incident list after:
![incidents_list_after](https://user-images.githubusercontent.com/41744410/148503108-102ba560-0aa3-4042-9549-2ebce912f365.png)
Incident details page before:
![incidents_details_before](https://user-images.githubusercontent.com/41744410/148503133-0a26a2d3-d75a-4913-9e7e-ae19c8f14679.png)
and after:
![incidents_details_after](https://user-images.githubusercontent.com/41744410/148503143-2c15f15a-c657-4466-a337-0023f4156773.png)
Incidents on officer page, before:
![officer_incidents_before](https://user-images.githubusercontent.com/41744410/148503320-6462ea3d-c231-429b-855d-9170ff694b3f.png)
and after:
![officer_incidents_after](https://user-images.githubusercontent.com/41744410/148503341-ffa7d893-eef9-4a48-82b2-a27b0e667030.png)



## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `flake8` checks pass
