### PR TITLE
Switch from docker to "machine" for circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ steps:
 
 jobs:
   staging_backup_and_deploy:
-    docker:
-      - image: cimg/python:3.9
+    machine:
+      image: ubuntu-2204:2022.10.2
     steps:
       - checkout
       - *setup_dependencies
@@ -68,8 +68,8 @@ jobs:
             fab staging migrate
 
   production_deploy:
-    docker:
-      - image: cimg/python:3.9
+    machine:
+      image: ubuntu-2204:2022.10.2
     steps:
       - checkout
       - *setup_dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FLASK_APP: OpenOversight.app
     strategy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ bleach-allowlist==1.0.3
 Markdown==3.2.2
 Jinja2==2.11.3
 MarkupSafe==1.1.1
+importlib-metadata<=4.13.0


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Hopefully fixes issues with the circle ci deploy script. The script fails due to attempting to run docker-compose inside the circle ci docker image which is not supported. Switching back to a "machine" (with a ubuntu version that is still current) will hopefully make the scripts run successfully.

## Tests and linting

 - [x] I have rebased my changes on current `develop`
