### PR TITLE
Backport from orca collective - Step 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
@@ -26,23 +25,20 @@ jobs:
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev-requirements.txt
-
-      # Run flake8
-      - name: Run flake8
-        run: flake8 --ignore=E501,E722,W504,W503
-      # Runs tests
       - name: Run tests
-        run: FLASK_ENV=testing pytest --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/ OpenOversight/app;
+        run: PYTHON_VERSION=${{ matrix.python-version }} make test_with_version
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Dependencies
+        run: pip install pre-commit
+      - name: Run pre-commits
+        run: pre-commit run --all-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run tests
         run: PYTHON_VERSION=${{ matrix.python-version }} make test_with_version
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Install Dependencies
-        run: pip install pre-commit
-      - name: Run pre-commits
-        run: pre-commit run --all-files
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,92 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-case-conflict
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: check-symlinks
+      - id: mixed-line-ending
+      - id: fix-encoding-pragma
+        args:
+          - --remove
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: requirements-txt-fixer
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.7.0
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-check-mock-methods
+      - id: python-no-eval
+      - id: python-no-log-warn
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: Run isort to sort imports
+        files: \.py$
+        # To keep consistent with the global isort skip config defined in setup.cfg
+        exclude: ^build/.*$|^.tox/.*$|^venv/.*$
+        args:
+          - --lines-after-imports=2
+          - --multi-line=3
+          - --trailing-comma
+          - --force-grid-wrap=0
+          - --use-parentheses
+          - --ensure-newline-before-comments
+          - --line-length=88
+
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 5.1.1
+    hooks:
+      - id: pydocstyle
+        name: Run pydocstyle
+        args:
+          - --convention=pep257
+          # Do not require docstrings, only check existing ones. (D1)
+          # Allow for a newline after a docstring. (D202)
+          # Don't require a summary line. (D205)
+          # Don't require a period on the first line. (D400)
+          - --add-ignore=D1,D202,D205,D400
+        exclude: tests/
+
+  - repo: local
+    hooks:
+      - id: no-shebang
+        language: pygrep
+        name: Do not use shebangs in non-executable files
+        description: Only executable files should have shebangs (e.g. '#!/usr/bin/env python')
+        entry: "#!/"
+        pass_filenames: true
+        exclude: bin|cli|manage.py|app.py|setup.py|docs|create_db.py|test_data.py
+        files: \.py$
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+        - id: flake8
+          args:
+            - --ignore=E203,E402,E501,E800,W503,W391,E261
+            - --select=B,C,E,F,W,T4,B9
+
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+        - id: black
+          args:
+            - --safe
+            - "--target-version=py35"
+            - "--target-version=py36"
+            - "--target-version=py37"
+            - "--target-version=py38"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-docstring-first
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
       - id: python-check-mock-methods
@@ -40,15 +40,10 @@ repos:
         exclude: ^build/.*$|^.tox/.*$|^venv/.*$
         args:
           - --lines-after-imports=2
-          - --multi-line=3
-          - --trailing-comma
-          - --force-grid-wrap=0
-          - --use-parentheses
-          - --ensure-newline-before-comments
-          - --line-length=88
+          - --profile=black
 
   - repo: https://github.com/pycqa/pydocstyle
-    rev: 5.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         name: Run pydocstyle
@@ -73,7 +68,7 @@ repos:
         files: \.py$
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 5.0.4
     hooks:
         - id: flake8
           args:

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -24,6 +24,8 @@ This will make sure that all commits you make locally are associated with your g
 
  We use [pre-commit](https://pre-commit.com/) for automated linting and style checks. Be sure to [install pre-commit](https://pre-commit.com/#installation) and run `pre-commit install` in your local version of the repository to install our pre-commit checks. This will make sure your commits are always formatted correctly.
 
+ You can run `pre-commit run --all-files` or `make lint` to run pre-commit over your local codebase, or `pre-commit run` to run it only over the currently stages files.
+
 ## Development Environment
 
 You can use our Docker-compose environment to stand up a development OpenOversight.

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -22,9 +22,7 @@ This will make sure that all commits you make locally are associated with your g
 
 ### Linting / Style Checks
 
- `flake8` is a tool for automated linting and style checks. Be sure to run `flake8` and fix any errors before submitting a PR.
-
- You can run it with `make lint` to execute flake8 from the docker containers.
+ We use [pre-commit](https://pre-commit.com/) for automated linting and style checks. Be sure to [install pre-commit](https://pre-commit.com/#installation) and run `pre-commit install` in your local version of the repository to install our pre-commit checks. This will make sure your commits are always formatted correctly.
 
 ## Development Environment
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ default: build start create_db populate test stop clean
 build:  ## Build containers
 	docker-compose build
 
+.PHONY: build_with_version
+build_with_version:
+	docker-compose build --build-arg TRAVIS_PYTHON_VERSION=$(PYTHON_VERSION)
+
+.PHONY: test_with_version
+test_with_version: build_with_version assets
+	FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n 4 --dist=loadfile -v tests/ app;
+
 .PHONY: start
 start: build  ## Run containers
 	docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: start  ## Run tests
 
 .PHONY: lint
 lint:
-	docker-compose run --no-deps --rm web /bin/bash -c 'flake8; mypy app --config="../mypy.ini"'
+	pre-commit run --all-files
 
 .PHONY: cleanassets
 cleanassets:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -33,4 +33,4 @@ Changes proposed in this pull request:
 
  - [ ] pytests pass in the development environment on my local machine
 
- - [ ] `flake8` checks pass
+ - [ ] `pre-commit` checks pass

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ mock==2.0.0
 mypy==0.782
 nose>=1.3.1
 pandas>=0.23.4
+pre-commit<=2.15.0
 pytest==5.2.2
 pytest-cov==2.4.0
 pytest-pep8==1.0.6


### PR DESCRIPTION
## Adding pre-commit to project
* This PR adds pre-commit to the project, using pretty much the same config file, as in the orca collective repository.
* Also adds the pre-commit to the github action and changes the tests to run in docker containers instead of hard to test github offered images.
* Finally, also updating the CONTRIB.md and the PR template to mention pre-commit, but a bigger re-write of the documentation should be done once the backport project is complete