### PR TITLE
Backport/follow up

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+from http import HTTPStatus
 from logging.handlers import RotatingFileHandler
 
 import bleach
@@ -95,11 +96,11 @@ def create_app(config_name="default"):
         return _handler_method
 
     error_handlers = [
-        (403, "Forbidden", "403.html"),
-        (404, "Not found", "404.html"),
-        (413, "File too large", "413.html"),
-        (429, "Too many requests", "429.html"),
-        (500, "Internal Server Error", "500.html"),
+        (HTTPStatus.FORBIDDEN, "Forbidden", "403.html"),
+        (HTTPStatus.NOT_FOUND, "Not found", "404.html"),
+        (HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "File too large", "413.html"),
+        (HTTPStatus.TOO_MANY_REQUESTS, "Too many requests", "429.html"),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "500.html"),
     ]
     for code, error, template in error_handlers:
         # Pass generated errorhandler function to @app.errorhandler decorator

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -254,9 +254,7 @@ def officer_profile(officer_id):
             face_paths.append(serve_image(face.image.filepath))
         if not face_paths:
             # Add in the placeholder image if no faces are found
-            face_paths = [
-                url_for("static", filename="images/placeholder.png", _external=True)
-            ]
+            face_paths = [url_for("static", filename="images/placeholder.png")]
     except:  # noqa: E722
         exception_type, value, full_tback = sys.exc_info()
         current_app.logger.error(
@@ -270,7 +268,6 @@ def officer_profile(officer_id):
             officer.image_url = url_for(
                 "static",
                 filename=faces[0].image.filepath.replace("/static/", ""),
-                _external=True,
             )
         if faces[0].face_width and faces[0].face_height:
             officer.image_width = faces[0].face_width


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Quick follow up to the recent backport work.

Changes proposed in this pull request:

 - Fix an issue that prevented the placeholder image from being shown in prod environments
   - The problem was that _external used "http" as default scheme, but _external is not needed here I am pretty sure
 - Replace magic numbers (http status numbers) with httpstatus constants.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `pre-commit` checks pass
