### PR TITLE
Restructure `utils.py` to its own package

### DIFF
--- a/OpenOversight/app/auth/forms.py
+++ b/OpenOversight/app/auth/forms.py
@@ -10,7 +10,7 @@ from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional, Regexp
 
 from ..models import User
-from ..utils import dept_choices
+from OpenOversight.app.util.utils import dept_choices
 
 
 class LoginForm(Form):

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -14,9 +14,8 @@ from flask_login import current_user, login_required, login_user, logout_user
 from .. import sitemap
 from ..email import send_email
 from ..models import User, db
+from OpenOversight.app.util.constants import HTTP_METHOD_GET, HTTP_METHOD_POST
 from OpenOversight.app.util.utils import (
-    HTTP_METHOD_GET,
-    HTTP_METHOD_POST,
     set_dynamic_default,
     validate_redirect_url,
 )

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -14,7 +14,7 @@ from flask_login import current_user, login_required, login_user, logout_user
 from .. import sitemap
 from ..email import send_email
 from ..models import User, db
-from ..utils import (
+from OpenOversight.app.util.utils import (
     HTTP_METHOD_GET,
     HTTP_METHOD_POST,
     set_dynamic_default,

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -14,8 +14,8 @@ from flask.cli import with_appcontext
 
 from .csv_imports import import_csv_files
 from .models import Assignment, Department, Job, Officer, Salary, User, db
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 from OpenOversight.app.util.utils import (
-    ENCODING_UTF_8,
     get_officer,
     normalize_gender,
     prompt_yes_no,

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -14,7 +14,7 @@ from flask.cli import with_appcontext
 
 from .csv_imports import import_csv_files
 from .models import Assignment, Department, Job, Officer, Salary, User, db
-from .utils import (
+from OpenOversight.app.util.utils import (
     ENCODING_UTF_8,
     get_officer,
     normalize_gender,

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -31,7 +31,7 @@ from wtforms.validators import (
 
 from ..formfields import TimeField
 from ..models import Officer
-from ..utils import dept_choices, unit_choices
+from OpenOversight.app.util.utils import dept_choices, unit_choices
 from ..widgets import BootstrapListWidget, FormFieldWidget
 from .choices import (
     AGE_CHOICES,

--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -9,7 +9,7 @@ from flask_wtf import FlaskForm as Form
 
 from ..auth.utils import ac_or_admin_required
 from ..models import db
-from ..utils import (
+from OpenOversight.app.util.utils import (
     HTTP_METHOD_GET,
     HTTP_METHOD_POST,
     add_department_query,

--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -9,9 +9,8 @@ from flask_wtf import FlaskForm as Form
 
 from ..auth.utils import ac_or_admin_required
 from ..models import db
+from OpenOversight.app.util.constants import HTTP_METHOD_GET, HTTP_METHOD_POST
 from OpenOversight.app.util.utils import (
-    HTTP_METHOD_GET,
-    HTTP_METHOD_POST,
     add_department_query,
     set_dynamic_default,
 )

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -42,9 +42,8 @@ from ..models import (
     User,
     db,
 )
+from OpenOversight.app.util.constants import HTTP_METHOD_GET, HTTP_METHOD_POST
 from OpenOversight.app.util.utils import (
-    HTTP_METHOD_GET,
-    HTTP_METHOD_POST,
     ac_can_edit_officer,
     add_department_query,
     add_new_assignment,

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -42,7 +42,7 @@ from ..models import (
     User,
     db,
 )
-from ..utils import (
+from OpenOversight.app.util.utils import (
     HTTP_METHOD_GET,
     HTTP_METHOD_POST,
     ac_can_edit_officer,

--- a/OpenOversight/app/model_imports.py
+++ b/OpenOversight/app/model_imports.py
@@ -13,7 +13,7 @@ from .models import (
     Salary,
     db,
 )
-from .utils import get_or_create, str_is_true
+from OpenOversight.app.util.utils import get_or_create, str_is_true
 from .validators import state_validator, url_validator
 
 

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -12,11 +12,11 @@ from sqlalchemy.orm import validates
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from . import login_manager
+from .util.constants import ENCODING_UTF_8
 from .validators import state_validator, url_validator
 
 
 db = SQLAlchemy()
-model_encoding = "utf-8"
 jwt = JsonWebToken("HS512")
 
 BaseModel = db.Model  # type: DefaultMeta
@@ -552,7 +552,7 @@ class User(UserMixin, BaseModel):
 
     def generate_confirmation_token(self, expiration=3600):
         payload = {"confirm": self.id}
-        return self._jwt_encode(payload, expiration).decode(model_encoding)
+        return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
     def confirm(self, token):
         try:
@@ -572,7 +572,7 @@ class User(UserMixin, BaseModel):
 
     def generate_reset_token(self, expiration=3600):
         payload = {"reset": self.id}
-        return self._jwt_encode(payload, expiration).decode(model_encoding)
+        return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
     def reset_password(self, token, new_password):
         try:
@@ -588,7 +588,7 @@ class User(UserMixin, BaseModel):
 
     def generate_email_change_token(self, new_email, expiration=3600):
         payload = {"change_email": self.id, "new_email": new_email}
-        return self._jwt_encode(payload, expiration).decode(model_encoding)
+        return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
     def change_email(self, token):
         try:

--- a/OpenOversight/app/util/constants.py
+++ b/OpenOversight/app/util/constants.py
@@ -1,0 +1,8 @@
+# Encoding constants
+ENCODING_UTF_8 = "utf-8"
+
+# HTTP Method constants
+# TODO: Remove these constants and use HTTPMethod in http package when we
+#  migrate to version 3.11
+HTTP_METHOD_GET = "GET"
+HTTP_METHOD_POST = "POST"

--- a/OpenOversight/app/util/utils.py
+++ b/OpenOversight/app/util/utils.py
@@ -23,9 +23,9 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.expression import cast
 
-from .custom import add_jpeg_patch
-from .main.choices import GENDER_CHOICES, RACE_CHOICES
-from .models import (
+from OpenOversight.app.custom import add_jpeg_patch
+from OpenOversight.app.main.choices import GENDER_CHOICES, RACE_CHOICES
+from OpenOversight.app.models import (
     Assignment,
     Department,
     Description,

--- a/OpenOversight/app/util/utils.py
+++ b/OpenOversight/app/util/utils.py
@@ -44,16 +44,6 @@ from OpenOversight.app.models import (
     db,
 )
 
-
-# Encoding constants
-ENCODING_UTF_8 = "utf-8"
-
-# HTTP Method constants
-# TODO: Remove these constants and use HTTPMethod in http package when we
-#  migrate to version 3.11
-HTTP_METHOD_GET = "GET"
-HTTP_METHOD_POST = "POST"
-
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0o077)
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -20,7 +20,8 @@ from xvfbwrapper import Xvfb
 from OpenOversight.app import create_app, models
 from OpenOversight.app.models import Job, Officer, Unit
 from OpenOversight.app.models import db as _db
-from OpenOversight.app.util.utils import ENCODING_UTF_8, merge_dicts
+from OpenOversight.app.util.constants import ENCODING_UTF_8
+from OpenOversight.app.util.utils import merge_dicts
 from OpenOversight.tests.routes.route_helpers import ADMIN_EMAIL, ADMIN_PASSWORD
 
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -20,7 +20,7 @@ from xvfbwrapper import Xvfb
 from OpenOversight.app import create_app, models
 from OpenOversight.app.models import Job, Officer, Unit
 from OpenOversight.app.models import db as _db
-from OpenOversight.app.utils import ENCODING_UTF_8, merge_dicts
+from OpenOversight.app.util.utils import ENCODING_UTF_8, merge_dicts
 from OpenOversight.tests.routes.route_helpers import ADMIN_EMAIL, ADMIN_PASSWORD
 
 

--- a/OpenOversight/tests/routes/test_descriptions.py
+++ b/OpenOversight/tests/routes/test_descriptions.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.main.forms import EditTextForm, TextForm
 from OpenOversight.app.models import Description, Officer, User, db
-from OpenOversight.app.utils import ENCODING_UTF_8
+from OpenOversight.app.util.utils import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
 
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_descriptions.py
+++ b/OpenOversight/tests/routes/test_descriptions.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.main.forms import EditTextForm, TextForm
 from OpenOversight.app.models import Description, Officer, User, db
-from OpenOversight.app.util.utils import ENCODING_UTF_8
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
 
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -9,7 +9,7 @@ from mock import MagicMock, patch
 from OpenOversight.app.main import views
 from OpenOversight.app.main.forms import FaceTag
 from OpenOversight.app.models import Department, Face, Image, Officer
-from OpenOversight.app.utils import ENCODING_UTF_8
+from OpenOversight.app.util.utils import ENCODING_UTF_8
 
 from ..conftest import AC_DEPT
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -9,7 +9,7 @@ from mock import MagicMock, patch
 from OpenOversight.app.main import views
 from OpenOversight.app.main.forms import FaceTag
 from OpenOversight.app.models import Department, Face, Image, Officer
-from OpenOversight.app.util.utils import ENCODING_UTF_8
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 
 from ..conftest import AC_DEPT
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -14,7 +14,7 @@ from OpenOversight.app.main.forms import (
     OOIdForm,
 )
 from OpenOversight.app.models import Department, Incident, Officer
-from OpenOversight.app.utils import ENCODING_UTF_8
+from OpenOversight.app.util.utils import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
 
 from .route_helpers import login_ac, login_admin, login_user, process_form_data

--- a/OpenOversight/tests/routes/test_notes.py
+++ b/OpenOversight/tests/routes/test_notes.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.main.forms import EditTextForm, TextForm
 from OpenOversight.app.models import Note, Officer, User, db
-from OpenOversight.app.utils import ENCODING_UTF_8
+from OpenOversight.app.util.utils import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
 
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_notes.py
+++ b/OpenOversight/tests/routes/test_notes.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.main.forms import EditTextForm, TextForm
 from OpenOversight.app.models import Note, Officer, User, db
-from OpenOversight.app.util.utils import ENCODING_UTF_8
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
 
 from .route_helpers import login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -41,7 +41,7 @@ from OpenOversight.app.models import (
     Unit,
     User,
 )
-from OpenOversight.app.utils import (
+from OpenOversight.app.util.utils import (
     ENCODING_UTF_8,
     add_new_assignment,
     dept_choices,

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -41,8 +41,8 @@ from OpenOversight.app.models import (
     Unit,
     User,
 )
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 from OpenOversight.app.util.utils import (
-    ENCODING_UTF_8,
     add_new_assignment,
     dept_choices,
     unit_choices,

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 import pytest
 from flask import current_app, url_for
 
-from OpenOversight.app.util.utils import ENCODING_UTF_8
+from OpenOversight.app.util.constants import ENCODING_UTF_8
 
 from .route_helpers import login_user
 

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 import pytest
 from flask import current_app, url_for
 
-from OpenOversight.app.utils import ENCODING_UTF_8
+from OpenOversight.app.util.utils import ENCODING_UTF_8
 
 from .route_helpers import login_user
 

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.auth.forms import EditUserForm, LoginForm, RegistrationForm
 from OpenOversight.app.models import User, db
-from OpenOversight.app.utils import ENCODING_UTF_8, HTTP_METHOD_GET, HTTP_METHOD_POST
+from OpenOversight.app.util.utils import ENCODING_UTF_8, HTTP_METHOD_GET, HTTP_METHOD_POST
 
 from ..conftest import AC_DEPT
 from .route_helpers import ADMIN_EMAIL, login_ac, login_admin, login_user

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -6,7 +6,7 @@ from flask import current_app, url_for
 
 from OpenOversight.app.auth.forms import EditUserForm, LoginForm, RegistrationForm
 from OpenOversight.app.models import User, db
-from OpenOversight.app.util.utils import ENCODING_UTF_8, HTTP_METHOD_GET, HTTP_METHOD_POST
+from OpenOversight.app.util.constants import ENCODING_UTF_8, HTTP_METHOD_GET, HTTP_METHOD_POST
 
 from ..conftest import AC_DEPT
 from .route_helpers import ADMIN_EMAIL, login_ac, login_admin, login_user

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -27,7 +27,7 @@ from OpenOversight.app.models import (
     Salary,
     Unit,
 )
-from OpenOversight.app.utils import get_officer
+from OpenOversight.app.util.utils import get_officer
 from OpenOversight.tests.conftest import RANK_CHOICES_1, generate_officer
 
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -7,7 +7,7 @@ from mock import MagicMock, Mock, patch
 
 import OpenOversight
 from OpenOversight.app.models import Department, Image, Officer, Unit
-from OpenOversight.app.utils import (
+from OpenOversight.app.util.utils import (
     crop_image,
     filter_by_form,
     upload_image_to_s3_and_store_in_db,
@@ -26,7 +26,7 @@ upload_s3_patch = patch(
 
 def test_department_filter(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {
             "race": ["Not Sure"],
             "gender": ["Not Sure"],
@@ -45,7 +45,7 @@ def test_department_filter(mockdata):
 
 def test_race_filter_select_all_black_officers(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"race": ["BLACK"], "dept": department}
     )
     for element in results.all():
@@ -54,7 +54,7 @@ def test_race_filter_select_all_black_officers(mockdata):
 
 def test_gender_filter_select_all_male_or_not_sure_officers(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"gender": ["M"], "dept": department}
     )
 
@@ -67,7 +67,7 @@ def test_gender_filter_select_all_male_or_not_sure_officers(mockdata):
 
 def test_gender_filter_include_all_genders_if_not_sure(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"gender": ["Not Sure"], "dept": department}
     )
 
@@ -81,7 +81,7 @@ def test_gender_filter_include_all_genders_if_not_sure(mockdata):
 
 def test_rank_filter_select_all_commanders(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"rank": ["Commander"], "dept": department}
     )
     for element in results.all():
@@ -91,7 +91,7 @@ def test_rank_filter_select_all_commanders(mockdata):
 
 def test_rank_filter_select_all_police_officers(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"rank": ["Police Officer"], "dept": department}
     )
     for element in results.all():
@@ -101,7 +101,7 @@ def test_rank_filter_select_all_police_officers(mockdata):
 
 def test_filter_by_name(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {"last_name": "J", "dept": department}
     )
     for element in results.all():
@@ -113,13 +113,13 @@ def test_filters_do_not_exclude_officers_without_assignments(mockdata):
     officer = OpenOversight.app.models.Officer(
         first_name="Rachel", last_name="S", department=department, birth_year=1992
     )
-    results = OpenOversight.app.utils.grab_officers({"name": "S", "dept": department})
+    results = OpenOversight.app.util.utils.grab_officers({"name": "S", "dept": department})
     assert officer in results.all()
 
 
 def test_filter_by_badge_no(mockdata):
     department = OpenOversight.app.models.Department.query.first()
-    results = OpenOversight.app.utils.grab_officers({"badge": "12", "dept": department})
+    results = OpenOversight.app.util.utils.grab_officers({"badge": "12", "dept": department})
     for element in results.all():
         assignment = element.assignments.first()
         assert "12" in str(assignment.star_no)
@@ -130,7 +130,7 @@ def test_filter_by_full_unique_internal_identifier_returns_officers(mockdata):
     target_unique_internal_id = (
         OpenOversight.app.models.Officer.query.first().unique_internal_identifier
     )
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {
             "race": ["Not Sure"],
             "gender": ["Not Sure"],
@@ -154,7 +154,7 @@ def test_filter_by_partial_unique_internal_identifier_returns_officers(mockdata)
         OpenOversight.app.models.Officer.query.first().unique_internal_identifier
     )
     partial_identifier = identifier[: len(identifier) // 2]
-    results = OpenOversight.app.utils.grab_officers(
+    results = OpenOversight.app.util.utils.grab_officers(
         {
             "race": ["Not Sure"],
             "gender": ["Not Sure"],
@@ -173,7 +173,7 @@ def test_filter_by_partial_unique_internal_identifier_returns_officers(mockdata)
 
 
 def test_compute_hash(mockdata):
-    hash_result = OpenOversight.app.utils.compute_hash(b"bacon")
+    hash_result = OpenOversight.app.util.utils.compute_hash(b"bacon")
     expected_hash = "9cca0703342e24806a9f64e08c053dca7f2cd90f10529af8ea872afb0a0c77d4"
     assert hash_result == expected_hash
 
@@ -183,7 +183,7 @@ def test_s3_upload_png(mockdata, test_png_BytesIO):
     mocked_resource = Mock()
     with patch("boto3.client", Mock(return_value=mocked_connection)):
         with patch("boto3.resource", Mock(return_value=mocked_resource)):
-            OpenOversight.app.utils.upload_obj_to_s3(test_png_BytesIO, "test_cop1.png")
+            OpenOversight.app.util.utils.upload_obj_to_s3(test_png_BytesIO, "test_cop1.png")
 
     assert (
         mocked_connection.method_calls[0][2]["ExtraArgs"]["ContentType"] == "image/png"
@@ -195,7 +195,7 @@ def test_s3_upload_jpeg(mockdata, test_jpg_BytesIO):
     mocked_resource = Mock()
     with patch("boto3.client", Mock(return_value=mocked_connection)):
         with patch("boto3.resource", Mock(return_value=mocked_resource)):
-            OpenOversight.app.utils.upload_obj_to_s3(test_jpg_BytesIO, "test_cop5.jpg")
+            OpenOversight.app.util.utils.upload_obj_to_s3(test_jpg_BytesIO, "test_cop5.jpg")
 
     assert (
         mocked_connection.method_calls[0][2]["ExtraArgs"]["ContentType"] == "image/jpeg"
@@ -210,21 +210,21 @@ def test_user_can_submit_allowed_file(mockdata):
         "valid_photo.PNG",
         "valid_photo.JPG",
     ]:
-        assert OpenOversight.app.utils.allowed_file(file_to_submit) is True
+        assert OpenOversight.app.util.utils.allowed_file(file_to_submit) is True
 
 
 def test_user_cannot_submit_malicious_file(mockdata):
     file_to_submit = "passwd"
-    assert OpenOversight.app.utils.allowed_file(file_to_submit) is False
+    assert OpenOversight.app.util.utils.allowed_file(file_to_submit) is False
 
 
 def test_user_cannot_submit_invalid_file_extension(mockdata):
     file_to_submit = "tests/test_models.py"
-    assert OpenOversight.app.utils.allowed_file(file_to_submit) is False
+    assert OpenOversight.app.util.utils.allowed_file(file_to_submit) is False
 
 
 def test_unit_choices(mockdata):
-    unit_choices = [str(x) for x in OpenOversight.app.utils.unit_choices()]
+    unit_choices = [str(x) for x in OpenOversight.app.util.utils.unit_choices()]
     assert "Unit: Bureau of Organized Crime" in unit_choices
 
 


### PR DESCRIPTION
## Status
In progress

## Description of Changes
Changed `utils.py` file from a gigantic mono-file to a package with more specialized files.

Fixes: https://github.com/lucyparsons/OpenOversight/issues/913

## Tests and linting
 - [ ] I have rebased my changes on current `develop`
 - [ ] pytests pass in the development environment on my local machine
 - [ ] `pre-commit` checks pass
