### PR TITLE
Support absolute imports in prod image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build_with_version:
 
 .PHONY: test_with_version
 test_with_version: build_with_version assets
-	FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n 4 --dist=loadfile -v tests/ app;
+	FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 .PHONY: start
 start: build  ## Run containers
@@ -48,13 +48,9 @@ populate: create_db  ## Build and run containers
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; then \
-	    if [ "$$(uname)" == "Darwin" ]; then \
-			FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n $$(sysctl -n hw.logicalcpu) --dist=loadfile -v tests/ app; \
-		else \
-			FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n $$(nproc --all) --dist=loadfile -v tests/ app; \
-		fi; \
+		FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-	    FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -v tests/ app -k $(name); \
+	    FLASK_ENV=testing docker-compose run --rm web pytest --doctest-modules -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint

--- a/OpenOversight/scripts/entrypoint_prod.sh
+++ b/OpenOversight/scripts/entrypoint_prod.sh
@@ -5,4 +5,4 @@ yarn build
 # Copy static assets into NEW folder, specifically at runtime
 cp -R /usr/src/app/OpenOversight/app/static/* /usr/src/app/OpenOversight/static/
 # Run flask server via gunicorn
-gunicorn -w 4 -b 0.0.0.0:3000 app:app
+gunicorn -w 4 -b 0.0.0.0:3000 OpenOversight.app:app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
      APPROVE_REGISTRATIONS: "${APPROVE_REGISTRATIONS}"
-     FLASK_APP: app
+     FLASK_APP: OpenOversight.app
      FLASK_ENV: "${FLASK_ENV:-development}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
@@ -40,6 +40,5 @@ services:
      - postgres:postgres
    expose:
      - "3000"
-   command: scripts/entrypoint.sh
    ports:
      - "3000:3000"

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,6 +1,6 @@
 ARG TRAVIS_PYTHON_VERSION
 ARG DOCKER_BUILD_ENV
-FROM python:${TRAVIS_PYTHON_VERSION:-3.5}-buster
+FROM python:${TRAVIS_PYTHON_VERSION:-3.8}-buster
 
 WORKDIR /usr/src/app
 
@@ -57,6 +57,6 @@ ENV PATH="/usr/src/app/geckodriver:${PATH}"
 ENV SECRET_KEY 4Q6ZaQQdiqtmvZaxP1If
 ENV SQLALCHEMY_DATABASE_URI postgresql://openoversight:terriblepassword@postgres/openoversight-dev
 
-WORKDIR /usr/src/app/OpenOversight
+WORKDIR /usr/src/app/
 
-CMD ["scripts/entrypoint.sh"]
+CMD ["OpenOversight/scripts/entrypoint_dev.sh"]

--- a/dockerfiles/web/Dockerfile-prod
+++ b/dockerfiles/web/Dockerfile-prod
@@ -46,9 +46,9 @@ RUN yarn
 # Copy python script to initialize database.
 COPY create_db.py /usr/src/app/
 
-WORKDIR /usr/src/app/OpenOversight
+WORKDIR /usr/src/app/
 
 FROM base as production
 # Copy source files.
-COPY OpenOversight .
-CMD ["scripts/entrypoint_prod.sh"]
+COPY OpenOversight OpenOversight
+CMD ["OpenOversight/scripts/entrypoint_prod.sh"]


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - Make absolute imports work in prod image
   - Absolute imports worked locally, but not in production. Now that we use docker to deploy we can actually fix that by making a small change to the gunicorn start command and the working directory set in the dockerfiles.
   - I mirrored the change in the local environment, so hopefully we can catch most problems before staging
 - Some changes to the tests makefile were required too

## Notes for Deployment

## Screenshots (if appropriate)

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `pre-commit` checks pass
