### PR TITLE
Fix dockerfile by removing outdated source.

### DIFF
--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -10,9 +10,8 @@ ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
 
 # install apt dependencies
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev && \
-    apt-get install -y -t stretch-backports libsqlite3-0 && apt-get clean
+    apt-get install -y libsqlite3-0 && apt-get clean
 
 # install node
 ENV NODE_SETUP_SHA=5d07994f59e3edc2904c547e772b818d10abb066f6ff36ab3db5d686b0fe9a73


### PR DESCRIPTION
The debian source "stretch-backports" has been removed. We don't need that backport to use libsqlite3.0 anymore, so we can remove all references to it.

## Status

Ready for review

## Description of Changes

Fixes issues with message `E: The repository 'http://deb.debian.org/debian stretch-backports Release' does not have a Release file.`

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [ ] pytests pass in the development environment on my local machine

 - [x] `pre-commit` checks pass