### PR TITLE
Packages/test performance

### DIFF
--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -67,6 +67,7 @@ class TestingConfig(BaseConfig):
     NUM_OFFICERS = 120
     APPROVE_REGISTRATIONS = False
     SITEMAP_URL_SCHEME = "http"
+    RATELIMIT_ENABLED = False
 
 
 class ProductionConfig(BaseConfig):

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -50,8 +50,8 @@ RANK_CHOICES_2 = [
 ]
 
 DEPARTMENT_NAME = "Springfield Police Department"
-DEPARTMENT_TWO_NAME = "Chicago Police Department"
-DEPARTMENT_EMPTY_NAME = "Empty Police Department"
+OTHER_DEPARTMENT_NAME = "Chicago Police Department"
+DEPARTMENT_WITHOUT_OFFICERS_NAME = "Empty Police Department"
 
 
 AC_DEPT = 1
@@ -287,9 +287,11 @@ def add_mockdata(session):
         unique_internal_identifier_label="homer_number",
     )
     session.add(department)
-    department2 = models.Department(name=DEPARTMENT_TWO_NAME, short_name="CPD")
+    department2 = models.Department(name=OTHER_DEPARTMENT_NAME, short_name="CPD")
     session.add(department2)
-    empty_department = models.Department(name=DEPARTMENT_EMPTY_NAME, short_name="EPD")
+    empty_department = models.Department(
+        name=DEPARTMENT_WITHOUT_OFFICERS_NAME, short_name="EPD"
+    )
     session.add(empty_department)
     session.commit()
 
@@ -339,13 +341,13 @@ def add_mockdata(session):
 
     test_images = [
         models.Image(
-            filepath="/static/images/test_cop{}.png".format(x + 1),
+            filepath=f"/static/images/test_cop{x+1}.png",
             department_id=department.id,
         )
         for x in range(5)
     ] + [
         models.Image(
-            filepath="/static/images/test_cop{}.png".format(x + 1),
+            filepath=f"/static/images/test_cop{x+1}.png",
             department_id=department2.id,
         )
         for x in range(5)
@@ -386,18 +388,17 @@ def add_mockdata(session):
     jobs_dept1 = models.Job.query.filter_by(department_id=1).all()
     jobs_dept2 = models.Job.query.filter_by(department_id=2).all()
 
-    assignment_ratio = 0.9
+    # which percentage of officers have an assignment
+    assignment_ratio = 0.9  # 90%
+    num_officers_with_assignments_1 = math.ceil(len(officers_dept1) * assignment_ratio)
     assignments_dept1 = [
         build_assignment(officer, test_units, jobs_dept1)
-        for officer in officers_dept1[
-            : math.ceil(len(officers_dept1) * assignment_ratio)
-        ]
+        for officer in officers_dept1[:num_officers_with_assignments_1]
     ]
+    num_officers_with_assignments_2 = math.ceil(len(officers_dept2) * assignment_ratio)
     assignments_dept2 = [
         build_assignment(officer, test_units, jobs_dept2)
-        for officer in officers_dept2[
-            : math.ceil(len(officers_dept2) * assignment_ratio)
-        ]
+        for officer in officers_dept2[:num_officers_with_assignments_2]
     ]
 
     salaries = [build_salary(officer) for officer in all_officers]
@@ -603,8 +604,10 @@ def department(session):
 
 
 @pytest.fixture
-def new_department(session):
-    return models.Department.query.filter_by(name=DEPARTMENT_EMPTY_NAME).one()
+def department_without_officers(session):
+    return models.Department.query.filter_by(
+        name=DEPARTMENT_WITHOUT_OFFICERS_NAME
+    ).one()
 
 
 @pytest.fixture

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -42,10 +42,10 @@ from OpenOversight.app.models import (
     User,
 )
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
-from OpenOversight.app.utils.db import dept_choices, unit_choices
+from OpenOversight.app.utils.db import unit_choices
 from OpenOversight.app.utils.forms import add_new_assignment
 
-from ..conftest import AC_DEPT, RANK_CHOICES_1
+from ..conftest import AC_DEPT, DEPARTMENT_NAME, RANK_CHOICES_1
 from .route_helpers import login_ac, login_admin, login_user, process_form_data
 
 
@@ -336,7 +336,8 @@ def test_admin_edit_assignment_validation_error(mockdata, client, session):
         login_admin(client)
 
         # Remove existing assignments
-        officer = Officer.query.filter_by(id=3).one()
+        officer = Officer.query.filter_by(id=10).one()
+        print(officer, officer.department, officer.assignments.all())
         job = Job.query.filter_by(
             department_id=officer.department_id, job_title="Police Officer"
         ).one()
@@ -348,14 +349,21 @@ def test_admin_edit_assignment_validation_error(mockdata, client, session):
         )
 
         rv = client.post(
-            url_for("main.add_assignment", officer_id=3),
+            url_for("main.add_assignment", officer_id=10),
             data=form.data,
             follow_redirects=True,
         )
 
         # Attempt to set resign date to a date before the start date
         form = AssignmentForm(resign_date=date(2018, 12, 31))
-        officer = Officer.query.filter_by(id=3).one()
+        officer = Officer.query.filter_by(id=10).one()
+
+        print(
+            officer,
+            officer.department,
+            officer.assignments.all(),
+            officer.assignments.all()[0].__dict__,
+        )
 
         rv = client.post(
             url_for(
@@ -604,11 +612,9 @@ def test_admin_can_edit_police_department(mockdata, client, session):
         assert edit_short_name_department.short_name == "CPD"
 
 
-def test_ac_cannot_edit_police_department(mockdata, client, session):
+def test_ac_cannot_edit_police_department(mockdata, client, session, department):
     with current_app.test_request_context():
         login_ac(client)
-
-        department = Department.query.first()
 
         form = EditDepartmentForm(name="Corrected Police Department", short_name="CPD")
 
@@ -621,21 +627,19 @@ def test_ac_cannot_edit_police_department(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_can_edit_rank_order(mockdata, client, session):
+def test_admin_can_edit_rank_order(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-
-        ranks = (
-            Department.query.filter_by(name="Springfield Police Department").one().jobs
-        )
+        department_name = department.name
+        ranks = department.jobs
         ranks_update = ranks.copy()
         original_first_rank = copy.deepcopy(ranks_update[0])
         ranks_update[0], ranks_update[1] = ranks_update[1], ranks_update[0]
         ranks_stringified = [rank.job_title for rank in ranks_update]
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department",
-            short_name="SPD",
+            name=department_name,
+            short_name=department.short_name,
             jobs=ranks_stringified,
         )
         processed_data = process_form_data(rank_change_form.data)
@@ -646,30 +650,25 @@ def test_admin_can_edit_rank_order(mockdata, client, session):
             follow_redirects=True,
         )
 
-        updated_ranks = (
-            Department.query.filter_by(name="Springfield Police Department").one().jobs
-        )
-        assert "Department Springfield Police Department edited" in rv.data.decode(
-            ENCODING_UTF_8
-        )
+        updated_ranks = Department.query.filter_by(name=department_name).one().jobs
+        assert f"Department {department_name} edited" in rv.data.decode(ENCODING_UTF_8)
         assert (
             updated_ranks[0].job_title == original_first_rank.job_title
             and updated_ranks[0].order != original_first_rank.order
         )
 
 
-def test_admin_cannot_delete_rank_in_use(mockdata, client, session):
+def test_admin_cannot_delete_rank_in_use(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
-        ranks = (
-            Department.query.filter_by(name="Springfield Police Department").one().jobs
-        )
+        ranks = department.jobs
+        department_name = department.name
         original_ranks = ranks.copy()
         ranks_update = RANK_CHOICES_1.copy()[:-1]
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -679,9 +678,7 @@ def test_admin_cannot_delete_rank_in_use(mockdata, client, session):
             follow_redirects=True,
         )
 
-        updated_ranks = (
-            Department.query.filter_by(name="Springfield Police Department").one().jobs
-        )
+        updated_ranks = Department.query.filter_by(name=department_name).one().jobs
         assert (
             "You attempted to delete a rank, Commander, that is still in use"
             in result.data.decode(ENCODING_UTF_8)
@@ -689,10 +686,10 @@ def test_admin_cannot_delete_rank_in_use(mockdata, client, session):
         assert len(updated_ranks) == len(original_ranks)
 
 
-def test_admin_can_delete_rank_not_in_use(mockdata, client, session):
+def test_admin_can_delete_rank_not_in_use(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-
+        department_name = department.name
         ranks_update = RANK_CHOICES_1.copy()
         original_ranks_length = len(ranks_update)
         ranks_update.append(
@@ -705,7 +702,7 @@ def test_admin_can_delete_rank_not_in_use(mockdata, client, session):
         )
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -718,24 +715,18 @@ def test_admin_can_delete_rank_not_in_use(mockdata, client, session):
 
         assert rv.status_code == HTTPStatus.OK
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length + 1
         )
 
         ranks_update = [
             job.job_title
-            for job in Department.query.filter_by(name="Springfield Police Department")
-            .one()
-            .jobs
+            for job in Department.query.filter_by(name=department_name).one().jobs
         ]
         ranks_update = ranks_update[:-1]
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -748,16 +739,14 @@ def test_admin_can_delete_rank_not_in_use(mockdata, client, session):
 
         assert rv.status_code == HTTPStatus.OK
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length
         )
 
 
-def test_admin_can_delete_multiple_ranks_not_in_use(mockdata, client, session):
+def test_admin_can_delete_multiple_ranks_not_in_use(
+    mockdata, client, session, department
+):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -766,8 +755,10 @@ def test_admin_can_delete_multiple_ranks_not_in_use(mockdata, client, session):
         ranks_update.append("Temporary Rank 1")
         ranks_update.append("Temporary Rank 2")
 
+        department_name = department.name
+
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -780,24 +771,18 @@ def test_admin_can_delete_multiple_ranks_not_in_use(mockdata, client, session):
 
         assert rv.status_code == HTTPStatus.OK
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length + 2
         )
 
         ranks_update = [
             job.job_title
-            for job in Department.query.filter_by(name="Springfield Police Department")
-            .one()
-            .jobs
+            for job in Department.query.filter_by(name=department_name).one().jobs
         ]
         ranks_update = ranks_update[:-2]
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -810,17 +795,13 @@ def test_admin_can_delete_multiple_ranks_not_in_use(mockdata, client, session):
 
         assert rv.status_code == HTTPStatus.OK
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length
         )
 
 
 def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_use_rank(
-    mockdata, client, session
+    mockdata, client, session, department
 ):
     with current_app.test_request_context():
         login_admin(client)
@@ -835,9 +816,9 @@ def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_us
                 department_id=1,
             )
         )
-
+        department_name = department.name
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -850,25 +831,19 @@ def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_us
 
         assert rv.status_code == HTTPStatus.OK
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length + 1
         )
 
         # attempt to delete multiple ranks
         ranks_update = [
             job.job_title
-            for job in Department.query.filter_by(name="Springfield Police Department")
-            .one()
-            .jobs
+            for job in Department.query.filter_by(name=department_name).one().jobs
         ]
         ranks_update = ranks_update[:-2]
 
         rank_change_form = EditDepartmentForm(
-            name="Springfield Police Department", short_name="SPD", jobs=ranks_update
+            name=department_name, short_name=department.short_name, jobs=ranks_update
         )
         processed_data = process_form_data(rank_change_form.data)
 
@@ -880,11 +855,7 @@ def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_us
         )
 
         assert (
-            len(
-                Department.query.filter_by(name="Springfield Police Department")
-                .one()
-                .jobs
-            )
+            len(Department.query.filter_by(name=department_name).one().jobs)
             == original_ranks_length + 1
         )
 
@@ -948,13 +919,12 @@ def test_expected_dept_appears_in_submission_dept_selection(mockdata, client, se
 
         rv = client.get(url_for("main.submit_data"), follow_redirects=True)
 
-        assert "Springfield Police Department" in rv.data.decode(ENCODING_UTF_8)
+        assert DEPARTMENT_NAME in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_can_add_new_officer(mockdata, client, session):
+def test_admin_can_add_new_officer(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
         links = [
             LinkForm(url="http://www.pleasework.com", link_type="link").data,
             LinkForm(url="http://www.avideo/?v=2345jk", link_type="video").data,
@@ -986,10 +956,9 @@ def test_admin_can_add_new_officer(mockdata, client, session):
         assert officer.gender == "M"
 
 
-def test_admin_can_add_new_officer_with_unit(mockdata, client, session):
+def test_admin_can_add_new_officer_with_unit(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
         unit = random.choice(unit_choices())
         links = [
             LinkForm(url="http://www.pleasework.com", link_type="link").data,
@@ -1147,10 +1116,9 @@ def test_ac_cannot_add_new_officer_not_in_their_dept(mockdata, client, session):
         assert officer is None
 
 
-def test_admin_can_edit_existing_officer(mockdata, client, session):
+def test_admin_can_edit_existing_officer(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
         unit = random.choice(unit_choices())
         link_url0 = "http://pleasework.com"
         link_url1 = "http://avideo/?v=2345jk"
@@ -1297,11 +1265,12 @@ def test_ac_can_edit_officer_in_their_dept(mockdata, client, session):
         assert officer.last_name == new_last_name
 
 
-def test_admin_adds_officer_without_middle_initial(mockdata, client, session):
+def test_admin_adds_officer_without_middle_initial(
+    mockdata, client, session, department
+):
     with current_app.test_request_context():
         login_admin(client)
 
-        department = random.choice(dept_choices())
         job = Job.query.filter_by(department_id=department.id).first()
         form = AddOfficerForm(
             first_name="Test",
@@ -1327,11 +1296,12 @@ def test_admin_adds_officer_without_middle_initial(mockdata, client, session):
         assert officer.gender == "M"
 
 
-def test_admin_adds_officer_with_letter_in_badge_no(mockdata, client, session):
+def test_admin_adds_officer_with_letter_in_badge_no(
+    mockdata, client, session, department
+):
     with current_app.test_request_context():
         login_admin(client)
 
-        department = random.choice(dept_choices())
         job = Job.query.filter_by(department_id=department.id).first()
         form = AddOfficerForm(
             first_name="Test",
@@ -1358,13 +1328,10 @@ def test_admin_adds_officer_with_letter_in_badge_no(mockdata, client, session):
         assert officer.assignments[0].star_no == "T666"
 
 
-def test_admin_can_add_new_unit(mockdata, client, session):
+def test_admin_can_add_new_unit(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
-        department = Department.query.filter_by(
-            name="Springfield Police Department"
-        ).first()
         form = AddUnitForm(descrip="Test", department=department.id)
 
         rv = client.post(
@@ -1412,10 +1379,9 @@ def test_ac_cannot_add_new_unit_not_in_their_dept(mockdata, client, session):
         assert unit is None
 
 
-def test_admin_can_add_new_officer_with_suffix(mockdata, client, session):
+def test_admin_can_add_new_officer_with_suffix(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
         links = [
             LinkForm(url="http://www.pleasework.com", link_type="link").data,
             LinkForm(url="http://www.avideo/?v=2345jk", link_type="video").data,
@@ -1467,10 +1433,9 @@ def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_officer_csv(mockdata, client, session):
+def test_officer_csv(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
         links = [
             LinkForm(url="http://www.pleasework.com", link_type="link").data,
         ]
@@ -1517,9 +1482,8 @@ def test_officer_csv(mockdata, client, session):
         assert form.star_no.data == added_lines[0]["badge number"]
 
 
-def test_assignments_csv(mockdata, client, session):
+def test_assignments_csv(mockdata, client, session, department):
     with current_app.test_request_context():
-        department = random.choice(dept_choices())
         officer = Officer.query.filter_by(department_id=department.id).first()
         job = (
             Job.query.filter_by(department_id=department.id)
@@ -1557,10 +1521,9 @@ def test_assignments_csv(mockdata, client, session):
         assert new_assignment[0]["job title"] == job.job_title
 
 
-def test_incidents_csv(mockdata, client, session):
+def test_incidents_csv(mockdata, client, session, department):
     with current_app.test_request_context():
         login_admin(client)
-        department = random.choice(dept_choices())
 
         # Delete existing incidents for chosen department
         Incident.query.filter_by(department_id=department.id).delete()
@@ -2163,9 +2126,10 @@ def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
         assert float(officer.salaries[0].salary) == 123456.78
 
 
-def test_get_department_ranks_with_specific_department_id(mockdata, client, session):
+def test_get_department_ranks_with_specific_department_id(
+    mockdata, client, session, department
+):
     with current_app.test_request_context():
-        department = Department.query.first()
         rv = client.get(
             url_for("main.get_dept_ranks", department_id=department.id),
             follow_redirects=True,

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -430,13 +430,17 @@ def test_csv_new_salary(csvfile, monkeypatch):
         assert float(salary.salary) == 123456.78 or float(salary.salary) == 150000.00
 
 
-def test_bulk_add_officers__success(session, new_department, csv_path, monkeypatch):
+def test_bulk_add_officers__success(
+    session, department_without_officers, csv_path, monkeypatch
+):
     monkeypatch.setattr("builtins.input", lambda: "y")
     # generate two officers with different names
-    first_officer = generate_officer(new_department)
+    first_officer = generate_officer(department_without_officers)
     print(Job.query.all())
-    print(Job.query.filter_by(department=new_department).all())
-    job = (Job.query.filter_by(department=new_department).filter_by(order=1)).first()
+    print(Job.query.filter_by(department=department_without_officers).all())
+    job = (
+        Job.query.filter_by(department=department_without_officers).filter_by(order=1)
+    ).first()
     fo_fn = "Uniquefirst"
     first_officer.first_name = fo_fn
     fo_ln = first_officer.last_name
@@ -445,7 +449,7 @@ def test_bulk_add_officers__success(session, new_department, csv_path, monkeypat
     assignment = Assignment(baseofficer=first_officer, job_id=job.id)
     session.add(assignment)
     session.commit()
-    different_officer = generate_officer(new_department)
+    different_officer = generate_officer(department_without_officers)
     different_officer.job = job
     do_fn = different_officer.first_name
     do_ln = different_officer.last_name
@@ -454,7 +458,7 @@ def test_bulk_add_officers__success(session, new_department, csv_path, monkeypat
     session.add(assignment)
     session.commit()
 
-    department_id = new_department.id
+    department_id = department_without_officers.id
 
     # generate csv to update one existing officer and add one new
 
@@ -708,12 +712,12 @@ def test_bulk_add_officers__write_static_field__flag_set(
 
 
 def test_bulk_add_officers__no_create_flag(
-    session, new_department, csv_path, monkeypatch
+    session, department_without_officers, csv_path, monkeypatch
 ):
     monkeypatch.setattr("builtins.input", lambda: "y")
     # department with one officer
-    department_id = new_department.id
-    officer = generate_officer(new_department)
+    department_id = department_without_officers.id
+    officer = generate_officer(department_without_officers)
     officer.gender = None
     session.add(officer)
     session.commit()
@@ -1292,15 +1296,15 @@ def test_advanced_csv_import__update_officer_different_department(
 
 
 def test_advanced_csv_import__unit_other_department(
-    session, department, new_department, tmp_path
+    session, department, department_without_officers, tmp_path
 ):
     # set up data
     officer = generate_officer(department)
     session.add(officer)
     session.flush()
-    session.add(new_department)
+    session.add(department_without_officers)
     session.flush()
-    unit = Unit(department_id=new_department.id)
+    unit = Unit(department_id=department_without_officers.id)
     session.add(unit)
     session.flush()
 
@@ -1325,7 +1329,7 @@ def test_advanced_csv_import__unit_other_department(
 
 
 def test_create_officer_from_row_adds_new_officer_and_normalizes_gender(
-    app, session, new_department
+    app, session, department_without_officers
 ):
     with app.app_context():
         lookup_officer = Officer.query.filter_by(
@@ -1340,7 +1344,7 @@ def test_create_officer_from_row_adds_new_officer_and_normalizes_gender(
             "employment_date": "1980-12-01",
             "unique_internal_identifier": "officer-jones-unique-id",
         }
-        create_officer_from_row(row, new_department.id)
+        create_officer_from_row(row, department_without_officers.id)
 
         lookup_officer = Officer.query.filter_by(
             first_name="NewOfficerFromRow"

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -157,7 +157,7 @@ def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
 
     dept_without_uii = Department.query.filter_by(
         unique_internal_identifier_label=None
-    ).one_or_none()
+    ).first()
     dept_id = str(dept_without_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Changes proposed in this pull request:

 - For some reason the mockdata used in the tests not only contains a lot of data, but it was freshly inserted into the database for every test that used it.
   - Now we will load the mockdata into the in-memory database only once (via the fixture with scope session). This makes tests significantly faster.
   - Adding an additional department to the mockdata broke some tests which had to be fixed.
   - Changing anything in the mockdata brakes tests because some of the data is assigned pseudo-randomly (random with fixed seed), so a test might fail because an officer used to not have a link in the profile but does after the change. I fixed the failing tests in a way that this does not happen again.

## Notes for Deployment
 Changes tests only

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `pre-commit` checks pass
