### PR TITLE
Fix issue with new version of Flask-Migrate.

### DIFF
--- a/OpenOversight/migrations/env.py
+++ b/OpenOversight/migrations/env.py
@@ -79,7 +79,6 @@ def run_migrations_online():
     context.configure(
         connection=connection,
         target_metadata=target_metadata,
-        compare_type=True,
         process_revision_directives=process_revision_directives,
         **current_app.extensions["migrate"].configure_args,
     )


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes issue when deploying, see https://github.com/lucyparsons/OpenOversight/actions/runs/5065271720/jobs/9251958094
`TypeError: configure() got multiple values for keyword argument 'compare_type'`

The `compare_type` argument is now directly set to true in the flask-migrate default configuration. Removing the line where we set it will fix this issue, as I verified locally.

## Tests and linting

 - [x] I have rebased my changes on current `develop`

 - [x] pytests pass in the development environment on my local machine

 - [x] `pre-commit` checks pass
