### PR TITLE
We are only using versions 3.8 and 3.9 in our builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: python
 dist: xenial
 sudo: required
 python:
-  - "3.5"
-  - "3.6"
-  - "3.7"
   - "3.8"
+  - "3.9"
 services:
   - docker
 env:


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/914

## Description of Changes
Coveralls has not been working the past couple of years and it appears the same can be said for Travis and potentially CircleCI. Gonna update things so that Coveralls works again and we delete any files that no longer need to be there.

## Changes proposed in this pull request:
 - Fix [Coveralls](https://coveralls.io/github/lucyparsons/OpenOversight) for OO
 - Remove CircleCI and/or Travis integration if they are no longer being used.

## Tests and linting
 - [ ] This branch is up-to-date with the `develop` branch.
 - [ ] `pytest` passes on my local development environment.
 - [ ] `pre-commit` passes on my local development environment.
