### PR TITLE
Address `Change Password` copy

### DIFF
--- a/OpenOversight/app/templates/auth/change_password.html
+++ b/OpenOversight/app/templates/auth/change_password.html
@@ -15,7 +15,7 @@
 
         {{ wtf.form_field(form.old_password) }}
         <div class="form-group {% if form.password.errors %}has-error{%endif%} required">
-            <label class="control-label" for="password">New Password</label>
+            <label class="control-label" for="password">NEW PASSWORD</label>
             <input class="form-control" id="password" name="password" required="" type="password" value="">
             <meter class="meter" max="5" id="password-strength-meter"></meter>
             <p id="password-strength-text"></p>
@@ -24,7 +24,7 @@
             {% endif %}
         </div>
         <div class="form-group  required">
-            <label class="control-label" for="password2">Confirm password</label>
+            <label class="control-label" for="password2">CONFIRM NEW PASSWORD</label>
             <input class="form-control" id="password2" name="password2" required="" type="password" value="">
             <meter class="binmeter" max="5" id="password-confirmation-meter"></meter>
             {% if form.password2.errors %}

--- a/OpenOversight/app/templates/auth/change_password.html
+++ b/OpenOversight/app/templates/auth/change_password.html
@@ -15,7 +15,7 @@
 
         {{ wtf.form_field(form.old_password) }}
         <div class="form-group {% if form.password.errors %}has-error{%endif%} required">
-            <label class="control-label" for="password">Password</label>
+            <label class="control-label" for="password">New Password</label>
             <input class="form-control" id="password" name="password" required="" type="password" value="">
             <meter class="meter" max="5" id="password-strength-meter"></meter>
             <p id="password-strength-text"></p>


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/948

## Description of Changes
The old copy just said `Password` for the `New Password` field, which was vague and slightly confusing. I updated that so it was clear what was being asked.

## Screenshots (if appropriate)
<img width="619" alt="Screenshot 2023-06-30 at 11 06 10 AM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/92252f13-8e8b-485a-a759-c4b2e80d9646">

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] Tested manually.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
