### PR TITLE
Change `FLASK_ENV` to `FLASK_DEBUG`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build_with_version:
 
 .PHONY: test_with_version
 test_with_version: build_with_version assets
-	FLASK_ENV=testing docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	FLASK_DEBUG=1 docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 .PHONY: start
 start: build  ## Run containers
@@ -48,9 +48,9 @@ populate: create_db  ## Build and run containers
 .PHONY: test
 test: start  ## Run tests
 	if [ -z "$(name)" ]; then \
-		FLASK_ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
+		FLASK_DEBUG=1  docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-	    FLASK_ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
+	    FLASK_DEBUG=1  docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,13 @@ services:
       - TRAVIS_PYTHON_VERSION
       dockerfile: ./dockerfiles/web/Dockerfile
    environment:
-     AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
-     AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
-     AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
-     S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
      APPROVE_REGISTRATIONS: "${APPROVE_REGISTRATIONS}"
+     AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+     AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
+     AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
      FLASK_APP: OpenOversight.app
      FLASK_ENV: "${FLASK_ENV:-development}"
+     S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
    user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID' and run docker-compose again}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
      FLASK_APP: OpenOversight.app
-     FLASK_ENV: "${FLASK_ENV:-development}"
+     FLASK_DEBUG: 1
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/950

## Description of Changes
`FLASK_ENV` is going to be sunset in v2.3 and changed to use `FLASK_DEBUG`, so I made these edits now.

## Tests and linting
 - [ ] This branch is up-to-date with the `develop` branch.
 - [ ] `pytest` passes on my local development environment.
 - [ ] `pre-commit` passes on my local development environment.
