### PR TITLE
Use `BaseConfig` instead of `config.get()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Credentials
 dbcred*
+service_account_key.json
 
 # Local database backups
 backup/*

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -39,7 +39,7 @@ csrf = CSRFProtect()
 def create_app(config_name="default"):
     app = Flask(__name__)
     app.config.from_object(config[config_name])
-    config[config_name].init_app(app)
+    config[config_name]
     from .models import db
 
     bootstrap.init_app(app)

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -63,7 +63,7 @@ def before_request():
 def unconfirmed():
     if current_user.is_anonymous or current_user.confirmed:
         return redirect(url_for("main.index"))
-    if current_app.config["APPROVE_REGISTRATIONS"]:
+    if BaseConfig.APPROVE_REGISTRATIONS:
         return render_template("auth/unapproved.html")
     else:
         return render_template("auth/unconfirmed.html")
@@ -107,11 +107,11 @@ def register():
             email=form.email.data,
             username=form.username.data,
             password=form.password.data,
-            approved=False if current_app.config["APPROVE_REGISTRATIONS"] else True,
+            approved=False if BaseConfig.APPROVE_REGISTRATIONS else True,
         )
         db.session.add(user)
         db.session.commit()
-        if current_app.config["APPROVE_REGISTRATIONS"]:
+        if BaseConfig.APPROVE_REGISTRATIONS:
             admins = User.query.filter_by(is_administrator=True).all()
             for admin in admins:
                 send_email(
@@ -340,7 +340,7 @@ def edit_user(user_id):
 
                 # automatically send a confirmation email when approving an unconfirmed user
                 if (
-                    current_app.config["APPROVE_REGISTRATIONS"]
+                    BaseConfig.APPROVE_REGISTRATIONS
                     and not already_approved
                     and user.approved
                     and not user.confirmed

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -338,7 +338,8 @@ def edit_user(user_id):
                 db.session.add(user)
                 db.session.commit()
 
-                # automatically send a confirmation email when approving an unconfirmed user
+                # automatically send a confirmation email when approving an
+                # unconfirmed user
                 if (
                     BaseConfig.APPROVE_REGISTRATIONS
                     and not already_approved

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -16,6 +16,7 @@ from OpenOversight.app.utils.forms import set_dynamic_default
 from OpenOversight.app.utils.general import validate_redirect_url
 
 from .. import sitemap
+from ..config import BaseConfig
 from ..email import send_email
 from ..models import User, db
 from . import auth
@@ -301,9 +302,8 @@ def get_users():
         page = int(request.args.get("page"))
     else:
         page = 1
-    USERS_PER_PAGE = int(current_app.config["USERS_PER_PAGE"])
     users = User.query.order_by(User.username).paginate(
-        page=page, per_page=USERS_PER_PAGE, error_out=False
+        page=page, per_page=BaseConfig.USERS_PER_PAGE, error_out=False
     )
 
     return render_template("auth/users.html", objects=users)

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -6,12 +6,14 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class BaseConfig(object):
     # DB SETUP
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:"
+    )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # pagination
-    OFFICERS_PER_PAGE = os.environ.get("OFFICERS_PER_PAGE", 20)
-    USERS_PER_PAGE = os.environ.get("USERS_PER_PAGE", 20)
+    OFFICERS_PER_PAGE = int(os.environ.get("OFFICERS_PER_PAGE", 20))
+    USERS_PER_PAGE = int(os.environ.get("USERS_PER_PAGE", 20))
 
     # Form Settings
     WTF_CSRF_ENABLED = True

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -16,7 +16,7 @@ class BaseConfig(object):
     USERS_PER_PAGE = int(os.environ.get("USERS_PER_PAGE", 20))
 
     # Form Settings
-    WTF_CSRF_ENABLED = True
+    WTF_CSRF_ENABLED = os.environ.get("WTF_CSRF_ENABLED", True)
     SECRET_KEY = os.environ.get("SECRET_KEY", "changemeplzorelsehax")
 
     # Mail Settings
@@ -64,7 +64,6 @@ class DevelopmentConfig(BaseConfig):
 
 class TestingConfig(BaseConfig):
     TESTING = True
-    WTF_CSRF_ENABLED = False
     NUM_OFFICERS = 120
     APPROVE_REGISTRATIONS = False
     SITEMAP_URL_SCHEME = "http"

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -5,82 +5,83 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 class BaseConfig(object):
-    # DB SETUP
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
-        "SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:"
-    )
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    def __init__(self):
+        # DB SETUP
+        self.SQLALCHEMY_DATABASE_URI = os.environ.get(
+            "SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:"
+        )
+        self.SQLALCHEMY_TRACK_MODIFICATIONS = False
 
-    # Protocol Settings
-    SITEMAP_URL_SCHEME = "http"
+        # Protocol Settings
+        self.SITEMAP_URL_SCHEME = "http"
 
-    # pagination
-    OFFICERS_PER_PAGE = int(os.environ.get("OFFICERS_PER_PAGE", 20))
-    USERS_PER_PAGE = int(os.environ.get("USERS_PER_PAGE", 20))
+        # pagination
+        self.OFFICERS_PER_PAGE = int(os.environ.get("OFFICERS_PER_PAGE", 20))
+        self.USERS_PER_PAGE = int(os.environ.get("USERS_PER_PAGE", 20))
 
-    # Form Settings
-    WTF_CSRF_ENABLED = os.environ.get("WTF_CSRF_ENABLED", True)
-    SECRET_KEY = os.environ.get("SECRET_KEY", "changemeplzorelsehax")
+        # Form Settings
+        self.WTF_CSRF_ENABLED = os.environ.get("WTF_CSRF_ENABLED", True)
+        self.SECRET_KEY = os.environ.get("SECRET_KEY", "changemeplzorelsehax")
 
-    # Mail Settings
-    MAIL_SERVER = os.environ.get("MAIL_SERVER", "smtp.googlemail.com")
-    MAIL_PORT = 587
-    MAIL_USE_TLS = True
-    MAIL_USERNAME = os.environ.get("MAIL_USERNAME")
-    MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD")
-    OO_MAIL_SUBJECT_PREFIX = os.environ.get("OO_MAIL_SUBJECT_PREFIX", "[OpenOversight]")
-    OO_MAIL_SENDER = os.environ.get(
-        "OO_MAIL_SENDER", "OpenOversight <OpenOversight@gmail.com>"
-    )
-    # OO_ADMIN = os.environ.get('OO_ADMIN')
+        # Mail Settings
+        self.MAIL_SERVER = os.environ.get("MAIL_SERVER", "smtp.googlemail.com")
+        self.MAIL_PORT = 587
+        self.MAIL_USE_TLS = True
+        self.MAIL_USERNAME = os.environ.get("MAIL_USERNAME")
+        self.MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD")
+        self.OO_MAIL_SUBJECT_PREFIX = os.environ.get(
+            "OO_MAIL_SUBJECT_PREFIX", "[OpenOversight]"
+        )
+        self.OO_MAIL_SENDER = os.environ.get(
+            "OO_MAIL_SENDER", "OpenOversight <OpenOversight@gmail.com>"
+        )
+        # OO_ADMIN = os.environ.get('OO_ADMIN')
 
-    # AWS Settings
-    AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION")
-    S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME")
+        # AWS Settings
+        self.AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+        self.AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        self.AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION")
+        self.S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME")
 
-    # Upload Settings
-    MAX_CONTENT_LENGTH = 50 * 1024 * 1024
-    ALLOWED_EXTENSIONS = set(["jpeg", "jpg", "jpe", "png", "gif", "webp"])
+        # Upload Settings
+        self.MAX_CONTENT_LENGTH = 50 * 1024 * 1024
+        self.ALLOWED_EXTENSIONS = set(["jpeg", "jpg", "jpe", "png", "gif", "webp"])
 
-    # User settings
-    APPROVE_REGISTRATIONS = os.environ.get("APPROVE_REGISTRATIONS", False)
+        # User settings
+        self.APPROVE_REGISTRATIONS = os.environ.get("APPROVE_REGISTRATIONS", False)
 
-    # Use session cookie to store URL to redirect to after login
-    # https://flask-login.readthedocs.io/en/latest/#customizing-the-login-process
-    USE_SESSION_FOR_NEXT = True
+        # Use session cookie to store URL to redirect to after login
+        # https://flask-login.readthedocs.io/en/latest/#customizing-the-login-process
+        self.USE_SESSION_FOR_NEXT = True
 
-    SEED = 666
-
-    @staticmethod
-    def init_app(app):
-        pass
+        self.SEED = 666
 
 
 class DevelopmentConfig(BaseConfig):
-    DEBUG = True
-    SQLALCHEMY_ECHO = True
-    NUM_OFFICERS = 15000
+    def __init__(self):
+        super().__init__()
+        self.DEBUG = True
+        self.SQLALCHEMY_ECHO = True
+        self.NUM_OFFICERS = 15000
 
 
 class TestingConfig(BaseConfig):
-    TESTING = True
-    NUM_OFFICERS = 120
-    RATELIMIT_ENABLED = False
+    def __init__(self):
+        super().__init__()
+        self.TESTING = True
+        self.NUM_OFFICERS = 120
+        self.RATELIMIT_ENABLED = False
 
 
 class ProductionConfig(BaseConfig):
-    SITEMAP_URL_SCHEME = "https"
-
-    @classmethod
-    def init_app(cls, app):  # pragma: no cover
-        config.init_app(app)
+    def __init__(self):
+        super().__init__()
+        self.SITEMAP_URL_SCHEME = "https"
 
 
 config = {
-    "development": DevelopmentConfig,
-    "testing": TestingConfig,
-    "production": ProductionConfig,
+    "development": DevelopmentConfig(),
+    "testing": TestingConfig(),
+    "production": ProductionConfig(),
 }
-config["default"] = config.get(os.environ.get("FLASK_ENV", ""), DevelopmentConfig)
+config["default"] = config.get(os.environ.get("FLASK_ENV", ""), DevelopmentConfig())

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -6,6 +6,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class BaseConfig(object):
     # DB SETUP
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # pagination
@@ -55,14 +56,12 @@ class BaseConfig(object):
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
     SQLALCHEMY_ECHO = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     NUM_OFFICERS = 15000
     SITEMAP_URL_SCHEME = "http"
 
 
 class TestingConfig(BaseConfig):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False
     NUM_OFFICERS = 120
     APPROVE_REGISTRATIONS = False
@@ -71,7 +70,6 @@ class TestingConfig(BaseConfig):
 
 
 class ProductionConfig(BaseConfig):
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     SITEMAP_URL_SCHEME = "https"
 
     @classmethod

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -11,6 +11,9 @@ class BaseConfig(object):
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    # Protocol Settings
+    SITEMAP_URL_SCHEME = "http"
+
     # pagination
     OFFICERS_PER_PAGE = int(os.environ.get("OFFICERS_PER_PAGE", 20))
     USERS_PER_PAGE = int(os.environ.get("USERS_PER_PAGE", 20))
@@ -59,13 +62,11 @@ class DevelopmentConfig(BaseConfig):
     DEBUG = True
     SQLALCHEMY_ECHO = True
     NUM_OFFICERS = 15000
-    SITEMAP_URL_SCHEME = "http"
 
 
 class TestingConfig(BaseConfig):
     TESTING = True
     NUM_OFFICERS = 120
-    SITEMAP_URL_SCHEME = "http"
     RATELIMIT_ENABLED = False
 
 

--- a/OpenOversight/app/config.py
+++ b/OpenOversight/app/config.py
@@ -65,7 +65,6 @@ class DevelopmentConfig(BaseConfig):
 class TestingConfig(BaseConfig):
     TESTING = True
     NUM_OFFICERS = 120
-    APPROVE_REGISTRATIONS = False
     SITEMAP_URL_SCHEME = "http"
     RATELIMIT_ENABLED = False
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -54,6 +54,7 @@ from OpenOversight.app.utils.general import (
 from .. import limiter, sitemap
 from ..auth.forms import LoginForm
 from ..auth.utils import ac_or_admin_required, admin_required
+from ..config import BaseConfig
 from ..models import (
     Assignment,
     Department,
@@ -664,7 +665,6 @@ def list_officer(
     form_data["current_job"] = current_job
     form_data["unique_internal_identifier"] = unique_internal_identifier
 
-    OFFICERS_PER_PAGE = int(current_app.config.OFFICERS_PER_PAGE)
     department = Department.query.filter_by(id=department_id).first()
     if not department:
         abort(HTTPStatus.NOT_FOUND)
@@ -727,7 +727,9 @@ def list_officer(
     )
     officers = officers.options(selectinload(Officer.face))
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
-    officers = officers.paginate(page=page, per_page=OFFICERS_PER_PAGE, error_out=False)
+    officers = officers.paginate(
+        page=page, per_page=BaseConfig.OFFICERS_PER_PAGE, error_out=False
+    )
     for officer in officers.items:
         officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -664,7 +664,7 @@ def list_officer(
     form_data["current_job"] = current_job
     form_data["unique_internal_identifier"] = unique_internal_identifier
 
-    OFFICERS_PER_PAGE = int(current_app.config["OFFICERS_PER_PAGE"])
+    OFFICERS_PER_PAGE = int(current_app.config.OFFICERS_PER_PAGE)
     department = Department.query.filter_by(id=department_id).first()
     if not department:
         abort(HTTPStatus.NOT_FOUND)

--- a/OpenOversight/app/models.py
+++ b/OpenOversight/app/models.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import validates
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from . import login_manager
+from .config import BaseConfig
 from .utils.constants import ENCODING_UTF_8
 from .validators import state_validator, url_validator
 
@@ -512,7 +513,7 @@ class User(UserMixin, BaseModel):
     tags = db.relationship("Face", backref="users")
 
     def _jwt_encode(self, payload, expiration):
-        secret = current_app.config["SECRET_KEY"]
+        secret = BaseConfig.SECRET_KEY
         header = {"alg": "HS512"}
 
         now = int(time.time())
@@ -522,7 +523,7 @@ class User(UserMixin, BaseModel):
         return jwt.encode(header, payload, secret)
 
     def _jwt_decode(self, token):
-        secret = current_app.config["SECRET_KEY"]
+        secret = BaseConfig.SECRET_KEY
         token = jwt.decode(token, secret)
         token.validate()
         return token

--- a/OpenOversight/app/utils/cloud.py
+++ b/OpenOversight/app/utils/cloud.py
@@ -15,6 +15,7 @@ from flask_login import current_user
 from PIL import Image as Pimage
 from PIL.PngImagePlugin import PngImageFile
 
+from ..config import BaseConfig
 from ..models import Image, db
 
 
@@ -112,7 +113,7 @@ def upload_image_to_s3_and_store_in_db(image_buf, user_id, department_id=None):
     """
     image_buf.seek(0)
     image_type = imghdr.what(image_buf)
-    if image_type not in current_app.config["ALLOWED_EXTENSIONS"]:
+    if image_type not in BaseConfig.ALLOWED_EXTENSIONS:
         raise ValueError("Attempted to pass invalid data type: {}".format(image_type))
     image_buf.seek(0)
     pimage = Pimage.open(image_buf)

--- a/OpenOversight/app/utils/general.py
+++ b/OpenOversight/app/utils/general.py
@@ -4,9 +4,10 @@ from distutils.util import strtobool
 from typing import Optional
 from urllib.parse import urlparse
 
-from flask import current_app, url_for
+from flask import url_for
 
 from ...app.custom import add_jpeg_patch
+from ..config import BaseConfig
 
 
 # Call JPEG patch function
@@ -22,8 +23,7 @@ def ac_can_edit_officer(officer, ac):
 def allowed_file(filename):
     return (
         "." in filename
-        and filename.rsplit(".", 1)[1].lower()
-        in current_app.config["ALLOWED_EXTENSIONS"]
+        and filename.rsplit(".", 1)[1].lower() in BaseConfig.ALLOWED_EXTENSIONS
     )
 
 

--- a/OpenOversight/migrations/env.py
+++ b/OpenOversight/migrations/env.py
@@ -4,6 +4,8 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from OpenOversight.app.config import BaseConfig
+
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -21,9 +23,7 @@ logger = logging.getLogger("alembic.env")
 from flask import current_app  # noqa: E402
 
 
-config.set_main_option(
-    "sqlalchemy.url", current_app.config.SQLALCHEMY_DATABASE_URI
-)
+config.set_main_option("sqlalchemy.url", BaseConfig.SQLALCHEMY_DATABASE_URI)
 target_metadata = current_app.extensions["migrate"].db.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/OpenOversight/migrations/env.py
+++ b/OpenOversight/migrations/env.py
@@ -22,7 +22,7 @@ from flask import current_app  # noqa: E402
 
 
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url", current_app.config.SQLALCHEMY_DATABASE_URI
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 from xvfbwrapper import Xvfb
 
 from OpenOversight.app import create_app, models
+from OpenOversight.app.config import BaseConfig
 from OpenOversight.app.models import Job, Officer, Unit
 from OpenOversight.app.models import db as _db
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
@@ -203,7 +204,7 @@ def assign_faces(officer, images):
 def app(request):
     """Session-wide test `Flask` application."""
     app = create_app("testing")
-    app.config["WTF_CSRF_ENABLED"] = False
+    BaseConfig.WTF_CSRF_ENABLED = False
 
     yield app
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -326,8 +326,7 @@ def add_mockdata(session):
     session.commit()
 
     # Ensure test data is deterministic
-    SEED = current_app.config["SEED"]
-    random.seed(SEED)
+    random.seed(BaseConfig.SEED)
 
     test_units = [
         models.Unit(descrip="test", department_id=1),

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -12,9 +12,10 @@ from OpenOversight.app.utils.constants import (
     HTTP_METHOD_POST,
 )
 
+from ...app.config import BaseConfig
 from ..conftest import AC_DEPT
 from .route_helpers import ADMIN_EMAIL, login_ac, login_admin, login_user
-from ...app.config import BaseConfig
+
 
 routes_methods = [
     ("/auth/users/", [HTTP_METHOD_GET]),

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -14,7 +14,7 @@ from OpenOversight.app.utils.constants import (
 
 from ..conftest import AC_DEPT
 from .route_helpers import ADMIN_EMAIL, login_ac, login_admin, login_user
-
+from ...app.config import BaseConfig
 
 routes_methods = [
     ("/auth/users/", [HTTP_METHOD_GET]),
@@ -266,7 +266,7 @@ def test_admin_can_resend_user_confirmation_email(mockdata, client, session):
 
 
 def test_register_user_approval_required(mockdata, client, session):
-    current_app.config["APPROVE_REGISTRATIONS"] = True
+    BaseConfig.APPROVE_REGISTRATIONS = True
     with current_app.test_request_context():
         diceware_password = "operative hamster perservere verbalize curling"
         form = RegistrationForm(
@@ -348,7 +348,7 @@ def test_admin_approval_sends_confirmation_email(
     client,
     session,
 ):
-    current_app.config["APPROVE_REGISTRATIONS"] = approve_registration_config
+    BaseConfig.APPROVE_REGISTRATIONS = approve_registration_config
     with current_app.test_request_context():
         login_admin(client)
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -110,24 +110,23 @@ def test_user_can_get_to_complaint(mockdata, browser, server_port):
 def test_officer_browse_pagination(mockdata, browser, server_port):
     dept_id = 1
     total = Officer.query.filter_by(department_id=dept_id).count()
-    perpage = BaseConfig.OFFICERS_PER_PAGE
 
     # first page of results
     browser.get(f"http://localhost:{server_port}/department/{dept_id}?page=1")
     wait_for_element(browser, By.TAG_NAME, "body")
     page_text = browser.find_element_by_tag_name("body").text
-    expected = "Showing 1-{} of {}".format(perpage, total)
+    expected = "Showing 1-{} of {}".format(BaseConfig.OFFICERS_PER_PAGE, total)
     assert expected in page_text
 
     # last page of results
-    last_page_index = (total // perpage) + 1
+    last_page_index = (total // BaseConfig.OFFICERS_PER_PAGE) + 1
     browser.get(
         f"http://localhost:{server_port}/department/{dept_id}?page={last_page_index}"
     )
     wait_for_element(browser, By.TAG_NAME, "body")
     page_text = browser.find_element_by_tag_name("body").text
     expected = "Showing {}-{} of {}".format(
-        perpage * (total // perpage) + 1, total, total
+        BaseConfig.OFFICERS_PER_PAGE * (total // BaseConfig.OFFICERS_PER_PAGE) + 1, total, total
     )
     assert expected in page_text
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -126,7 +126,9 @@ def test_officer_browse_pagination(mockdata, browser, server_port):
     wait_for_element(browser, By.TAG_NAME, "body")
     page_text = browser.find_element_by_tag_name("body").text
     expected = "Showing {}-{} of {}".format(
-        BaseConfig.OFFICERS_PER_PAGE * (total // BaseConfig.OFFICERS_PER_PAGE) + 1, total, total
+        BaseConfig.OFFICERS_PER_PAGE * (total // BaseConfig.OFFICERS_PER_PAGE) + 1,
+        total,
+        total,
     )
     assert expected in page_text
 


### PR DESCRIPTION
## Fixes issue
 https://github.com/lucyparsons/OpenOversight/issues/954

## Description of Changes
We no longer use the `config.get()` commands anywhere but `OpenOversight/app/config.py`

## Tests and linting
 - [ ] This branch is up-to-date with the `develop` branch.
 - [ ] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
