### PR TITLE
Move to the latest version of 🐍

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -12,7 +12,7 @@ env:
   env_name: ${{ fromJson(vars.env_mapping)[github.ref_name] }}
   # docker_mapping: {"develop": "latest", "main": "stable"}
   docker_name: ${{ fromJson(vars.docker_mapping)[github.ref_name] }}
-  python_version: "3.8"
+  python_version: "3.11"
 
 jobs:
   push_to_registry:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Run tests
         run: |
           PYTHON_VERSION=${{ matrix.python-version }} make test_with_version

--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -19,7 +19,7 @@ jobs:
       FLASK_APP: OpenOversight.app
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -32,5 +32,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ var/
 .installed.cfg
 *.egg
 .mypy_cache
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Credentials
 dbcred*
+service_account_key.json
 
 # Local database backups
 backup/*

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 no_implicit_optional = True
 
-
 [mypy-boto3]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/960

## Description of Changes
Move to the latest version of Python, specificaly `v3.11.x`.

## Notes for Deployment
- @abandoned-prototype needs to mark the `3.11` build as mandatory and remove the designations for `3.8` and `3.9`.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
