### PR TITLE
Add `context` as parameter to `EmailClient`

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -48,7 +48,11 @@ def create_app(config_name="default"):
     # This allows the application to run without creating an email client if it is
     # in testing or dev mode and the service account file is empty.
     service_account_file_size = os.path.getsize(SERVICE_ACCOUNT_FILE)
-    EmailClient(dev=app.debug and service_account_file_size == 0, testing=app.testing)
+    EmailClient(
+        config=app.config,
+        dev=app.debug and service_account_file_size == 0,
+        testing=app.testing,
+    )
     limiter.init_app(app)
     login_manager.init_app(app)
     sitemap.init_app(app)

--- a/OpenOversight/app/email_client.py
+++ b/OpenOversight/app/email_client.py
@@ -18,17 +18,15 @@ class EmailClient(object):
 
     _instance = None
 
-    def __new__(cls, dev=False, testing=False):
+    def __new__(cls, config=None, dev=False, testing=False):
         if (testing or dev) and cls._instance is None:
             cls._instance = {}
 
-        if cls._instance is None:
+        if cls._instance is None and config:
             credentials = service_account.Credentials.from_service_account_file(
                 SERVICE_ACCOUNT_FILE, scopes=cls.SCOPES
             )
-            delegated_credentials = credentials.with_subject(
-                current_app.config["OO_SERVICE_EMAIL"]
-            )
+            delegated_credentials = credentials.with_subject(config["OO_SERVICE_EMAIL"])
             cls.service = build("gmail", "v1", credentials=delegated_credentials)
             cls._instance = super(EmailClient, cls).__new__(cls)
         return cls._instance


### PR DESCRIPTION
## Fixes Issue
https://github.com/lucyparsons/OpenOversight/actions/runs/5510368096/jobs/10044531971

## Description of Changes
For the config to be properly accessed in the `email_client`, a `with app.context:` line needed to be added or the config needed to be added as a parameter to the `EmailClient`.

## Notes for Deployment
This should fix the issue.

## Screenshots (if appropriate)
- Validated fix by creating a new user on my local development environment.
<img width="1139" alt="Screenshot 2023-07-10 at 11 26 55 AM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/615add77-0f11-4c46-885d-58826000974c">

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
