### PR TITLE
Address `FLASK_ENV` warning

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -172,11 +172,11 @@ Usage: flask [OPTIONS] COMMAND [ARGS]...
 
   Provides commands from Flask, extensions, and the application. Loads the
   application defined in the FLASK_APP environment variable, or from a
-  wsgi.py file. Setting the FLASK_ENV environment variable to 'development'
+  wsgi.py file. Setting the ENVIRONMENT environment variable to 'development'
   will enable debug mode.
 
     $ export FLASK_APP=hello.py
-    $ export FLASK_ENV=development
+    $ export ENVIRONMENT=development
     $ flask run
 
 Options:
@@ -211,7 +211,7 @@ In `docker-compose.yml`, below the line specifying the port number, add the foll
    stdin_open: true
    tty: true
 ```
-Also in `docker-compose.yml`, below the line specifying the `FLASK_ENV`, add the following to the `environment` portion of the `web` service:
+Also in `docker-compose.yml`, below the line specifying the `ENVIRONMENT`, add the following to the `environment` portion of the `web` service:
 ```yml
   FLASK_DEBUG: 0
 ```

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -172,11 +172,11 @@ Usage: flask [OPTIONS] COMMAND [ARGS]...
 
   Provides commands from Flask, extensions, and the application. Loads the
   application defined in the FLASK_APP environment variable, or from a
-  wsgi.py file. Setting the ENVIRONMENT environment variable to 'development'
+  wsgi.py file. Setting the ENV environment variable to 'development'
   will enable debug mode.
 
     $ export FLASK_APP=hello.py
-    $ export ENVIRONMENT=development
+    $ export ENV=development
     $ flask run
 
 Options:

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -211,7 +211,7 @@ In `docker-compose.yml`, below the line specifying the port number, add the foll
    stdin_open: true
    tty: true
 ```
-Also in `docker-compose.yml`, below the line specifying the `ENVIRONMENT`, add the following to the `environment` portion of the `web` service:
+Also in `docker-compose.yml`, below the line specifying the `ENV`, add the following to the `environment` portion of the `web` service:
 ```yml
   FLASK_DEBUG: 0
 ```

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build_with_version: create_empty_secret create_empty_env
 
 .PHONY: test_with_version
 test_with_version: build_with_version assets
-	FLASK_ENV=testing docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	ENVIRONMENT=testing docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 .PHONY: start
 start: build ## Run containers
@@ -48,9 +48,9 @@ populate: create_db ## Build and run containers
 .PHONY: test
 test: start ## Run tests
 	if [ -z "$(name)" ]; then \
-		FLASK_ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
+		ENVIRONMENT=testing docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-		FLASK_ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
+		ENVIRONMENT=testing docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build_with_version: create_empty_secret create_empty_env
 
 .PHONY: test_with_version
 test_with_version: build_with_version assets
-	ENVIRONMENT=testing docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	ENV=testing docker-compose run --rm web pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 .PHONY: start
 start: build ## Run containers
@@ -48,9 +48,9 @@ populate: create_db ## Build and run containers
 .PHONY: test
 test: start ## Run tests
 	if [ -z "$(name)" ]; then \
-		ENVIRONMENT=testing docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
+		ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-		ENVIRONMENT=testing docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
+		ENV=testing docker-compose run --rm web pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint

--- a/OpenOversight/app/models/config.py
+++ b/OpenOversight/app/models/config.py
@@ -80,4 +80,4 @@ config = {
     "testing": TestingConfig(),
     "production": ProductionConfig(),
 }
-config["default"] = config.get(os.environ.get("FLASK_ENV", ""), DevelopmentConfig())
+config["default"] = config.get(os.environ.get("ENVIRONMENT", ""), DevelopmentConfig())

--- a/OpenOversight/app/models/config.py
+++ b/OpenOversight/app/models/config.py
@@ -10,6 +10,7 @@ class BaseConfig:
     def __init__(self):
         # App Settings
         self.DEBUG = False
+        self.ENV = os.environ.get("ENV")
         self.SEED = 666
         self.TESTING = False
         # Use session cookie to store URL to redirect to after login
@@ -80,4 +81,4 @@ config = {
     "testing": TestingConfig(),
     "production": ProductionConfig(),
 }
-config["default"] = config.get(os.environ.get("ENVIRONMENT", ""), DevelopmentConfig())
+config["default"] = config.get(os.environ.get("ENV", ""), DevelopmentConfig())

--- a/docker-compose.prod-img.yml
+++ b/docker-compose.prod-img.yml
@@ -10,7 +10,7 @@ services:
     env_file:
       - .env
     environment:
-      ENVIRONMENT: production
+      ENV: production
       FLASK_APP: OpenOversight.app
     volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
+     ENVIRONMENT: "${FLASK_ENV:-development}"
      FLASK_APP: OpenOversight.app
-     FLASK_ENV: "${FLASK_ENV:-development}"
      OO_SERVICE_EMAIL: "openoversightchi@lucyparsonslabs.com"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
    volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
-     ENVIRONMENT: "${FLASK_ENV:-development}"
+     ENVIRONMENT: "${ENVIRONMENT:-development}"
      FLASK_APP: OpenOversight.app
      OO_SERVICE_EMAIL: "openoversightchi@lucyparsonslabs.com"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
-     ENVIRONMENT: "${ENVIRONMENT:-development}"
+     ENV: "${ENV:-development}"
      FLASK_APP: OpenOversight.app
      OO_SERVICE_EMAIL: "openoversightchi@lucyparsonslabs.com"
      S3_BUCKET_NAME: "${S3_BUCKET_NAME}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ docutils~=0.20.1
 dominate~=2.8.0
 email-validator==2.0.0.post2
 Faker~=18.11.2
-Flask==2.2.5 # Updating this breaks the build for python 3.8
+Flask==2.3.2
 Flask-Bootstrap==3.3.7.1
 Flask-Limiter==3.3.1
 Flask-Login==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ pycparser~=2.21
 Pygments~=2.15.1
 pytest~=7.4.0
 python-dateutil==2.8.2
+python-dotenv==1.0.0
 PyYAML~=6.0
 requests~=2.31.0
 rich~=13.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ pycparser~=2.21
 Pygments~=2.15.1
 pytest~=7.4.0
 python-dateutil==2.8.2
-python-dotenv==1.0.0
 PyYAML~=6.0
 requests~=2.31.0
 rich~=13.4.2


### PR DESCRIPTION
## Fixes issue


## Description of Changes
I removed the use of the `FLASK_ENV` variable in the application and replaced it with the `ENV` variable. This was done to remove the warning that you'll see below and to simply the potential updating of Flask to a version higher than `v2.3`.

```console
'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
```

## Startup Console Log Output
<details><summary>Console Log Output Before Change</summary>

```console
2023-07-11 15:42:33 openoversight-postgres-1  | 
2023-07-11 15:42:33 openoversight-postgres-1  | PostgreSQL Database directory appears to contain a database; Skipping initialization
2023-07-11 15:42:33 openoversight-postgres-1  | 
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.064 UTC [1] LOG:  starting PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.064 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.064 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.065 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.069 UTC [29] LOG:  database system was shut down at 2023-07-11 20:42:24 UTC
2023-07-11 15:42:33 openoversight-postgres-1  | 2023-07-11 20:42:33.073 UTC [1] LOG:  database system is ready to accept connections
2023-07-11 15:42:33 openoversight-web-1       | yarn run v1.22.19
2023-07-11 15:42:33 openoversight-web-1       | warning package.json: No license field
2023-07-11 15:42:33 openoversight-web-1       | $ sass OpenOversight/app/static/scss/index.scss OpenOversight/app/static/dist/index.css
2023-07-11 15:42:34 openoversight-web-1       | Done in 0.76s.
2023-07-11 15:42:34 openoversight-web-1       | yarn run v1.22.19
2023-07-11 15:42:34 openoversight-web-1       | warning package.json: No license field
2023-07-11 15:42:34 openoversight-web-1       | $ sass --watch OpenOversight/app/static/scss/index.scss OpenOversight/app/static/dist/index.css
2023-07-11 15:42:34 openoversight-web-1       | 'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
2023-07-11 15:42:34 openoversight-web-1       | /usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
2023-07-11 15:42:34 openoversight-web-1       |   warnings.warn(
2023-07-11 15:42:34 openoversight-web-1       | Sass is watching for changes. Press Ctrl-C to stop.
2023-07-11 15:42:34 openoversight-web-1       | 
2023-07-11 15:42:34 openoversight-web-1       | [2023-07-11 20:42:34,720] INFO in __init__: OpenOversight startup
2023-07-11 15:42:34 openoversight-web-1       | 'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
2023-07-11 15:42:34 openoversight-web-1       | 'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
2023-07-11 15:42:34 openoversight-web-1       |  * Serving Flask app 'OpenOversight.app'
2023-07-11 15:42:34 openoversight-web-1       |  * Debug mode: on
2023-07-11 15:42:34 openoversight-web-1       | WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
2023-07-11 15:42:34 openoversight-web-1       |  * Running on all addresses (0.0.0.0)
2023-07-11 15:42:34 openoversight-web-1       |  * Running on http://127.0.0.1:3000
2023-07-11 15:42:34 openoversight-web-1       |  * Running on http://172.18.0.3:3000
2023-07-11 15:42:34 openoversight-web-1       | Press CTRL+C to quit
2023-07-11 15:42:34 openoversight-web-1       |  * Restarting with stat
2023-07-11 15:42:35 openoversight-web-1       | 'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
```
</details>


<details><summary>Console Log Output After Change</summary>

```console
2023-07-11 15:37:52 openoversight-postgres-1  | 
2023-07-11 15:37:52 openoversight-postgres-1  | PostgreSQL Database directory appears to contain a database; Skipping initialization
2023-07-11 15:37:52 openoversight-postgres-1  | 
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.079 UTC [1] LOG:  starting PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.079 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.079 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.081 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.085 UTC [29] LOG:  database system was shut down at 2023-07-11 20:37:08 UTC
2023-07-11 15:37:52 openoversight-postgres-1  | 2023-07-11 20:37:52.090 UTC [1] LOG:  database system is ready to accept connections
2023-07-11 15:37:52 openoversight-web-1       | yarn run v1.22.19
2023-07-11 15:37:52 openoversight-web-1       | warning package.json: No license field
2023-07-11 15:37:52 openoversight-web-1       | $ sass OpenOversight/app/static/scss/index.scss OpenOversight/app/static/dist/index.css
2023-07-11 15:37:53 openoversight-web-1       | Done in 0.84s.
2023-07-11 15:37:53 openoversight-web-1       | yarn run v1.22.19
2023-07-11 15:37:53 openoversight-web-1       | warning package.json: No license field
2023-07-11 15:37:53 openoversight-web-1       | $ sass --watch OpenOversight/app/static/scss/index.scss OpenOversight/app/static/dist/index.css
2023-07-11 15:37:53 openoversight-web-1       | /usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
2023-07-11 15:37:53 openoversight-web-1       |   warnings.warn(
2023-07-11 15:37:53 openoversight-web-1       | [2023-07-11 20:37:53,820] INFO in __init__: OpenOversight startup
2023-07-11 15:37:53 openoversight-web-1       |  * Serving Flask app 'OpenOversight.app'
2023-07-11 15:37:53 openoversight-web-1       |  * Debug mode: off
2023-07-11 15:37:53 openoversight-web-1       | WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
2023-07-11 15:37:53 openoversight-web-1       |  * Running on all addresses (0.0.0.0)
2023-07-11 15:37:53 openoversight-web-1       |  * Running on http://127.0.0.1:3000
2023-07-11 15:37:53 openoversight-web-1       |  * Running on http://172.18.0.3:3000
2023-07-11 15:37:53 openoversight-web-1       | Press CTRL+C to quit
2023-07-11 15:37:53 openoversight-web-1       | Sass is watching for changes. Press Ctrl-C to stop.
```
</details>

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
