### PR TITLE
Center and size officer profile pictures

### DIFF
--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -594,9 +594,9 @@ tr:hover .row-actions {
     display: block;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 992px) {
     .officer-face.officer-profile {
-        height: 474px;
+        height: 510px;
     }
 }
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -585,9 +585,35 @@ tr:hover .row-actions {
 }
 
 .officer-face {
+    border: none;
     height: 300px;
     margin: auto;
 }
+
+.officer-face.officer-profile {
+    display: block;
+}
+
+@media (min-width: 768px) {
+    .officer-face.officer-profile {
+        height: 474px;
+    }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+    .officer-face.officer-profile {
+        height: 590px;
+    }
+}
+
+@media (max-width: 767px) {
+    .officer-face.officer-profile {
+        height: 460px;
+        margin-bottom: 10px;
+    }
+}
+
+
 
 .face-wrap {
     margin: auto;

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -609,8 +609,16 @@ tr:hover .row-actions {
 @media (max-width: 767px) {
     .officer-face.officer-profile {
         height: 460px;
-        margin-bottom: 10px;
+        padding-bottom: 10px;
     }
+}
+
+#face-img {
+    border: none;
+    display: block;
+    margin: auto;
+    max-height: 500px;
+    padding-bottom: 10px;
 }
 
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -621,8 +621,6 @@ tr:hover .row-actions {
     padding-bottom: 10px;
 }
 
-
-
 .face-wrap {
     margin: auto;
     position: relative;

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,6 +1,8 @@
 {% for path in paths %}
   {# Don't try to link if only image is the placeholder #}
   {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
-    <img class="officer-face officer-profile" src="{{ path }}" alt="Submission">
+    <img class="officer-face officer-profile"
+         src="{{ path }}"
+         alt="Submission">
     {% if faces %}</a>{% endif %}
 {% endfor %}

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,6 +1,6 @@
 {% for path in paths %}
   {# Don't try to link if only image is the placeholder #}
   {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
-    <img class="officer-face" src="{{ path }}" alt="Submission">
+    <img class="officer-face officer-profile" src="{{ path }}" alt="Submission">
     {% if faces %}</a>{% endif %}
 {% endfor %}

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -16,7 +16,7 @@
   </div>
   <div class="container">
     <div class="row">
-      <div class="col-sm-12">You can download the full officer photo by clicking the image below:</div>
+      <div class="col-sm-12 text-center">You can download the full officer photo by clicking the image below.</div>
     </div>
     <br>
     <div class="row">


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/931

## Description of Changes
I centered and addressed sizing issues with the officer profile pictures in the profile page, officer list page, and officer image page.

## Screenshots (if appropriate)
Located in the comments.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
