### PR TITLE
Add license to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "sass": "^1.54.4"
   },
+  "license": "GPL-3.0-only",
   "name": "openoversight",
   "repository": "https://github.com/lucyparsons/OpenOversight",
   "scripts": {


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/985

## Description of Changes
This addition was made so that the below text does not pop up when running the application.
```console
2023-07-21 15:45:07 openoversight-web-1       | warning package.json: No license field
```

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
