### PR TITLE
Add additional `/timezone` test

### DIFF
--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -1,3 +1,4 @@
+from faker import Faker
 from flask import url_for
 
 from OpenOversight.app.auth.forms import LoginForm
@@ -5,6 +6,7 @@ from OpenOversight.app.auth.forms import LoginForm
 
 ADMIN_EMAIL = "test@example.org"
 ADMIN_PASSWORD = "testtest"
+FAKER = Faker()
 
 
 def login_user(client):

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -5,7 +5,7 @@ import pytest
 from flask import current_app, url_for
 
 from OpenOversight.app.utils.constants import ENCODING_UTF_8, KEY_TIMEZONE
-from OpenOversight.tests.routes.route_helpers import login_user
+from OpenOversight.tests.routes.route_helpers import FAKER, login_user
 
 
 @pytest.mark.parametrize(
@@ -58,12 +58,26 @@ def test_user_can_access_profile_differently_cased(mockdata, client, session):
 
 def test_timezone_setting(client):
     with current_app.test_request_context():
+        test_tz = FAKER.timezone()
         with client.session_transaction() as session:
             assert KEY_TIMEZONE not in session
         rv = client.post(
             url_for("main.set_session_timezone"),
-            data="A TIMEZONE".encode(ENCODING_UTF_8),
+            data=test_tz.encode(ENCODING_UTF_8),
         )
         assert rv.status_code == HTTPStatus.OK
         with client.session_transaction() as session:
-            assert session[KEY_TIMEZONE] == "A TIMEZONE"
+            assert session[KEY_TIMEZONE] == test_tz
+
+
+def test_timezone_setting_empty_string(client):
+    with current_app.test_request_context():
+        with client.session_transaction() as session:
+            assert KEY_TIMEZONE not in session
+        rv = client.post(
+            url_for("main.set_session_timezone"),
+            data="".encode(ENCODING_UTF_8),
+        )
+        assert rv.status_code == HTTPStatus.OK
+        with client.session_transaction() as session:
+            assert session[KEY_TIMEZONE] == current_app.config.get(KEY_TIMEZONE)


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/323

## Description of Changes
Added test to cover an empty string timezone being passed.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
