### PR TITLE
Sort `Department`s and add stats and cacheing

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1386,9 +1386,7 @@ def download_dept_descriptions_csv(department_id):
 @sitemap_include
 @main.route("/download/all", methods=[HTTPMethod.GET])
 def all_data():
-    departments = Department.query.filter_by(Department.officers.any()).order_by(
-        Department.state.desc(), Department.name.desc()
-    )
+    departments = Department.query.filter(Department.officers.any())
     return render_template("departments_all.html", departments=departments)
 
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -154,7 +154,9 @@ def set_session_timezone():
 @sitemap_include
 @main.route("/browse", methods=[HTTPMethod.GET])
 def browse():
-    departments = Department.query.filter(Department.officers.any())
+    departments = Department.query.filter(Department.officers.any()).order_by(
+        Department.state.asc(), Department.name.asc()
+    )
     return render_template("browse.html", departments=departments)
 
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1386,7 +1386,9 @@ def download_dept_descriptions_csv(department_id):
 @sitemap_include
 @main.route("/download/all", methods=[HTTPMethod.GET])
 def all_data():
-    departments = Department.query.filter(Department.officers.any())
+    departments = Department.query.filter_by(Department.officers.any()).order_by(
+        Department.state.desc(), Department.name.desc()
+    )
     return render_template("departments_all.html", departments=departments)
 
 

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -61,6 +61,24 @@ class Department(BaseModel):
             "unique_internal_identifier_label": self.unique_internal_identifier_label,
         }
 
+    def total_documented_officers(self):
+        return (
+            db.session.query(Officer).filter(Officer.department_id == self.id).count()
+        )
+
+    def total_documented_assignments(self):
+        return (
+            db.session.query(Assignment.id)
+            .join(Officer, Assignment.officer_id == Officer.id)
+            .filter(Officer.department_id == self.id)
+            .count()
+        )
+
+    def total_documented_incidents(self):
+        return (
+            db.session.query(Incident).filter(Incident.department_id == self.id).count()
+        )
+
 
 class Job(BaseModel):
     __tablename__ = "jobs"

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -3,6 +3,8 @@ import time
 from datetime import date
 
 from authlib.jose import JoseError, JsonWebToken
+from cachetools import TTLCache, cached
+from cachetools.keys import hashkey
 from flask import current_app
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
@@ -11,7 +13,13 @@ from sqlalchemy.orm import validates
 from sqlalchemy.sql import func as sql_func
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from OpenOversight.app.utils.constants import ENCODING_UTF_8
+from OpenOversight.app.utils.constants import (
+    ENCODING_UTF_8,
+    HOUR,
+    KEY_TOTAL_ASSIGNMENTS,
+    KEY_TOTAL_INCIDENTS,
+    KEY_TOTAL_OFFICERS,
+)
 from OpenOversight.app.validators import state_validator, url_validator
 
 
@@ -33,6 +41,31 @@ officer_incidents = db.Table(
         "incident_id", db.Integer, db.ForeignKey("incidents.id"), primary_key=True
     ),
 )
+
+
+# This is a last recently used cache that also utilizes a time-to-live function for each
+# value saved in it (12 hours).
+# TODO: Change this into a singleton so that we can clear values when updates happen
+DATABASE_CACHE = TTLCache(maxsize=1024, ttl=12 * HOUR)
+
+
+# TODO: In the singleton create functions for other model types.
+def _date_updated_cache_key(update_type: str):
+    """Return a key function to calculate the cache key for Department
+    methods using the department id and a given update type.
+
+    Department.id is used instead of a Department obj because the default Python
+    __hash__ is unique per obj instance, meaning multiple instances of the same
+    department will have different hashes.
+
+    Update type is used in the hash to differentiate between the update types we compute
+    per department.
+    """
+
+    def _cache_key(dept: "Department"):
+        return hashkey(dept.id, update_type)
+
+    return _cache_key
 
 
 class Department(BaseModel):
@@ -61,11 +94,7 @@ class Department(BaseModel):
             "unique_internal_identifier_label": self.unique_internal_identifier_label,
         }
 
-    def total_documented_officers(self):
-        return (
-            db.session.query(Officer).filter(Officer.department_id == self.id).count()
-        )
-
+    @cached(cache=DATABASE_CACHE, key=_date_updated_cache_key(KEY_TOTAL_ASSIGNMENTS))
     def total_documented_assignments(self):
         return (
             db.session.query(Assignment.id)
@@ -74,9 +103,16 @@ class Department(BaseModel):
             .count()
         )
 
+    @cached(cache=DATABASE_CACHE, key=_date_updated_cache_key(KEY_TOTAL_INCIDENTS))
     def total_documented_incidents(self):
         return (
             db.session.query(Incident).filter(Incident.department_id == self.id).count()
+        )
+
+    @cached(cache=DATABASE_CACHE, key=_date_updated_cache_key(KEY_TOTAL_OFFICERS))
+    def total_documented_officers(self):
+        return (
+            db.session.query(Officer).filter(Officer.department_id == self.id).count()
         )
 
 

--- a/OpenOversight/app/templates/browse.html
+++ b/OpenOversight/app/templates/browse.html
@@ -14,7 +14,7 @@
       </h1>
     </div>
     <div class="text-center frontpage-leads">
-      {% for department in departments | sort(attribute="state,name") %}
+      {% for department in departments %}
         <p>
           <div class="btn-group">
             <h2>

--- a/OpenOversight/app/templates/browse.html
+++ b/OpenOversight/app/templates/browse.html
@@ -14,7 +14,7 @@
       </h1>
     </div>
     <div class="text-center frontpage-leads">
-      {% for department in departments %}
+      {% for department in departments | sort(attribute="state,name") %}
         <p>
           <div class="btn-group">
             <h2>
@@ -26,6 +26,13 @@
                 </a>
               {% endif %}
             </h2>
+            <div>
+              <i class="dept-{{ department.id }}">Officers Documented: {{ department.total_documented_officers() }}</i>
+              <br>
+              <i class="dept-{{ department.id }}">Assignments Documented: {{ department.total_documented_assignments() }}</i>
+              <br>
+              <i class="dept-{{ department.id }}">Incidents Documented: {{ department.total_documented_incidents() }}</i>
+            </div>
             <p>
               <a class="btn btn-lg btn-primary"
                  href="{{ url_for('main.list_officer', department_id=department.id) }}">Officers</a>

--- a/OpenOversight/app/templates/browse.html
+++ b/OpenOversight/app/templates/browse.html
@@ -27,11 +27,11 @@
               {% endif %}
             </h2>
             <div>
-              <i class="dept-{{ department.id }}">Officers Documented: {{ department.total_documented_officers() }}</i>
+              <b class="dept-{{ department.id }}">Officers Documented:</b> {{ department.total_documented_officers() }}
               <br>
-              <i class="dept-{{ department.id }}">Assignments Documented: {{ department.total_documented_assignments() }}</i>
+              <b class="dept-{{ department.id }}">Assignments Documented:</b> {{ department.total_documented_assignments() }}
               <br>
-              <i class="dept-{{ department.id }}">Incidents Documented: {{ department.total_documented_incidents() }}</i>
+              <b class="dept-{{ department.id }}">Incidents Documented:</b> {{ department.total_documented_incidents() }}
             </div>
             <p>
               <a class="btn btn-lg btn-primary"

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -1,6 +1,15 @@
 import os
 
 
+# Cache Key Constants
+KEY_TOTAL_ASSIGNMENTS = "total_assignments"
+KEY_TOTAL_INCIDENTS = "total_incidents"
+KEY_TOTAL_OFFICERS = "total_officers"
+
+# Config Key Constants
+KEY_OFFICERS_PER_PAGE = "OFFICERS_PER_PAGE"
+KEY_TIMEZONE = "TIMEZONE"
+
 # File Handling Constants
 ENCODING_UTF_8 = "utf-8"
 SAVED_UMASK = os.umask(0o077)  # Ensure the file is read/write by the creator only
@@ -8,11 +17,9 @@ SAVED_UMASK = os.umask(0o077)  # Ensure the file is read/write by the creator on
 # File Name Constants
 SERVICE_ACCOUNT_FILE = "service_account_key.json"
 
-# Key Constants
-KEY_OFFICERS_PER_PAGE = "OFFICERS_PER_PAGE"
-KEY_TIMEZONE = "TIMEZONE"
-
 # Numerical Constants
 BYTE = 1
 KILOBYTE = 1024 * BYTE
 MEGABYTE = 1024 * KILOBYTE
+MINUTE = 60
+HOUR = 60 * MINUTE

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -18,6 +18,7 @@ from OpenOversight.app.models.database import (
     User,
     db,
 )
+from OpenOversight.tests.conftest import SPRINGFIELD_PD
 
 
 def test_department_repr(mockdata):
@@ -26,6 +27,55 @@ def test_department_repr(mockdata):
         repr(department)
         == f"<Department ID {department.id}: {department.name} {department.state}>"
     )
+
+
+def test_department_total_documented_officers(mockdata):
+    springfield_officers = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .join(Officer, Department.id == Officer.department_id)
+        .count()
+    )
+
+    test_count = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .first()
+        .total_documented_officers()
+    )
+
+    assert springfield_officers == test_count
+
+
+def test_department_total_documented_assignments(mockdata):
+    springfield_assignments = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .join(Officer, Department.id == Officer.department_id)
+        .join(Assignment, Officer.id == Assignment.officer_id)
+        .count()
+    )
+
+    test_count = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .first()
+        .total_documented_assignments()
+    )
+
+    assert springfield_assignments == test_count
+
+
+def test_department_total_documented_incidents(mockdata):
+    springfield_incidents = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .join(Incident, Department.id == Incident.department_id)
+        .count()
+    )
+
+    test_count = (
+        Department.query.filter_by(name=SPRINGFIELD_PD.name, state=SPRINGFIELD_PD.state)
+        .first()
+        .total_documented_incidents()
+    )
+
+    assert springfield_incidents == test_count
 
 
 def test_officer_repr(mockdata):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ bleach-allowlist==1.0.3
 blinker~=1.6.2
 boto3==1.28.1
 botocore==1.31.1
+cachetools==5.3.1
 certifi~=2023.5.7
 cffi~=1.15.1
 click==8.1.4


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/797

## Description of Changes
Added sorting by `state` and `name` columns for department listing , added baseline `Department` statistics for each department, and added cacheing for those `Department` statistics.

## Screenshots (if appropriate)
Before change:
<img width="1220" alt="Screenshot 2023-07-28 at 3 24 50 PM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/1f8a7a17-f4b4-4593-8651-a3b4f0c6dfdf">

After change:
<img width="1220" alt="Screenshot 2023-07-28 at 3 27 03 PM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/77f70398-53aa-4f5d-af94-d9b4bc06834c">

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
