### PR TITLE
Add gzip compression for HTML, JS, and CSS files

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -5,11 +5,11 @@ from logging.handlers import RotatingFileHandler
 
 from flask import Flask, jsonify, render_template, request
 from flask_bootstrap import Bootstrap
+from flask_compress import Compress
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_migrate import Migrate
-from flask_minify import Minify
 from flask_sitemap import Sitemap
 from flask_wtf.csrf import CSRFProtect
 
@@ -25,6 +25,7 @@ from OpenOversight.app.utils.constants import (
 
 
 bootstrap = Bootstrap()
+compress = Compress()
 
 login_manager = LoginManager()
 login_manager.session_protection = "strong"
@@ -43,8 +44,6 @@ def create_app(config_name="default"):
     # Creates and adds the Config object of the correct type to app.config
     app.config.from_object(config[config_name])
 
-    if not app.config.get(KEY_TESTING):
-        Minify(app=app, cssless=True, html=True, js=True)
     bootstrap.init_app(app)
     csrf.init_app(app)
     db.init_app(app)
@@ -59,6 +58,7 @@ def create_app(config_name="default"):
     limiter.init_app(app)
     login_manager.init_app(app)
     sitemap.init_app(app)
+    compress.init_app(app)
 
     from OpenOversight.app.main import main as main_blueprint
 

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -17,10 +17,7 @@ from OpenOversight.app.email_client import EmailClient
 from OpenOversight.app.filters import instantiate_filters
 from OpenOversight.app.models.config import config
 from OpenOversight.app.models.database import db
-from OpenOversight.app.utils.constants import (
-    MEGABYTE,
-    SERVICE_ACCOUNT_FILE,
-)
+from OpenOversight.app.utils.constants import MEGABYTE, SERVICE_ACCOUNT_FILE
 
 
 bootstrap = Bootstrap()

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -9,6 +9,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_migrate import Migrate
+from flask_minify import Minify
 from flask_sitemap import Sitemap
 from flask_wtf.csrf import CSRFProtect
 
@@ -16,7 +17,11 @@ from OpenOversight.app.email_client import EmailClient
 from OpenOversight.app.filters import instantiate_filters
 from OpenOversight.app.models.config import config
 from OpenOversight.app.models.database import db
-from OpenOversight.app.utils.constants import MEGABYTE, SERVICE_ACCOUNT_FILE
+from OpenOversight.app.utils.constants import (
+    KEY_TESTING,
+    MEGABYTE,
+    SERVICE_ACCOUNT_FILE,
+)
 
 
 bootstrap = Bootstrap()
@@ -38,6 +43,8 @@ def create_app(config_name="default"):
     # Creates and adds the Config object of the correct type to app.config
     app.config.from_object(config[config_name])
 
+    if not app.config.get(KEY_TESTING):
+        Minify(app=app, cssless=True, html=True, js=True)
     bootstrap.init_app(app)
     csrf.init_app(app)
     db.init_app(app)

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -18,7 +18,6 @@ from OpenOversight.app.filters import instantiate_filters
 from OpenOversight.app.models.config import config
 from OpenOversight.app.models.database import db
 from OpenOversight.app.utils.constants import (
-    KEY_TESTING,
     MEGABYTE,
     SERVICE_ACCOUNT_FILE,
 )

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -8,7 +8,6 @@ KEY_TOTAL_OFFICERS = "total_officers"
 
 # Config Key Constants
 KEY_OFFICERS_PER_PAGE = "OFFICERS_PER_PAGE"
-KEY_TESTING = "TESTING"
 KEY_TIMEZONE = "TIMEZONE"
 
 # File Handling Constants

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -8,6 +8,7 @@ KEY_TOTAL_OFFICERS = "total_officers"
 
 # Config Key Constants
 KEY_OFFICERS_PER_PAGE = "OFFICERS_PER_PAGE"
+KEY_TESTING = "TESTING"
 KEY_TIMEZONE = "TIMEZONE"
 
 # File Handling Constants

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ Flask-Bootstrap==3.3.7.1
 Flask-Limiter==3.3.1
 Flask-Login==0.6.2
 Flask-Migrate==4.0.4
+Flask-Minify==0.42
 Flask-Sitemap==0.4.0
 Flask-SQLAlchemy==3.0.5
 Flask-WTF==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,10 @@ email-validator==2.0.0.post2
 Faker==18.13.0
 Flask==2.3.2
 Flask-Bootstrap==3.3.7.1
+Flask-Compress==1.13
 Flask-Limiter==3.3.1
 Flask-Login==0.6.2
 Flask-Migrate==4.0.4
-Flask-Minify==0.42
 Flask-Sitemap==0.4.0
 Flask-SQLAlchemy==3.0.5
 Flask-WTF==1.1.1


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/996

## Description of Changes
Added gzip compression to HTML, JS, and CSS file responses via the [`Flask-Compress` package](https://github.com/colour-science/flask-compress).

Network tab of `http://localhost:3000/department/1` without compression:
<img width="821" alt="Screenshot 2023-07-31 at 12 36 41 PM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/1ab41e56-a976-4e3c-83dc-fe3ef0bac16a">

Network tab of `http://localhost:3000/department/1` with compression:
<img width="821" alt="Screenshot 2023-07-31 at 12 32 38 PM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/fc09cbec-17b9-4640-9a9d-2348a1b973d3">


## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
