### PR TITLE
Fix adding duplicate officers to incidents

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1626,7 +1626,7 @@ class IncidentApi(ModelView):
                     except ValueError:
                         our_id = officer["oo_id"].split('value="')[1][:-2]
                         of = Officer.query.filter_by(id=int(our_id)).first()
-                    if of:
+                    if of and of not in obj.officers:
                         obj.officers.append(of)
 
         license_plates = form.data.pop("license_plates")


### PR DESCRIPTION
## Description of Changes
Merging fix https://github.com/OrcaCollective/OpenOversight/pull/347 upstream.

**Original PR description**:
Only add new officers to incidents.

When a user edits an incident currently, we retrieve the Incident from the database and append all officers in the form to that Incident. This led to sqlalchemy trying to insert duplicate rows into the officer_incidents association table.

As far as I can tell, this was silently ignored by sqlalchemy in the past and no unexpected rows were created. With the upgrade to sqlalchemy 2.0.19 (https://github.com/OrcaCollective/OpenOversight/pull/344), the library appears to have started raising exceptions related to this behavior.

This change checks to see whether an officer already exists in Incident.officers before adding them so as to not add duplicate officers.

## Notes for Deployment
N/A

## Screenshots (if appropriate)
N/A

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.

