### PR TITLE
Hotfix: Address missing constraint issue

### DIFF
--- a/OpenOversight/migrations/versions/2023-08-01-1905_b38c133bed3c_add_created_by_and_created_at_columns.py
+++ b/OpenOversight/migrations/versions/2023-08-01-1905_b38c133bed3c_add_created_by_and_created_at_columns.py
@@ -56,7 +56,6 @@ def upgrade():
 
     with op.batch_alter_table("descriptions", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by", sa.Integer(), nullable=True))
-        batch_op.drop_constraint("descriptions_creator_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "descriptions_created_by_fkey",
             "users",
@@ -86,7 +85,6 @@ def upgrade():
                 nullable=False,
             )
         )
-        batch_op.drop_constraint("faces_user_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "faces_created_by_fkey", "users", ["created_by"], ["id"]
         )
@@ -150,8 +148,6 @@ def upgrade():
                 nullable=True,
             )
         )
-        batch_op.drop_constraint("incidents_last_updated_id_fkey", type_="foreignkey")
-        batch_op.drop_constraint("incidents_creator_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "incidents_last_updated_by_fkey",
             "users",
@@ -221,7 +217,6 @@ def upgrade():
                 nullable=False,
             )
         )
-        batch_op.drop_constraint("links_creator_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "links_created_by_fkey",
             "users",
@@ -261,7 +256,6 @@ def upgrade():
 
     with op.batch_alter_table("notes", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by", sa.Integer(), nullable=True))
-        batch_op.drop_constraint("notes_creator_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "notes_created_by_fkey",
             "users",
@@ -321,7 +315,6 @@ def upgrade():
 
     with op.batch_alter_table("raw_images", schema=None) as batch_op:
         batch_op.add_column(sa.Column("created_by", sa.Integer(), nullable=True))
-        batch_op.drop_constraint("raw_images_user_id_fkey", type_="foreignkey")
         batch_op.create_foreign_key(
             "raw_images_created_by_fkey",
             "users",


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/1005

## Description of Changes
This fixes the issue we were having with trying to drop the `faces_user_id_fkey` in the push to `main`.  What happened was the `faces_user_id_fkey` wasn't saved under a name in the previous database model. PosgreSQL will drop any attached constraints when a column is dropped (presuming there are no `CASCADE` effects), so I am removing the `drop_constraint` commands and JUST dropping the column. This will allow PostgreSQL to take care of the constraint problem for us.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.

<details><summary>DB migration output</summary>

```console
:/usr/src/app$ flask db upgrade
[2023-08-03 21:48:37,989] INFO in __init__: OpenOversight startup
...
INFO  [sqlalchemy.engine.Engine] COMMIT
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 18f43ac4622f -> b38c133bed3c, add created_by and created_at columns
:/usr/src/app$ flask db downgrade
[2023-08-03 21:48:50,167] INFO in __init__: OpenOversight startup
...
INFO  [sqlalchemy.engine.Engine] COMMIT
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade b38c133bed3c -> 18f43ac4622f, add created_by and created_at columns
:/usr/src/app$ flask db upgrade
[2023-08-03 21:48:58,053] INFO in __init__: OpenOversight startup
...
INFO  [sqlalchemy.engine.Engine] COMMIT
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 18f43ac4622f -> b38c133bed3c, add created_by and created_at columns
:/usr/src/app$ 
```
</details>