### PR TITLE
Address database creation warnings

### DIFF
--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -82,9 +82,9 @@ def salary_record_maker(salary: Salary) -> _Record:
 
 
 def officer_record_maker(officer: Officer) -> _Record:
-    if officer.assignments_lazy:
+    if officer.assignments:
         most_recent_assignment = max(
-            officer.assignments_lazy, key=lambda a: a.start_date or date.min
+            officer.assignments, key=lambda a: a.start_date or date.min
         )
         most_recent_title = most_recent_assignment.job and check_output(
             most_recent_assignment.job.job_title

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1232,7 +1232,7 @@ def submit_data():
 def download_dept_officers_csv(department_id):
     officers = (
         db.session.query(Officer)
-        .options(joinedload(Officer.assignments_lazy).joinedload(Assignment.job))
+        .options(joinedload(Officer.assignments).joinedload(Assignment.job))
         .options(joinedload(Officer.salaries))
         .filter_by(department_id=department_id)
     )

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -198,8 +198,10 @@ class Officer(BaseModel):
     gender = db.Column(db.String(5), index=True, unique=False, nullable=True)
     employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
     birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
-    assignments = db.relationship("Assignment", backref="officer", lazy="dynamic")
-    assignments_lazy = db.relationship("Assignment")
+    assignments = db.relationship(
+        "Assignment", back_populates="base_officer", lazy="dynamic"
+    )
+    assignments_lazy = db.relationship("Assignment", back_populates="base_officer")
     face = db.relationship("Face", backref="officer")
     department_id = db.Column(db.Integer, db.ForeignKey("departments.id"))
     department = db.relationship("Department", backref="officers")
@@ -334,7 +336,7 @@ class Assignment(BaseModel):
 
     id = db.Column(db.Integer, primary_key=True)
     officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
-    base_officer = db.relationship("Officer")
+    base_officer = db.relationship("Officer", back_populates="assignments")
     star_no = db.Column(db.String(120), index=True, unique=False, nullable=True)
     job_id = db.Column(db.Integer, db.ForeignKey("jobs.id"), nullable=False)
     job = db.relationship("Job")
@@ -408,12 +410,12 @@ class Face(BaseModel):
     face_position_y = db.Column(db.Integer, unique=False)
     face_width = db.Column(db.Integer, unique=False)
     face_height = db.Column(db.Integer, unique=False)
-    image = db.relationship("Image", backref="faces", foreign_keys=[img_id])
+    image = db.relationship("Image", back_populates="faces", foreign_keys=[img_id])
     original_image = db.relationship(
         "Image", backref="tags", foreign_keys=[original_image_id], lazy=True
     )
     created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
-    user = db.relationship("User", backref="faces")
+    user = db.relationship("User", back_populates="faces")
     featured = db.Column(
         db.Boolean, nullable=False, default=False, server_default="false"
     )
@@ -456,7 +458,7 @@ class Image(BaseModel):
         unique=False,
     )
 
-    user = db.relationship("User", backref="raw_images")
+    user = db.relationship("User", back_populates="classifications")
     is_tagged = db.Column(db.Boolean, default=False, unique=False, nullable=True)
 
     department_id = db.Column(db.Integer, db.ForeignKey("departments.id"))
@@ -704,8 +706,8 @@ class User(UserMixin, BaseModel):
     is_disabled = db.Column(db.Boolean, default=False)
     dept_pref = db.Column(db.Integer, db.ForeignKey("departments.id"))
     dept_pref_rel = db.relationship("Department", foreign_keys=[dept_pref])
-    classifications = db.relationship("Image", backref="users")
-    tags = db.relationship("Face", backref="users")
+    classifications = db.relationship("Image", back_populates="users")
+    tags = db.relationship("Face", back_populates="users")
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -401,7 +401,7 @@ class Face(BaseModel):
     face_position_y = db.Column(db.Integer, unique=False)
     face_width = db.Column(db.Integer, unique=False)
     face_height = db.Column(db.Integer, unique=False)
-    image = db.relationship("Image", backref="raw_images", foreign_keys=[img_id])
+    image = db.relationship("Image", backref="faces", foreign_keys=[img_id])
     original_image = db.relationship(
         "Image", backref="tags", foreign_keys=[original_image_id], lazy=True
     )

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -198,9 +198,7 @@ class Officer(BaseModel):
     gender = db.Column(db.String(5), index=True, unique=False, nullable=True)
     employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
     birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
-    assignments = db.relationship(
-        "Assignment", back_populates="base_officer", lazy="dynamic"
-    )
+    assignments = db.relationship("Assignment", back_populates="base_officer")
     face = db.relationship("Face", backref="officer")
     department_id = db.Column(db.Integer, db.ForeignKey("departments.id"))
     department = db.relationship("Department", backref="officers")

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -325,9 +325,7 @@ def filter_by_form(form_data, officer_query, department_id=None):
 
         if form_data.get("current_job"):
             officer_query = officer_query.filter(Assignment.resign_date.is_(None))
-    officer_query = officer_query.options(
-        selectinload(Officer.assignments_lazy)
-    ).distinct()
+    officer_query = officer_query.options(selectinload(Officer.assignments)).distinct()
 
     return officer_query
 

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -213,7 +213,7 @@ def build_assignment(
     return Assignment(
         star_no=pick_star(),
         job_id=random.choice(jobs).id,
-        officer=officer,
+        base_officer=officer,
         unit_id=unit_id,
         start_date=pick_date(officer.full_name().encode(ENCODING_UTF_8)),
         resign_date=pick_date(officer.full_name().encode(ENCODING_UTF_8)),

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -213,7 +213,7 @@ def build_assignment(
     return Assignment(
         star_no=pick_star(),
         job_id=random.choice(jobs).id,
-        base_officer=officer,
+        officer_id=officer.id,
         unit_id=unit_id,
         start_date=pick_date(officer.full_name().encode(ENCODING_UTF_8)),
         resign_date=pick_date(officer.full_name().encode(ENCODING_UTF_8)),

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -1,4 +1,6 @@
 from flask import url_for
+from flask.testing import FlaskClient
+from werkzeug.test import TestResponse
 
 from OpenOversight.app.auth.forms import LoginForm
 from OpenOversight.app.models.database import User
@@ -18,14 +20,14 @@ from OpenOversight.tests.constants import (
 )
 
 
-def login_user(client):
+def login_user(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=GENERAL_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def login_unconfirmed_user(client):
+def login_unconfirmed_user(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=UNCONFIRMED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=UNCONFIRMED_USER_PASSWORD, remember_me=True
@@ -35,7 +37,7 @@ def login_unconfirmed_user(client):
     return rv, user
 
 
-def login_disabled_user(client):
+def login_disabled_user(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=DISABLED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=DISABLED_USER_PASSWORD, remember_me=True
@@ -44,7 +46,7 @@ def login_disabled_user(client):
     return rv, user
 
 
-def login_modified_disabled_user(client):
+def login_modified_disabled_user(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=MOD_DISABLED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=MOD_DISABLED_USER_PASSWORD, remember_me=True
@@ -53,21 +55,21 @@ def login_modified_disabled_user(client):
     return rv, user
 
 
-def login_admin(client):
+def login_admin(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=ADMIN_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=ADMIN_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def login_ac(client):
+def login_ac(client: FlaskClient) -> (TestResponse, User):
     user = User.query.filter_by(email=AC_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=AC_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def process_form_data(form_dict):
+def process_form_data(form_dict: dict) -> dict:
     """Mock the browser-flattening of a form containing embedded data."""
     new_dict = {}
     for key, value in form_dict.items():
@@ -75,8 +77,8 @@ def process_form_data(form_dict):
             if value[0]:
                 if type(value[0]) is dict:
                     for idx, item in enumerate(value):
-                        for subkey, subvalue in item.items():
-                            new_dict[f"{key}-{idx}-{subkey}"] = subvalue
+                        for sub_key, sub_value in item.items():
+                            new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
                 elif type(value[0]) is str or type(value[0]) is int:
                     for idx, item in enumerate(value):
                         new_dict[f"{key}-{idx}"] = item
@@ -87,8 +89,8 @@ def process_form_data(form_dict):
                         )
                     )
         elif type(value) == dict:
-            for subkey, subvalue in value.items():
-                new_dict[f"{key}-{subkey}"] = subvalue
+            for sub_key, sub_value in value.items():
+                new_dict[f"{key}-{sub_key}"] = sub_value
         else:
             new_dict[key] = value
 

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -1,6 +1,4 @@
 from flask import url_for
-from flask.testing import FlaskClient
-from werkzeug.test import TestResponse
 
 from OpenOversight.app.auth.forms import LoginForm
 from OpenOversight.app.models.database import User
@@ -20,14 +18,14 @@ from OpenOversight.tests.constants import (
 )
 
 
-def login_user(client: FlaskClient) -> (TestResponse, User):
+def login_user(client):
     user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=GENERAL_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def login_unconfirmed_user(client: FlaskClient) -> (TestResponse, User):
+def login_unconfirmed_user(client):
     user = User.query.filter_by(email=UNCONFIRMED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=UNCONFIRMED_USER_PASSWORD, remember_me=True
@@ -37,7 +35,7 @@ def login_unconfirmed_user(client: FlaskClient) -> (TestResponse, User):
     return rv, user
 
 
-def login_disabled_user(client: FlaskClient) -> (TestResponse, User):
+def login_disabled_user(client):
     user = User.query.filter_by(email=DISABLED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=DISABLED_USER_PASSWORD, remember_me=True
@@ -46,7 +44,7 @@ def login_disabled_user(client: FlaskClient) -> (TestResponse, User):
     return rv, user
 
 
-def login_modified_disabled_user(client: FlaskClient) -> (TestResponse, User):
+def login_modified_disabled_user(client):
     user = User.query.filter_by(email=MOD_DISABLED_USER_EMAIL).first()
     form = LoginForm(
         email=user.email, password=MOD_DISABLED_USER_PASSWORD, remember_me=True
@@ -55,21 +53,21 @@ def login_modified_disabled_user(client: FlaskClient) -> (TestResponse, User):
     return rv, user
 
 
-def login_admin(client: FlaskClient) -> (TestResponse, User):
+def login_admin(client):
     user = User.query.filter_by(email=ADMIN_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=ADMIN_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def login_ac(client: FlaskClient) -> (TestResponse, User):
+def login_ac(client):
     user = User.query.filter_by(email=AC_USER_EMAIL).first()
     form = LoginForm(email=user.email, password=AC_USER_PASSWORD, remember_me=True)
     rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
     return rv, user
 
 
-def process_form_data(form_dict: dict) -> dict:
+def process_form_data(form_dict):
     """Mock the browser-flattening of a form containing embedded data."""
     new_dict = {}
     for key, value in form_dict.items():
@@ -77,8 +75,8 @@ def process_form_data(form_dict: dict) -> dict:
             if value[0]:
                 if type(value[0]) is dict:
                     for idx, item in enumerate(value):
-                        for sub_key, sub_value in item.items():
-                            new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
+                        for subkey, subvalue in item.items():
+                            new_dict[f"{key}-{idx}-{subkey}"] = subvalue
                 elif type(value[0]) is str or type(value[0]) is int:
                     for idx, item in enumerate(value):
                         new_dict[f"{key}-{idx}"] = item
@@ -89,8 +87,8 @@ def process_form_data(form_dict: dict) -> dict:
                         )
                     )
         elif type(value) == dict:
-            for sub_key, sub_value in value.items():
-                new_dict[f"{key}-{sub_key}"] = sub_value
+            for subkey, subvalue in value.items():
+                new_dict[f"{key}-{subkey}"] = subvalue
         else:
             new_dict[key] = value
 

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -568,22 +568,20 @@ def test_bulk_add_officers__success(
     officers = officer_query.all()
     assert len(officers) == 3
     first_officer_db = officer_query.filter_by(first_name=fo_fn, last_name=fo_ln).one()
-    assert {asmt.job.job_title for asmt in first_officer_db.assignments} == {
+    assert {a.job.job_title for a in first_officer_db.assignments} == {
         RANK_CHOICES_1[2],
         RANK_CHOICES_1[1],
     }
     different_officer_db = officer_query.filter_by(
         first_name=do_fn, last_name=do_ln
     ).one()
-    assert [asmt.job.job_title for asmt in different_officer_db.assignments] == [
+    assert [a.job.job_title for a in different_officer_db.assignments] == [
         RANK_CHOICES_1[1]
     ]
     new_officer_db = officer_query.filter_by(
         first_name=new_officer_first_name, last_name=new_officer_last_name
     ).one()
-    assert [asmt.job.job_title for asmt in new_officer_db.assignments] == [
-        RANK_CHOICES_1[1]
-    ]
+    assert [a.job.job_title for a in new_officer_db.assignments] == [RANK_CHOICES_1[1]]
 
 
 def test_bulk_add_officers__duplicate_name(session, department, csv_path):

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -568,20 +568,20 @@ def test_bulk_add_officers__success(
     officers = officer_query.all()
     assert len(officers) == 3
     first_officer_db = officer_query.filter_by(first_name=fo_fn, last_name=fo_ln).one()
-    assert {asmt.job.job_title for asmt in first_officer_db.assignments.all()} == {
+    assert {asmt.job.job_title for asmt in first_officer_db.assignments} == {
         RANK_CHOICES_1[2],
         RANK_CHOICES_1[1],
     }
     different_officer_db = officer_query.filter_by(
         first_name=do_fn, last_name=do_ln
     ).one()
-    assert [asmt.job.job_title for asmt in different_officer_db.assignments.all()] == [
+    assert [asmt.job.job_title for asmt in different_officer_db.assignments] == [
         RANK_CHOICES_1[1]
     ]
     new_officer_db = officer_query.filter_by(
         first_name=new_officer_first_name, last_name=new_officer_last_name
     ).one()
-    assert [asmt.job.job_title for asmt in new_officer_db.assignments.all()] == [
+    assert [asmt.job.job_title for asmt in new_officer_db.assignments] == [
         RANK_CHOICES_1[1]
     ]
 
@@ -958,14 +958,14 @@ def test_advanced_csv_import__success(session, department, test_csv_dir):
     assert len(cop2.salaries) == 1
     assert cop2.salaries[0].salary == 20000
 
-    assert len(cop2.assignments.all()) == 1
+    assert len(cop2.assignments) == 1
     assert cop2.assignments[0].job.job_title == "Commander"
 
     cop3 = all_officers["UID-3"]
     assert cop3.first_name == "Robert"
     assert cop3.last_name == "Brown"
 
-    assert len(cop3.assignments.all()) == 0
+    assert len(cop3.assignments) == 0
     assert len(cop3.salaries) == 0
 
     cop4 = all_officers["UID-4"]
@@ -975,7 +975,7 @@ def test_advanced_csv_import__success(session, department, test_csv_dir):
     assert cop4.gender == "Other"
     assert cop4.salaries[0].salary == 50000
 
-    assert len(cop4.assignments.all()) == 2
+    assert len(cop4.assignments) == 2
     updated_assignment, new_assignment = sorted(
         cop4.assignments, key=operator.attrgetter("start_date")
     )
@@ -1268,15 +1268,15 @@ def test_advanced_csv_import__overwrite_assignments(session, department, tmp_pat
 
     # make sure all the data is imported as expected
     cop1 = Officer.query.get(cop1_id)
-    assert len(cop1.assignments.all()) == 1
+    assert len(cop1.assignments) == 1
     assert cop1.assignments[0].star_no == b1
 
     cop2 = Officer.query.get(cop2_id)
-    assert len(cop2.assignments.all()) == 1
+    assert len(cop2.assignments) == 1
     assert cop2.assignments[0] == Assignment.query.get(a2_id)
 
     cop3 = Officer.query.filter_by(first_name="Second", last_name="Test").first()
-    assert len(cop3.assignments.all()) == 1
+    assert len(cop3.assignments) == 1
     assert cop3.assignments[0].star_no == b2
     assert cop3.assignments[0].job.job_title == "Police Officer"
 

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -98,7 +98,7 @@ def test_assignment_repr(mockdata):
     assignment = Assignment.query.first()
     assert (
         repr(assignment)
-        == f"<Assignment: ID {assignment.officer.id} : {assignment.star_no}>"
+        == f"<Assignment: ID {assignment.base_officer.id} : {assignment.star_no}>"
     )
 
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -78,7 +78,7 @@ def test_rank_filter_select_all_commanders(mockdata):
     department = Department.query.first()
     results = grab_officers({"rank": ["Commander"], "dept": department})
     for element in results.all():
-        assignment = element.assignments.first()
+        assignment = element.assignments[0]
         assert assignment.job.job_title in ("Commander", "Not Sure")
 
 
@@ -86,7 +86,7 @@ def test_rank_filter_select_all_police_officers(mockdata):
     department = Department.query.first()
     results = grab_officers({"rank": ["Police Officer"], "dept": department})
     for element in results.all():
-        assignment = element.assignments.first()
+        assignment = element.assignments[0]
         assert assignment.job.job_title in ("Police Officer", "Not Sure")
 
 
@@ -110,7 +110,7 @@ def test_filter_by_badge_no(mockdata):
     department = Department.query.first()
     results = grab_officers({"badge": "12", "dept": department})
     for element in results.all():
-        assignment = element.assignments.first()
+        assignment = element.assignments[0]
         assert "12" in str(assignment.star_no)
 
 


### PR DESCRIPTION
## Fixes issue
 <!-- LINK YOUR ISSUE HERE -->

## Description of Changes
Addressed DB warnings that we'd see during creation and removed redundant/unnecessary Model properties.
```console
SAWarning: relationship 'Face.users' will copy column users.id to column faces.user_id, which conflicts with relationship(s): 'Face.user' (copies users.id to faces.user_id), 'User.faces' (copies users.id to faces.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="faces,user"' to the 'Face.users' relationship.
SAWarning: relationship 'Officer.assignments_lazy' will copy column officers.id to column assignments.officer_id, which conflicts with relationship(s): 'Assignment.officer' (copies officers.id to assignments.officer_id), 'Officer.assignments' (copies officers.id to assignments.officer_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="assignments,officer"' to the 'Officer.assignments_lazy' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  department = Department(
SAWarning: relationship 'Assignment.base_officer' will copy column officers.id to column assignments.officer_id, which conflicts with relationship(s): 'Assignment.officer' (copies officers.id to assignments.officer_id), 'Officer.assignments' (copies officers.id to assignments.officer_id), 'Officer.assignments_lazy' (copies officers.id to assignments.officer_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="assignments,assignments_lazy,officer"' to the 'Assignment.base_officer' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  department = Department(
SAWarning: relationship 'Image.users' will copy column users.id to column raw_images.created_by, which conflicts with relationship(s): 'Image.user' (copies users.id to raw_images.created_by), 'User.raw_images' (copies users.id to raw_images.created_by). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="raw_images,user"' to the 'Image.users' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  department = Department(
SAWarning: relationship 'User.classifications' will copy column users.id to column raw_images.created_by, which conflicts with relationship(s): 'Image.user' (copies users.id to raw_images.created_by), 'User.raw_images' (copies users.id to raw_images.created_by). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="raw_images,user"' to the 'User.classifications' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  department = Department(
SAWarning: relationship 'Face.users' will copy column users.id to column faces.created_by, which conflicts with relationship(s): 'Face.user' (copies users.id to faces.created_by), 'User.faces' (copies users.id to faces.created_by). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="faces,user"' to the 'Face.users' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
  department = Department(
SAWarning: relationship 'User.tags' will copy column users.id to column faces.created_by, which conflicts with relationship(s): 'Face.user' (copies users.id to faces.created_by), 'User.faces' (copies users.id to faces.created_by). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="faces,user"' to the 'User.tags' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
```

Relevant information: https://stackoverflow.com/a/59920780

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.

The warnings are gone:
```console
Postgres is up
## Populate database with test data
docker-compose run --rm web python ./test_data.py -p
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
[+] Creating 1/0
 ✔ Container openoversight-postgres-1  Running                                                                                                                                                             0.0s 
/usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
  warnings.warn(
[2023-08-08 18:05:22,006] INFO in __init__: OpenOversight startup
/usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
  warnings.warn(
[2023-08-08 18:05:22,097] INFO in __init__: OpenOversight startup
[*] Populating database with test data...
2023-08-08 18:05:27,443 INFO sqlalchemy.engine.Engine select pg_catalog.version()
```
