### PR TITLE
Order department listings and add `display_name`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ attach:
 	docker-compose exec postgres psql -h localhost -U openoversight openoversight-dev
 
 .PHONY: create_empty_secret
-create_empty_secret: # This is needed to make sure docker doesn't create an empty directory, or delete that directory first
+create_empty_secret: ## This is needed to make sure docker doesn't create an empty directory, or delete that directory first
 	touch service_account_key.json || \
 	(echo "Need to delete that empty directory first"; \
 	 sudo rm -d service_account_key.json/; \

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -40,7 +40,7 @@ from OpenOversight.app.utils.choices import (
     STATE_CHOICES,
     SUFFIX_CHOICES,
 )
-from OpenOversight.app.utils.db import dept_choices, unit_choices, unsorted_dept_choices
+from OpenOversight.app.utils.db import dept_choices, unit_choices
 from OpenOversight.app.widgets import BootstrapListWidget, FormFieldWidget
 
 

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -97,12 +97,10 @@ class FindOfficerForm(Form):
         default="",
         validators=[Regexp(r"\w*"), Length(max=55)],
     )
-    # TODO: Figure out why this test is failing when the departments are sorted using
-    #  the dept_choices function.
     dept = QuerySelectField(
         "dept",
         validators=[DataRequired()],
-        query_factory=unsorted_dept_choices,
+        query_factory=dept_choices,
         get_label="display_name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -97,6 +97,8 @@ class FindOfficerForm(Form):
         default="",
         validators=[Regexp(r"\w*"), Length(max=55)],
     )
+    # TODO: Figure out why this test is failing when the departments are sorted using
+    #  the dept_choices function.
     dept = QuerySelectField(
         "dept",
         validators=[DataRequired()],

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -101,7 +101,7 @@ class FindOfficerForm(Form):
         "dept",
         validators=[DataRequired()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])
     current_job = BooleanField("current_job", default=None, validators=[Optional()])
@@ -306,7 +306,7 @@ class AddOfficerForm(Form):
         "Department",
         validators=[DataRequired()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
     first_name = StringField(
         "First name",
@@ -433,7 +433,7 @@ class EditOfficerForm(Form):
         "Department",
         validators=[Optional()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
     submit = SubmitField(label="Update")
 
@@ -448,7 +448,7 @@ class AddUnitForm(Form):
         "Department",
         validators=[DataRequired()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
     created_by = HiddenField(
         validators=[
@@ -463,7 +463,7 @@ class AddImageForm(Form):
         "Department",
         validators=[DataRequired()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
 
 
@@ -574,7 +574,7 @@ class IncidentForm(DateFieldForm):
         "Department*",
         validators=[DataRequired()],
         query_factory=dept_choices,
-        get_label="name",
+        get_label="display_name",
     )
     address = FormField(LocationForm)
     officers = FieldList(

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -40,7 +40,7 @@ from OpenOversight.app.utils.choices import (
     STATE_CHOICES,
     SUFFIX_CHOICES,
 )
-from OpenOversight.app.utils.db import dept_choices, unit_choices
+from OpenOversight.app.utils.db import dept_choices, unit_choices, unsorted_dept_choices
 from OpenOversight.app.widgets import BootstrapListWidget, FormFieldWidget
 
 
@@ -100,7 +100,7 @@ class FindOfficerForm(Form):
     dept = QuerySelectField(
         "dept",
         validators=[DataRequired()],
-        query_factory=dept_choices,
+        query_factory=unsorted_dept_choices,
         get_label="display_name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -40,7 +40,7 @@ from OpenOversight.app.utils.choices import (
     STATE_CHOICES,
     SUFFIX_CHOICES,
 )
-from OpenOversight.app.utils.db import dept_choices, unit_choices
+from OpenOversight.app.utils.db import dept_choices, unit_choices, unsorted_dept_choices
 from OpenOversight.app.widgets import BootstrapListWidget, FormFieldWidget
 
 
@@ -97,10 +97,12 @@ class FindOfficerForm(Form):
         default="",
         validators=[Regexp(r"\w*"), Length(max=55)],
     )
+    # TODO: Figure out why this test is failing when the departments are sorted using
+    #  the dept_choices function.
     dept = QuerySelectField(
         "dept",
         validators=[DataRequired()],
-        query_factory=dept_choices,
+        query_factory=unsorted_dept_choices,
         get_label="display_name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -99,6 +99,7 @@ from OpenOversight.app.utils.db import (
     compute_leaderboard_stats,
     dept_choices,
     unit_choices,
+    unsorted_dept_choices,
 )
 from OpenOversight.app.utils.forms import (
     add_new_assignment,
@@ -179,7 +180,11 @@ def browse():
 def get_officer():
     form = FindOfficerForm()
 
-    departments_dict = [dept_choice.to_custom_dict() for dept_choice in dept_choices()]
+    # TODO: Figure out why this test is failing when the departments are sorted using
+    #  the dept_choices function.
+    departments_dict = [
+        dept_choice.to_custom_dict() for dept_choice in unsorted_dept_choices()
+    ]
 
     if getattr(current_user, "dept_pref_rel", None):
         set_dynamic_default(form.dept, current_user.dept_pref_rel)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -97,7 +97,6 @@ from OpenOversight.app.utils.db import (
     add_department_query,
     add_unit_query,
     compute_leaderboard_stats,
-    dept_choices,
     unit_choices,
     unsorted_dept_choices,
 )

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -98,6 +98,10 @@ class Department(BaseModel):
             "unique_internal_identifier_label": self.unique_internal_identifier_label,
         }
 
+    @property
+    def display_name(self):
+        return self.name if not self.state else f"[{self.state}] {self.name}"
+
     @cached(cache=DB_CACHE, key=model_cache_key(KEY_DEPT_TOTAL_ASSIGNMENTS))
     def total_documented_assignments(self):
         return (

--- a/OpenOversight/app/templates/browse.html
+++ b/OpenOversight/app/templates/browse.html
@@ -18,8 +18,7 @@
         <p>
           <div class="btn-group">
             <h2>
-              {% if department.state %}[{{ department.state }}] {{ department.name }}{% endif %}
-              {% if not department.state %}{{ department.name }}{% endif %}
+              {{ department.display_name }}
               {% if current_user.is_administrator %}
                 <a href="{{ url_for('main.edit_department', department_id=department.id) }}">
                   <i class="fa fa-pencil-square-o" aria-hidden="true"></i>

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -116,7 +116,7 @@
             </div>
             <div id="uii-question">
               <h2>
-                <small>Do you know any part of the Officer's unique internal identifier?</small>
+                <small>Do you know any part of the Officer's <span id="current-uii" data-departments='{{ depts_dict | tojson }}'></span>?</small>
               </h2>
               <div class="input-group input-group-lg col-md-4 col-md-offset-4">
                 {{ form.unique_internal_identifier(class="form-control") }}

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -116,7 +116,7 @@
             </div>
             <div id="uii-question">
               <h2>
-                <small>Do you know any part of the Officer's <span id="current-uii" data-departments='{{ depts_dict | tojson }}'>unique internal identifier</span>?</small>
+                <small>Do you know any part of the Officer's unique internal identifier?</small>
               </h2>
               <div class="input-group input-group-lg col-md-4 col-md-offset-4">
                 {{ form.unique_internal_identifier(class="form-control") }}

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -116,7 +116,7 @@
             </div>
             <div id="uii-question">
               <h2>
-                <small>Do you know any part of the Officer's <span id="current-uii" data-departments='{{ depts_dict | tojson }}'></span>?</small>
+                <small>Do you know any part of the Officer's <span id="current-uii" data-departments='{{ depts_dict | tojson }}'>unique internal identifier</span>?</small>
               </h2>
               <div class="input-group input-group-lg col-md-4 col-md-offset-4">
                 {{ form.unique_internal_identifier(class="form-control") }}

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -13,11 +13,7 @@
 {% endblock head %}
 {% block content %}
   <div class="container" role="main">
-    {% if department.state %}
-      <h1>[{{ department.state }}] {{ department.name | title }} Officers</h1>
-    {% else %}
-      <h1>{{ department.name | title }} Officers</h1>
-    {% endif %}
+    <h1>{{ department.display_name | title }} Officers</h1>
     <div class="row">
       <div class="filter-sidebar col-sm-3">
         <h3 class="sidebar-title">Filter officers</h3>

--- a/OpenOversight/app/templates/partials/officer_general_information.html
+++ b/OpenOversight/app/templates/partials/officer_general_information.html
@@ -34,11 +34,7 @@
           <td>
             <b>Department</b>
           </td>
-          {% if officer.department.state %}
-            <td>[{{ officer.department.state }}] {{ officer.department.name }}</td>
-          {% else %}
-            <td>{{ officer.department.name }}</td>
-          {% endif %}
+          <td>{{ officer.department.display_name }}</td>
         </tr>
         <tr>
           <td>

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -60,18 +60,14 @@
     <script src="{{ url_for('static', filename='js/init-dropzone.js') }}"></script>
     <script>
         // Select user's preferred department by default
-        document.getElementById("department").selectedIndex = {
-            {
-                preferred_dept_id
-            }
-        } - 1;
+        document.getElementById("department").selectedIndex = {{ preferred_dept_id }} - 1;
         // Save the preferred department in dept_id
-        var dept_id = document.getElementById("department").selectedIndex + 1;
-        var csrf_token = "{{ csrf_token() }}";
+        let dept_id = document.getElementById("department").selectedIndex + 1;
+        const csrf_token = "{{ csrf_token() }}";
 
         // Store changes in drop down list in dept_id variable
         $(function() {
-            select_dept = $('#dept-select');
+            const select_dept = $('#dept-select');
             select_dept.on('change', function() {
                 // fires when department selection changes
                 dept_id = document.getElementById("department").value;

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -36,11 +36,11 @@
     <h3>Select the department that the police officer in your image belongs to:</h3>
     <div class="form-group">
       <form class="form"
-            name="deptselect"
-            id="deptselect"
+            name="dept-select"
+            id="dept-select"
             method="post"
             role="form"
-            label="deptselect">
+            label="dept-select">
         {{ wtf.form_field(form.department) }}
       </form>
       <br>
@@ -71,7 +71,7 @@
 
         // Store changes in drop down list in dept_id variable
         $(function() {
-            select_dept = $('#deptselect');
+            select_dept = $('#dept-select');
             select_dept.on('change', function() {
                 // fires when department selection changes
                 dept_id = document.getElementById("department").value;

--- a/OpenOversight/app/utils/db.py
+++ b/OpenOversight/app/utils/db.py
@@ -54,7 +54,15 @@ def compute_leaderboard_stats(select_top=25):
 
 
 def dept_choices():
-    return db.session.query(Department).order_by(Department.name.asc()).all()
+    return (
+        db.session.query(Department)
+        .order_by(Department.state.asc(), Department.name.asc())
+        .all()
+    )
+
+
+def unsorted_dept_choices():
+    return db.session.query(Department).all()
 
 
 def get_officer(department_id, star_no, first_name, last_name):

--- a/OpenOversight/app/utils/db.py
+++ b/OpenOversight/app/utils/db.py
@@ -54,7 +54,11 @@ def compute_leaderboard_stats(select_top=25):
 
 
 def dept_choices():
-    return db.session.query(Department).all()
+    return (
+        db.session.query(Department)
+        .order_by(Department.state.asc(), Department.name.asc())
+        .all()
+    )
 
 
 def get_officer(department_id, star_no, first_name, last_name):

--- a/OpenOversight/app/utils/db.py
+++ b/OpenOversight/app/utils/db.py
@@ -54,11 +54,7 @@ def compute_leaderboard_stats(select_top=25):
 
 
 def dept_choices():
-    return (
-        db.session.query(Department)
-        .order_by(Department.state.asc(), Department.name.asc())
-        .all()
-    )
+    return db.session.query(Department).order_by(Department.name.asc()).all()
 
 
 def get_officer(department_id, star_no, first_name, last_name):

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -83,7 +83,7 @@ class PoliceDepartment:
         name,
         short_name,
         state="",
-        unique_internal_identifier_label="",
+        uid_label="",
         exclude_state="",
     ):
         self.name = name
@@ -95,11 +95,7 @@ class PoliceDepartment:
                 [s for s in DEPARTMENT_STATE_CHOICES if s[0] != exclude_state]
             )[0]
         )
-        self.unique_internal_identifier_label = (
-            unique_internal_identifier_label
-            if unique_internal_identifier_label
-            else pick_uid()
-        )
+        self.uid_label = uid_label if uid_label else pick_uid()
 
 
 OFFICERS = [
@@ -424,7 +420,7 @@ def add_mockdata(session):
         name=SPRINGFIELD_PD.name,
         short_name=SPRINGFIELD_PD.short_name,
         state=SPRINGFIELD_PD.state,
-        unique_internal_identifier_label=SPRINGFIELD_PD.unique_internal_identifier_label,
+        unique_internal_identifier_label=SPRINGFIELD_PD.uid_label,
         created_by=test_admin.id,
     )
     session.add(department)

--- a/OpenOversight/tests/test_commands.py
+++ b/OpenOversight/tests/test_commands.py
@@ -70,7 +70,7 @@ def test_add_department__success(session):
             AddedPD.name,
             AddedPD.short_name,
             AddedPD.state,
-            AddedPD.unique_internal_identifier_label,
+            AddedPD.uid_label,
         ],
     )
 
@@ -78,7 +78,7 @@ def test_add_department__success(session):
     assert result.exit_code == 0
     # department was added to database
     departments = Department.query.filter_by(
-        unique_internal_identifier_label=AddedPD.unique_internal_identifier_label
+        unique_internal_identifier_label=AddedPD.uid_label
     ).all()
     assert len(departments) == 1
     department = departments[0]
@@ -94,7 +94,7 @@ def test_add_department__duplicate(session):
         name=DuplicatePD.name,
         short_name=DuplicatePD.short_name,
         state=DuplicatePD.state,
-        unique_internal_identifier_label=DuplicatePD.unique_internal_identifier_label,
+        unique_internal_identifier_label=DuplicatePD.uid_label,
     )
     session.add(department)
     session.commit()

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -142,7 +142,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
     browser.get(f"http://localhost:{server_port}/find")
 
     dept_with_uii = Department.query.filter_by(
-        unique_internal_identifier_label=SPRINGFIELD_PD.unique_internal_identifier_label,
+        unique_internal_identifier_label=SPRINGFIELD_PD.uid_label,
     ).one()
     dept_id = str(dept_with_uii.id)
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -142,16 +142,16 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
     browser.get(f"http://localhost:{server_port}/find")
 
     dept_with_uii = Department.query.filter_by(
-        id=2,
-    ).one()
+        Department.unique_internal_identifier_label.isnot(None)
+    ).first()
     dept_id = str(dept_with_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))
     dept_selector.select_by_value(dept_id)
     browser.find_element_by_id("activate-step-2").click()
 
-    page_text = browser.find_element_by_tag_name("body").text
-    assert "Do you know any part of the Officer's" in page_text
+    uii_elements = browser.find_elements_by_id("#uii-question")
+    assert len(uii_elements) == 1
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
@@ -168,8 +168,8 @@ def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
     dept_selector.select_by_value(dept_id)
     browser.find_element_by_id("activate-step-2").click()
 
-    results = browser.find_elements_by_id("#uii-question")
-    assert len(results) == 0
+    uii_elements = browser.find_elements_by_id("#uii-question")
+    assert len(uii_elements) == 0
 
 
 def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -150,8 +150,8 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
     dept_selector.select_by_value(dept_id)
     browser.find_element_by_id("activate-step-2").click()
 
-    uii_elements = browser.find_elements_by_id("#uii-question")
-    assert len(uii_elements) == 1
+    page_text = browser.find_element_by_tag_name("body").text
+    assert "Do you know any part of the Officer's" in page_text
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -117,7 +117,7 @@ def test_officer_browse_pagination(mockdata, browser, server_port):
     browser.get(f"http://localhost:{server_port}/departments/{AC_DEPT}?page=1")
     wait_for_element(browser, By.TAG_NAME, "body")
     page_text = browser.find_element_by_tag_name("body").text
-    expected = f"Showing 1-{current_app.config['OFFICERS_PER_PAGE']} of {total}"
+    expected = f"Showing 1-{current_app.config[KEY_OFFICERS_PER_PAGE]} of {total}"
     assert expected in page_text
 
     # last page of results
@@ -143,7 +143,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 
     dept_with_uii = Department.query.filter(
         Department.unique_internal_identifier_label.isnot(None)
-    ).first()
+    )[1]
     dept_id = str(dept_with_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -110,24 +110,6 @@ def test_user_can_get_to_complaint(mockdata, browser, server_port):
     assert "File a Complaint" in title_text
 
 
-def test_find_officer_can_see_uii_question_for_depts_with_uiis(
-    mockdata, browser, server_port
-):
-    browser.get(f"http://localhost:{server_port}/find")
-
-    dept_with_uii = Department.query.filter(
-        Department.unique_internal_identifier_label.isnot(None)
-    ).first()
-    dept_id = str(dept_with_uii.id)
-
-    dept_selector = Select(browser.find_element_by_id("dept"))
-    dept_selector.select_by_value(dept_id)
-    browser.find_element_by_id("activate-step-2").click()
-
-    uii_elements = browser.find_elements_by_id("#uii-question")
-    assert len(uii_elements) == 1
-
-
 def test_officer_browse_pagination(mockdata, browser, server_port):
     total = Officer.query.filter_by(department_id=AC_DEPT).count()
 
@@ -152,6 +134,24 @@ def test_officer_browse_pagination(mockdata, browser, server_port):
     )
     expected = f"Showing {start_of_page}-{total} of {total}"
     assert expected in page_text
+
+
+def test_find_officer_can_see_uii_question_for_depts_with_uiis(
+    mockdata, browser, server_port
+):
+    browser.get(f"http://localhost:{server_port}/find")
+
+    dept_with_uii = Department.query.filter(
+        Department.unique_internal_identifier_label.isnot(None)
+    ).first()
+    dept_id = str(dept_with_uii.id)
+
+    dept_selector = Select(browser.find_element_by_id("dept"))
+    dept_selector.select_by_value(dept_id)
+    browser.find_element_by_id("activate-step-2").click()
+
+    uii_elements = browser.find_elements_by_id("#uii-question")
+    assert len(uii_elements) == 1
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -110,6 +110,24 @@ def test_user_can_get_to_complaint(mockdata, browser, server_port):
     assert "File a Complaint" in title_text
 
 
+def test_find_officer_can_see_uii_question_for_depts_with_uiis(
+    mockdata, browser, server_port
+):
+    browser.get(f"http://localhost:{server_port}/find")
+
+    dept_with_uii = Department.query.filter(
+        Department.unique_internal_identifier_label.isnot(None)
+    ).first()
+    dept_id = str(dept_with_uii.id)
+
+    dept_selector = Select(browser.find_element_by_id("dept"))
+    dept_selector.select_by_value(dept_id)
+    browser.find_element_by_id("activate-step-2").click()
+
+    uii_elements = browser.find_elements_by_id("#uii-question")
+    assert len(uii_elements) == 1
+
+
 def test_officer_browse_pagination(mockdata, browser, server_port):
     total = Officer.query.filter_by(department_id=AC_DEPT).count()
 
@@ -134,24 +152,6 @@ def test_officer_browse_pagination(mockdata, browser, server_port):
     )
     expected = f"Showing {start_of_page}-{total} of {total}"
     assert expected in page_text
-
-
-def test_find_officer_can_see_uii_question_for_depts_with_uiis(
-    mockdata, browser, server_port
-):
-    browser.get(f"http://localhost:{server_port}/find")
-
-    dept_with_uii = Department.query.filter(
-        Department.unique_internal_identifier_label.isnot(None)
-    ).first()
-    dept_id = str(dept_with_uii.id)
-
-    dept_selector = Select(browser.find_element_by_id("dept"))
-    dept_selector.select_by_value(dept_id)
-    browser.find_element_by_id("activate-step-2").click()
-
-    uii_elements = browser.find_elements_by_id("#uii-question")
-    assert len(uii_elements) == 1
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -142,7 +142,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
     browser.get(f"http://localhost:{server_port}/find")
 
     dept_with_uii = Department.query.filter_by(
-        id=1,
+        id=2,
     ).one()
     dept_id = str(dept_with_uii.id)
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.expression import func
 
 from OpenOversight.app.models.database import Department, Incident, Officer, Unit, db
 from OpenOversight.app.utils.constants import KEY_OFFICERS_PER_PAGE
-from OpenOversight.tests.conftest import AC_DEPT
+from OpenOversight.tests.conftest import AC_DEPT, SPRINGFIELD_PD
 from OpenOversight.tests.constants import ADMIN_USER_EMAIL
 
 
@@ -141,9 +141,9 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 ):
     browser.get(f"http://localhost:{server_port}/find")
 
-    dept_with_uii = Department.query.filter(
-        Department.unique_internal_identifier_label.isnot(None)
-    ).first()
+    dept_with_uii = Department.query.filter_by(
+        unique_internal_identifier_label=SPRINGFIELD_PD.unique_internal_identifier_label,
+    ).one()
     dept_id = str(dept_with_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -143,7 +143,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 
     dept_with_uii = Department.query.filter(
         Department.unique_internal_identifier_label.isnot(None)
-    ).all()[1]
+    ).first()
     dept_id = str(dept_with_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -143,7 +143,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 
     dept_with_uii = Department.query.filter(
         Department.unique_internal_identifier_label.isnot(None)
-    )[1]
+    ).all()[1]
     dept_id = str(dept_with_uii.id)
 
     dept_selector = Select(browser.find_element_by_id("dept"))

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -141,7 +141,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 ):
     browser.get(f"http://localhost:{server_port}/find")
 
-    dept_with_uii = Department.query.filter_by(
+    dept_with_uii = Department.query.filter(
         Department.unique_internal_identifier_label.isnot(None)
     ).first()
     dept_id = str(dept_with_uii.id)

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.expression import func
 
 from OpenOversight.app.models.database import Department, Incident, Officer, Unit, db
 from OpenOversight.app.utils.constants import KEY_OFFICERS_PER_PAGE
-from OpenOversight.tests.conftest import AC_DEPT, SPRINGFIELD_PD
+from OpenOversight.tests.conftest import AC_DEPT
 from OpenOversight.tests.constants import ADMIN_USER_EMAIL
 
 
@@ -142,7 +142,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
     browser.get(f"http://localhost:{server_port}/find")
 
     dept_with_uii = Department.query.filter_by(
-        unique_internal_identifier_label=SPRINGFIELD_PD.uid_label,
+        id=1,
     ).one()
     dept_id = str(dept_with_uii.id)
 


### PR DESCRIPTION
## Description of Changes
Added a `display_name` property to the `Department` model which adds the state to all displays of the department name and sorted all department lists by state and department name.

## Screenshots (if appropriate)
<img width="943" alt="Screenshot 2023-08-17 at 3 21 55 PM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/19639e8f-66e3-49ce-ab65-21c60053ad61">

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
