### PR TITLE
Fix migration down_revision

### DIFF
--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -724,14 +724,14 @@ class User(UserMixin, BaseModel):
     def password(self):
         raise AttributeError("password is not a readable attribute")
 
-    @property
-    def uuid(self):
-        return self._uuid
-
     @password.setter
     def password(self, password):
         self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
         self.regenerate_uuid()
+
+    @property
+    def uuid(self):
+        return self._uuid
 
     @staticmethod
     def _case_insensitive_equality(field, value):

--- a/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
+++ b/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
@@ -1,7 +1,7 @@
 """add _uuid column to users
 
 Revision ID: 52d3f6a21dd9
-Revises: b38c133bed3c
+Revises: a35aa1a114fa
 Create Date: 2023-07-24 16:19:01.375427
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "52d3f6a21dd9"
-down_revision = "b38c133bed3c"
+down_revision = "a35aa1a114fa"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Fixes issue
Fixes #1038 

## Description of Changes
Update `down_revision` since 2 migrations are using `b38c133bed3c` as their `down_revision`.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
