### PR TITLE
Address PostgreSQL error

### DIFF
--- a/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
+++ b/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
@@ -17,6 +17,8 @@ depends_on = None
 
 
 def upgrade():
+    op.execute("CREATE EXTENSION pgcrypto;")
+
     op.add_column(
         "users",
         sa.Column(
@@ -32,3 +34,4 @@ def upgrade():
 def downgrade():
     op.drop_index(op.f("ix_users__uuid"), table_name="users")
     op.drop_column("users", "_uuid")
+    op.execute("DROP EXTENSION pgcrypto;")


### PR DESCRIPTION
## Description of Changes
We are currently seeing an error in the deployment process due to the lack of the `gen_random_uuid()` function in the PostgreSQL instance.

```zsh
INFO  [alembic.runtime.migration] Running upgrade a35aa1a114fa -> 52d3f6a21dd9, add _uuid column to users
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1900, in _execute_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UndefinedFunction: function gen_random_uuid() does not exist
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
