### PR TITLE
Address missing UUIDs in pre-existing users

### DIFF
--- a/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
+++ b/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
@@ -9,6 +9,9 @@ import uuid
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.orm import Session
+
+from OpenOversight.app.models.database import User, db
 
 
 revision = "52d3f6a21dd9"
@@ -21,11 +24,17 @@ def upgrade():
         sa.Column(
             "_uuid",
             sa.String(36),
-            nullable=False,
-            server_default=lambda: str(uuid.uuid4()),
         ),
     )
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    for user in session.query(User).all():
+        user._uuid = str(uuid.uuid4())
+        session.commit()
+
     op.create_index(op.f("ix_users__uuid"), "users", ["_uuid"], unique=True)
+    op.alter_column("users", "_uuid", nullable=False)
 
 
 def downgrade():

--- a/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
+++ b/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
@@ -5,6 +5,8 @@ Revises: a35aa1a114fa
 Create Date: 2023-07-24 16:19:01.375427
 
 """
+import uuid
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -20,6 +22,7 @@ def upgrade():
             "_uuid",
             sa.String(36),
             nullable=False,
+            server_default=lambda: str(uuid.uuid4()),
         ),
     )
     op.create_index(op.f("ix_users__uuid"), "users", ["_uuid"], unique=True)

--- a/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
+++ b/OpenOversight/migrations/versions/2023-07-24-1619_52d3f6a21dd9_add__uuid_column_to_users.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.orm import Session
 
-from OpenOversight.app.models.database import User, db
+from OpenOversight.app.models.database import User
 
 
 revision = "52d3f6a21dd9"


### PR DESCRIPTION
## Description of Changes
The previous build ran into a problem where we added a middleware creation for the `_uuid` column in the `users` table, but did not deal with the problem of the rows that lacked UUIDs in the `users` table. This was dealt with through the use of a loop in the migration that adds a UUID to all pre-existing rows via Python 🐍.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
 - [x] Manually tested through the below process:

```zsh
% git checkout address_missing_uuids
% make clean_all                          
rm -rf ./OpenOversight/app/static/dist/
docker-compose stop
...
% git checkout 872a01ab  # Checks out a previous version of the branch before we merged in the UUIDs
...
HEAD is now at 872a01ab Remove `HiddenField`s and add `created_by` to `LicensePlate` and `Location` (#1034)
% make start    
docker-compose build
...
% make dev # Create tables and the application at the point in time for the above commit
... # Verify that all tables and data are in place, etc.
% git checkout address_missing_uuids      
Previous HEAD position was 872a01ab Remove `HiddenField`s and add `created_by` to `LicensePlate` and `Location` (#1034)
Switched to branch 'address_missing_uuids'
Your branch is up to date with 'origin/address_missing_uuids'.
% (env) michaelp@MacBook-Air-5 OpenOversight % make start
docker-compose build
...
docker-compose up -d
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
[+] Running 2/0
 ✔ Container openoversight-postgres-1  Running                                                                                                                                                             0.0s 
 ✔ Container openoversight-web-1       Running                                                                                                                                                             0.0s 
% docker exec -it openoversight-web-1 bash
I have no name!@0e2d34544358:/usr/src/app$ flask db upgrade
...
INFO  [alembic.runtime.migration] Running upgrade b38c133bed3c -> a35aa1a114fa, Add create and last_update columns
INFO  [alembic.runtime.migration] Running upgrade a35aa1a114fa -> 52d3f6a21dd9, add _uuid column to users
I have no name!@0e2d34544358:/usr/src/app$ exit
%
```
