### PR TITLE
Move flake8 configs to pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,2 @@
 [flake8]
-ignore = E501,W503,W504
 exclude = ./OpenOversight/app/db_repository/versions/

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-exclude = ./OpenOversight/app/db_repository/versions/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,8 +81,9 @@ repos:
     hooks:
         - id: flake8
           args:
-            - --ignore=E203,E402,E501,E800,W503,W391,E261
+            - --ignore=E203,E402,E501,E800,W503,W391,E261,W504
             - --select=B,C,E,F,W,T4,B9
+            - --exclude=./OpenOversight/app/db_repository/versions/
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -48,7 +48,6 @@ COPY package.json /usr/src/app/
 RUN yarn
 
 COPY test_data.py /usr/src/app/
-COPY .flake8 /usr/src/app/
 COPY mypy.ini /usr/src/app/
 EXPOSE 3000
 


### PR DESCRIPTION
## Description of Changes
Moved configurations from `.flake8` file to `.pre-commit-config.yaml` and deleted `.flake8`.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
