### PR TITLE
Add image carousel for officers with multiple images

### DIFF
--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -554,7 +554,12 @@ class Location(BaseModel, TrackUpdates):
         return state_validator(state)
 
     def __repr__(self):
-        if self.street_name and self.cross_street2:
+        if self.street_name and self.cross_street1 and self.cross_street2:
+            return (
+                f"Intersection of {self.street_name} between {self.cross_street1} "
+                f"and {self.cross_street2}, {self.city} {self.state}"
+            )
+        elif self.street_name and self.cross_street2:
             return (
                 f"Intersection of {self.street_name} and {self.cross_street2}, "
                 + f"{self.city} {self.state}"
@@ -563,11 +568,6 @@ class Location(BaseModel, TrackUpdates):
             return (
                 f"Intersection of {self.street_name} and {self.cross_street1}, "
                 + f"{self.city} {self.state}"
-            )
-        elif self.street_name and self.cross_street1 and self.cross_street2:
-            return (
-                f"Intersection of {self.street_name} between {self.cross_street1} "
-                f"and {self.cross_street2}, {self.city} {self.state}"
             )
         else:
             return f"{self.city} {self.state}"

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -584,6 +584,10 @@ tr:hover .row-actions {
     bottom: 10px;
 }
 
+#face-carousel {
+    min-height: 300px;
+}
+
 .officer-face {
     border: none;
     height: 300px;
@@ -594,20 +598,38 @@ tr:hover .row-actions {
     display: block;
 }
 
+#face-carousel .item {
+    margin-top: 0;
+}
+
+#face-carousel .carousel-control {
+    background-image: none;
+    color: black;
+}
+
 @media (min-width: 992px) {
-    .officer-face.officer-profile {
+    #face-carousel {
+        max-height: 485px;
+    }
+    .item .officer-face.officer-profile {
         height: 510px;
     }
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
-    .officer-face.officer-profile {
+    #face-carousel {
+        max-height: 565px;
+    }
+    .item .officer-face.officer-profile {
         height: 590px;
     }
 }
 
 @media (max-width: 767px) {
-    .officer-face.officer-profile {
+    #face-carousel {
+        max-height: 435px;
+    }
+    .item .officer-face.officer-profile {
         height: 460px;
         padding-bottom: 10px;
     }

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -616,12 +616,14 @@ tr:hover .row-actions {
 @media (min-width: 992px) {
     .item .officer-face.officer-profile {
         height: 490px;
+        width: auto;
     }
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
     .item .officer-face.officer-profile {
         height: 590px;
+        width: auto;
     }
 }
 
@@ -629,6 +631,7 @@ tr:hover .row-actions {
     .item .officer-face.officer-profile {
         height: 460px;
         padding-bottom: 10px;
+        width: auto;
     }
 }
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -600,6 +600,12 @@ tr:hover .row-actions {
 
 #face-carousel .item {
     margin-top: 0;
+    min-height: 0;
+}
+
+#face-carousel {
+    margin-bottom: 0;
+    min-height: 100%;
 }
 
 #face-carousel .carousel-control {
@@ -608,27 +614,18 @@ tr:hover .row-actions {
 }
 
 @media (min-width: 992px) {
-    #face-carousel {
-        max-height: 485px;
-    }
     .item .officer-face.officer-profile {
-        height: 510px;
+        height: 490px;
     }
 }
 
 @media (min-width: 768px) and (max-width: 991px) {
-    #face-carousel {
-        max-height: 565px;
-    }
     .item .officer-face.officer-profile {
         height: 590px;
     }
 }
 
 @media (max-width: 767px) {
-    #face-carousel {
-        max-height: 435px;
-    }
     .item .officer-face.officer-profile {
         height: 460px;
         padding-bottom: 10px;

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -6,11 +6,15 @@
     {% for path in paths %}
       <div class="item{{ ' active' if loop.index == 1 else '' }}">
         {# Don't try to link if only image is the placeholder #}
-        {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
-          <img class="officer-face officer-profile"
-               src="{{ path }}"
-               alt="Submission">
-          {% if faces %}</a>{% endif %}
+        <div class="row text-center">
+          <div class="col-12">
+            {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
+              <img class="officer-face officer-profile"
+                   src="{{ path }}"
+                   alt="Submission">
+              {% if faces %}</a>{% endif %}
+          </div>
+        </div>
       </div>
     {% endfor %}
   </div>

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -1,8 +1,33 @@
-{% for path in paths %}
-  {# Don't try to link if only image is the placeholder #}
-  {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
-    <img class="officer-face officer-profile"
-         src="{{ path }}"
-         alt="Submission">
-    {% if faces %}</a>{% endif %}
-{% endfor %}
+<div id="face-carousel"
+     class="carousel slide"
+     data-interval="false"
+     data-ride="carousel">
+  <div class="carousel-inner">
+    {% for path in paths %}
+      <div class="item{{ ' active' if loop.index == 1 else '' }}">
+        {# Don't try to link if only image is the placeholder #}
+        {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
+          <img class="officer-face officer-profile"
+               src="{{ path }}"
+               alt="Submission">
+          {% if faces %}</a>{% endif %}
+      </div>
+    {% endfor %}
+  </div>
+  {% if paths | length > 1 %}
+    <a class="left carousel-control"
+       href="#face-carousel"
+       role="button"
+       data-slide="prev">
+      <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+      <span class="sr-only">Previous</span>
+    </a>
+    <a class="right carousel-control"
+       href="#face-carousel"
+       role="button"
+       data-slide="next">
+      <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+      <span class="sr-only">Next</span>
+    </a>
+  {% endif %}
+</div>

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -1,5 +1,6 @@
 import base64
 import datetime
+import random
 import time
 from email.mime.text import MIMEText
 
@@ -25,6 +26,7 @@ from OpenOversight.app.models.database import (
     db,
 )
 from OpenOversight.app.models.emails import Email
+from OpenOversight.app.utils.choices import STATE_CHOICES
 from OpenOversight.app.utils.constants import FILE_TYPE_HTML, KEY_OO_SERVICE_EMAIL
 from OpenOversight.tests.conftest import SPRINGFIELD_PD
 
@@ -142,6 +144,15 @@ def test_officer_repr(session):
         f"{officer_no_mi.last_name} {officer_no_mi.suffix} "
         f"({officer_no_mi.unique_internal_identifier})>"
     )
+
+
+def test_officer_race_label(faker):
+    officer = Officer(
+        first_name=faker.first_name(),
+        last_name=faker.last_name(),
+    )
+
+    assert officer.race_label() == "Data Missing"
 
 
 def test_assignment_repr(mockdata):
@@ -380,6 +391,64 @@ def test_locations_must_have_valid_zip_codes(mockdata):
             state="MA",
             zip_code="543",
         )
+
+
+def test_location_repr(faker):
+    street_name = faker.street_address()
+    cross_street_one = faker.street_name()
+    cross_street_two = faker.street_name()
+    state = random.choice(STATE_CHOICES)[0]
+    city = faker.city()
+    zip_code = faker.postcode()
+
+    no_cross_streets = Location(
+        street_name=street_name,
+        state=state,
+        city=city,
+        zip_code=zip_code,
+    )
+
+    assert repr(no_cross_streets) == f"{city} {state}"
+
+    cross_street1 = Location(
+        street_name=street_name,
+        cross_street1=cross_street_one,
+        state=state,
+        city=city,
+        zip_code=zip_code,
+    )
+
+    assert (
+        repr(cross_street1)
+        == f"Intersection of {street_name} and {cross_street_one}, {city} {state}"
+    )
+
+    cross_street2 = Location(
+        street_name=street_name,
+        cross_street2=cross_street_two,
+        state=state,
+        city=city,
+        zip_code=zip_code,
+    )
+
+    assert (
+        repr(cross_street2)
+        == f"Intersection of {street_name} and {cross_street_two}, {city} {state}"
+    )
+
+    both_cross_streets = Location(
+        street_name=street_name,
+        cross_street1=cross_street_one,
+        cross_street2=cross_street_two,
+        state=state,
+        city=city,
+        zip_code=zip_code,
+    )
+
+    assert repr(both_cross_streets) == (
+        f"Intersection of {street_name} between {cross_street_one} and "
+        f"{cross_street_two}, {city} {state}"
+    )
 
 
 def test_locations_can_be_saved_with_valid_zip_codes(mockdata):


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/1045

## Description of Changes
Added image carousel for officers with multiple images and additional test coverage.

## Screenshots (if appropriate)
Multiple images:
<img width="1251" alt="Screenshot 2023-08-27 at 1 27 07 AM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/e7858594-557d-4e8f-9c08-bb92c854ec8a">

Single image:
<img width="1253" alt="Screenshot 2023-08-27 at 1 27 37 AM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/f46a19aa-326a-4e13-9561-d22b345ee2aa">

No images:
<img width="1251" alt="Screenshot 2023-08-27 at 1 27 58 AM" src="https://github.com/lucyparsons/OpenOversight/assets/5885605/b3f3c37a-7542-422d-9e54-b788e01dec4a">

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
