### PR TITLE
Fix officer creation with notes and descriptions

### DIFF
--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -67,6 +67,8 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
         birth_year=form.birth_year.data,
         employment_date=form.employment_date.data,
         department_id=form.department.data.id,
+        created_by=current_user.id,
+        last_updated_by=current_user.id,
     )
     db.session.add(officer)
     db.session.commit()
@@ -79,6 +81,8 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
         job_id=form.job_id.data,
         unit=officer_unit,
         start_date=form.employment_date.data,
+        created_by=current_user.id,
+        last_updated_by=current_user.id,
     )
     db.session.add(assignment)
     if form.links.data:
@@ -92,8 +96,9 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
             if note["text_contents"]:
                 new_note = Note(
                     text_contents=note["text_contents"],
-                    created_by=current_user.id,
                     officer=officer,
+                    created_by=current_user.id,
+                    last_updated_by=current_user.id,
                 )
                 db.session.add(new_note)
     if form.descriptions.data:
@@ -102,8 +107,9 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
             if description["text_contents"]:
                 new_description = Description(
                     text_contents=description["text_contents"],
-                    created_by=current_user.id,
                     officer=officer,
+                    created_by=current_user.id,
+                    last_updated_by=current_user.id,
                 )
                 db.session.add(new_description)
     if form.salaries.data:
@@ -116,6 +122,8 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
                     overtime_pay=salary["overtime_pay"],
                     year=salary["year"],
                     is_fiscal_year=salary["is_fiscal_year"],
+                    created_by=current_user.id,
+                    last_updated_by=current_user.id,
                 )
                 db.session.add(new_salary)
 

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -91,8 +91,8 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
             # don't try to create with a blank string
             if note["text_contents"]:
                 new_note = Note(
-                    note=note["text_contents"],
-                    user_id=current_user.get_id(),
+                    text_contents=note["text_contents"],
+                    created_by=current_user.id,
                     officer=officer,
                 )
                 db.session.add(new_note)
@@ -101,8 +101,8 @@ def add_officer_profile(form: AddOfficerForm, current_user: User) -> Officer:
             # don't try to create with a blank string
             if description["text_contents"]:
                 new_description = Description(
-                    description=description["text_contents"],
-                    user_id=current_user.get_id(),
+                    text_contents=description["text_contents"],
+                    created_by=current_user.id,
                     officer=officer,
                 )
                 db.session.add(new_description)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1166,7 +1166,7 @@ def test_expected_dept_appears_in_submission_dept_selection(mockdata, client, se
 
 def test_admin_can_add_new_officer(mockdata, client, session, department, faker):
     with current_app.test_request_context():
-        login_admin(client)
+        rv, admin = login_admin(client)
 
         links = [
             LinkForm(url=faker.url(), link_type="link").data,
@@ -1184,6 +1184,8 @@ def test_admin_can_add_new_officer(mockdata, client, session, department, faker)
             department=department.id,
             birth_year=1990,
             links=links,
+            notes=[{"text_contents": "note"}],
+            descriptions=[{"text_contents": "description"}],
         )
 
         data = process_form_data(form.data)
@@ -1197,6 +1199,14 @@ def test_admin_can_add_new_officer(mockdata, client, session, department, faker)
         assert officer.first_name == "Test"
         assert officer.race == "WHITE"
         assert officer.gender == "M"
+
+        assert len(officer.notes) == 1
+        assert officer.notes[0].text_contents == "note"
+        assert officer.notes[0].created_by == admin.id
+
+        assert len(officer.descriptions) == 1
+        assert officer.descriptions[0].text_contents == "description"
+        assert officer.descriptions[0].created_by == admin.id
 
 
 def test_admin_can_add_new_officer_with_unit(

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -4,6 +4,7 @@ import json
 import random
 import re
 from datetime import date, datetime
+from decimal import Decimal
 from http import HTTPStatus
 from io import BytesIO
 
@@ -1166,7 +1167,7 @@ def test_expected_dept_appears_in_submission_dept_selection(mockdata, client, se
 
 def test_admin_can_add_new_officer(mockdata, client, session, department, faker):
     with current_app.test_request_context():
-        rv, admin = login_admin(client)
+        _, admin = login_admin(client)
 
         links = [
             LinkForm(url=faker.url(), link_type="link").data,
@@ -1186,6 +1187,7 @@ def test_admin_can_add_new_officer(mockdata, client, session, department, faker)
             links=links,
             notes=[{"text_contents": "note"}],
             descriptions=[{"text_contents": "description"}],
+            salaries=[{"salary": "123.45", "overtime_pay": "543.21"}],
         )
 
         data = process_form_data(form.data)
@@ -1199,14 +1201,29 @@ def test_admin_can_add_new_officer(mockdata, client, session, department, faker)
         assert officer.first_name == "Test"
         assert officer.race == "WHITE"
         assert officer.gender == "M"
+        assert officer.created_by == admin.id
+        assert officer.last_updated_by == admin.id
+
+        assert len(officer.assignments) == 1
+        assert officer.assignments[0].star_no == "666"
+        assert officer.assignments[0].created_by == admin.id
+        assert officer.assignments[0].last_updated_by == admin.id
 
         assert len(officer.notes) == 1
         assert officer.notes[0].text_contents == "note"
         assert officer.notes[0].created_by == admin.id
+        assert officer.notes[0].last_updated_by == admin.id
 
         assert len(officer.descriptions) == 1
         assert officer.descriptions[0].text_contents == "description"
         assert officer.descriptions[0].created_by == admin.id
+        assert officer.descriptions[0].last_updated_by == admin.id
+
+        assert len(officer.salaries) == 1
+        assert officer.salaries[0].salary == Decimal("123.45")
+        assert officer.salaries[0].overtime_pay == Decimal("543.21")
+        assert officer.salaries[0].created_by == admin.id
+        assert officer.descriptions[0].last_updated_by == admin.id
 
 
 def test_admin_can_add_new_officer_with_unit(


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commits are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md

If this pull request is not ready for review yet, please submit it as a draft.
-->
## Fixes issue
Fixes #1052 

## Description of Changes
Creating an officer with notes and descriptions was failing since it was using the wrong constructor parameter to create Notes and Descriptions (`note` and `description` instead of `text_contents`). This change fixes this bug.

```
web_1       | 192.168.48.1 - - [05/Sep/2023 07:19:08] "POST /officers/new HTTP/1.1" 500 -                                                                                      [3/9884]
web_1       | Traceback (most recent call last):                                                                                                                                       
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 2213, in __call__                                                                                    
web_1       |     return self.wsgi_app(environ, start_response)                                                                                                                        
web_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                        
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 2193, in wsgi_app                                                                                    
web_1       |     response = self.handle_exception(e)                                                                                                                                  
web_1       |                ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                  
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 2190, in wsgi_app                                                                                    
web_1       |     response = self.full_dispatch_request()                                                                                                                              
web_1       |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1486, in full_dispatch_request                                                                       
web_1       |     rv = self.handle_user_exception(e)                                                                                                                                   
web_1       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                   
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1484, in full_dispatch_request                                                                       
web_1       |     rv = self.dispatch_request()                                                                                                                                         
web_1       |          ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                         
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1469, in dispatch_request                                                                            
web_1       |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)                                                                                             
web_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
web_1       |   File "/usr/local/lib/python3.11/site-packages/flask_login/utils.py", line 290, in decorated_view                                                                       
web_1       |     return current_app.ensure_sync(func)(*args, **kwargs)                                                                                                                
web_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
web_1       |   File "/usr/src/app/OpenOversight/app/utils/auth.py", line 27, in decorated_function                                                                                    
web_1       |     return f(*args, **kwargs)                                                                                                                                            
web_1       |            ^^^^^^^^^^^^^^^^^^
web_1       |   File "/usr/src/app/OpenOversight/app/main/views.py", line 1165, in add_officer
web_1       |     officer = add_officer_profile(form, current_user)
web_1       |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
web_1       |   File "/usr/src/app/OpenOversight/app/utils/forms.py", line 93, in add_officer_profile
web_1       |     new_note = Note(
web_1       |                ^^^^^
web_1       |   File "<string>", line 4, in __init__
web_1       |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/state.py", line 481, in _initialize_instance
web_1       |     with util.safe_reraise():
web_1       |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
web_1       |     compat.raise_(
web_1       |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
web_1       |     raise exception
web_1       |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/state.py", line 479, in _initialize_instance
web_1       |     return manager.original_init(*mixed[1:], **kwargs)
web_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
web_1       |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/decl_base.py", line 1197, in _declarative_constructor
web_1       |     raise TypeError(
web_1       | TypeError: 'note' is an invalid keyword argument for Note
```

## Notes for Deployment
None!

## Screenshots (if appropriate)


## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
