### PR TITLE
Fix production deployments

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -74,6 +74,6 @@ jobs:
       - name: backup db
         run: invoke backup ${{ env.env_name }}
       - name: deploy
-        run: invoke deploy ${{ env.env_name }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }}
+        run: invoke deploy ${{ env.env_name }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }} ${{ github.ref_name }}
       - name: cleanup
         run: invoke cleanup ${{ env.env_name }}


### PR DESCRIPTION
## Fixes issue
Prod deploy failed.

## Description of Changes
Pushing into the main branch is now longer required for production deployments, but the task.py script was hard-coded to fetch the (out of date) main branch.
After this change, the script will now fetch the given git ref, in the prod deploy case this is the tag used in the release.

## Notes for Deployment
Tested task.py script locally

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
