### PR TITLE
Invalidate session on email/pw update

### DIFF
--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -175,7 +175,7 @@ def change_password():
             current_user.password = form.password.data
             db.session.add(current_user)
             db.session.commit()
-            flash("Your password has been updated.")
+            flash("Your password has been updated. Please log in again.")
             EmailClient.send_email(
                 ChangePasswordEmail(current_user.email, user=current_user)
             )
@@ -216,7 +216,7 @@ def password_reset(token):
         if user is None:
             return redirect(url_for("main.index"))
         if user.reset_password(token, form.password.data):
-            flash("Your password has been updated.")
+            flash("Your password has been updated. Please log in again.")
             return redirect(url_for("auth.login"))
         else:
             return redirect(url_for("main.index"))
@@ -252,7 +252,7 @@ def change_email_request():
 @login_required
 def change_email(token):
     if current_user.change_email(token):
-        flash("Your email address has been updated.")
+        flash("Your email address has been updated. Please log in again.")
     else:
         flash("Invalid request.")
     return redirect(url_for("main.index"))

--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -80,9 +80,9 @@ class ModelView(MethodView):
         if form.validate_on_submit():
             new_obj = self.create_function(form, current_user)
             if hasattr(new_obj, "created_by"):
-                new_obj.created_by = current_user.get_id()
+                new_obj.created_by = current_user.id
             if hasattr(new_obj, "last_updated_by"):
-                new_obj.last_updated_by = current_user.get_id()
+                new_obj.last_updated_by = current_user.id
             db.session.add(new_obj)
             db.session.commit()
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -291,7 +291,7 @@ def profile(username: str):
     else:
         abort(HTTPStatus.NOT_FOUND)
     try:
-        pref = User.query.filter_by(id=current_user.get_id()).one().dept_pref
+        pref = User.query.filter_by(id=current_user.id).one().dept_pref
         department = Department.query.filter_by(id=pref).one().name
     except NoResultFound:
         department = None
@@ -1527,10 +1527,8 @@ def submit_data():
     preferred_dept_id = Department.query.first().id
     # try to use preferred department if available
     try:
-        if User.query.filter_by(id=current_user.get_id()).one().dept_pref:
-            preferred_dept_id = (
-                User.query.filter_by(id=current_user.get_id()).one().dept_pref
-            )
+        if User.query.filter_by(id=current_user.id).one().dept_pref:
+            preferred_dept_id = User.query.filter_by(id=current_user.id).one().dept_pref
             form = AddImageForm()
         else:
             form = AddImageForm()
@@ -1888,7 +1886,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
 
     try:
         image = save_image_to_s3_and_db(
-            file_to_upload, current_user.get_id(), department_id=department_id
+            file_to_upload, current_user.id, department_id=department_id
         )
     except ValueError:
         # Raised if MIME type not allowed

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -811,6 +811,10 @@ class User(UserMixin, BaseModel):
     def regenerate_uuid(self):
         self._uuid = str(uuid.uuid4())
 
+    def get_id(self):
+        """Get the Flask-Login user identifier, NOT THE DATABASE ID."""
+        return str(self.uuid)
+
     @property
     def is_active(self):
         """Override UserMixin.is_active to prevent disabled users from logging in."""

--- a/OpenOversight/app/models/database_imports.py
+++ b/OpenOversight/app/models/database_imports.py
@@ -348,5 +348,8 @@ def update_incident_from_dict(data: Dict[str, Any], incident: Incident) -> Incid
 
 
 @login_manager.user_loader
-def load_user(user_id):
-    return User.query.get(int(user_id))
+def load_user(token):
+    # Identify user using alternative token so their sessions are
+    # automatically invalidated when they update their email or password.
+    # https://flask-login.readthedocs.io/en/latest/#alternative-tokens
+    return User.query.filter_by(_uuid=token).one_or_none()

--- a/OpenOversight/app/templates/partials/officer_descriptions.html
+++ b/OpenOversight/app/templates/partials/officer_descriptions.html
@@ -7,7 +7,7 @@
         <br />
         {{ description.text_contents | markdown }}
         {% if current_user and not current_user.is_anonymous %}<em>{{ description.creator.username }}</em>{% endif %}
-        {% if description.created_by == current_user.get_id() or
+        {% if description.created_by == current_user.id or
           current_user.is_administrator %}
           <a href="{{ url_for('main.description_api', officer_id=officer.id, obj_id=description.id) + '/edit' }}">
             <span class="sr-only">Edit</span>

--- a/OpenOversight/app/templates/partials/officer_notes.html
+++ b/OpenOversight/app/templates/partials/officer_notes.html
@@ -6,7 +6,7 @@
       <br />
       {{ note.text_contents | markdown }}
       <em>{{ note.creator.username }}</em>
-      {% if note.created_by == current_user.get_id() or current_user.is_administrator %}
+      {% if note.created_by == current_user.id or current_user.is_administrator %}
         <a href="{{ url_for('main.note_api', officer_id=officer.id, obj_id=note.id) + '/edit' }}">
           <span class="sr-only">Edit</span>
           <i class="fa fa-pencil-square-o" aria-hidden="true"></i>

--- a/OpenOversight/app/templates/submit_image.html
+++ b/OpenOversight/app/templates/submit_image.html
@@ -25,7 +25,7 @@
       <p>
         The next step after a photograph of an officer has been submitted is to match it to the correct badge number, name, and OpenOversight ID (a unique identifier in our system). Volunteers <a href="https://openoversight.com/label">sort through submitted images</a> by first confirming that officers are present in each photograph, and then by matching each photograph to the officer it depicts.
       </p>
-      {% if not current_user.get_id() %}
+      {% if not current_user.id %}
         <p>
           Please consider creating an account and logging in so that we can keep track of the images you've submitted and contact you with any questions.
         </p>

--- a/OpenOversight/app/utils/cloud.py
+++ b/OpenOversight/app/utils/cloud.py
@@ -59,9 +59,7 @@ def crop_image(image, crop_data=None, department_id=None):
     cropped_image_buf = BytesIO()
     pimage.save(cropped_image_buf, "jpeg", quality=95, optimize=True, progressive=True)
 
-    return save_image_to_s3_and_db(
-        cropped_image_buf, current_user.get_id(), department_id
-    )
+    return save_image_to_s3_and_db(cropped_image_buf, current_user.id, department_id)
 
 
 # 36867 in the exif tags holds the date and the original image was taken

--- a/OpenOversight/tests/routes/test_auth.py
+++ b/OpenOversight/tests/routes/test_auth.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from urllib.parse import urlparse
 
 import pytest
-from flask import current_app, g, url_for
+from flask import current_app, url_for
 from flask_login import current_user
 
 from OpenOversight.app.auth.forms import (

--- a/OpenOversight/tests/routes/test_auth.py
+++ b/OpenOversight/tests/routes/test_auth.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from urllib.parse import urlparse
 
 import pytest
-from flask import current_app, url_for
+from flask import current_app, g, url_for
 from flask_login import current_user
 
 from OpenOversight.app.auth.forms import (
@@ -512,27 +512,51 @@ def test_user_can_change_dept_pref(mockdata, client, session):
         assert user.dept_pref == AC_DEPT
 
 
-def test_user_email_update_resets_session_token(mockdata, client, session, faker):
-    with current_app.test_request_context():
+def test_user_email_update_resets_session_token(mockdata, app, session, faker):
+    client = current_app.test_client()
+
+    with current_app.app_context(), current_app.test_request_context():
         _, user = login_user(client)
         original_uuid = user.uuid
+
+        # While logged in, user can access leaderboard
+        rv = client.get(url_for("main.leaderboard"), follow_redirects=False)
+        assert rv.status_code == HTTPStatus.OK
 
         token = user.generate_email_change_token(faker.ascii_email())
         client.get(url_for("auth.change_email", token=token), follow_redirects=True)
-
         assert original_uuid != current_user.uuid
 
+    # User is stored in `g` which lasts for the duration of the appcontext,
+    # which is typically the lifespan of a request. Splitting this into a
+    # separate context so the user will be reloaded properly
+    with current_app.app_context(), current_app.test_request_context():
+        # When session is invalidated, user is redirected to login page
+        rv = client.get(url_for("main.leaderboard"), follow_redirects=False)
+        assert rv.status_code == HTTPStatus.FOUND
 
-def test_user_password_update_resets_session_token(mockdata, client, session):
-    with current_app.test_request_context():
+
+def test_user_password_update_resets_session_token(mockdata, app, session):
+    client = current_app.test_client()
+
+    with current_app.app_context(), current_app.test_request_context():
         _, user = login_user(client)
         original_uuid = user.uuid
 
+        # While logged in, user can access leaderboard
+        rv = client.get(url_for("main.leaderboard"), follow_redirects=False)
+        assert rv.status_code == HTTPStatus.OK
+
+        # Update user's password
         form = ChangePasswordForm(
             old_password="dog", password="validpasswd", password2="validpasswd"
         )
         client.post(
             url_for("auth.change_password"), data=form.data, follow_redirects=True
         )
-
         assert original_uuid != current_user.uuid
+
+    with current_app.app_context(), current_app.test_request_context():
+        # When session is invalidated, user is redirected to login page
+        rv = client.get(url_for("main.leaderboard"), follow_redirects=False)
+        assert rv.status_code == HTTPStatus.FOUND

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -295,7 +295,7 @@ def test_crop_image_calls_save_image_to_s3_and_db_with_user_id(mockdata, client)
         ) as save_image_to_s3_and_db:
             crop_image(image, None, department.id)
 
-            assert current_user.get_id() in save_image_to_s3_and_db.call_args[0]
+            assert current_user.id in save_image_to_s3_and_db.call_args[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commits are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md

If this pull request is not ready for review yet, please submit it as a draft.
-->
## Fixes issue
Fixes #1067 

## Description of Changes
This invalidates all of a user's sessions when their email or password is updated. This builds upon changes made in https://github.com/lucyparsons/OpenOversight/commit/0912f9071742c1269fe16b8228c2d2b4cded6b6e.

See the Flask-Login documentation for an explanation of how this works:
https://flask-login.readthedocs.io/en/latest/#alternative-tokens

## Notes for Deployment
None!

## Screenshots (if appropriate)


## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
