### PR TITLE
Make url_for work with all endpoints 

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -17,6 +17,7 @@ from OpenOversight.app.email_client import EmailClient
 from OpenOversight.app.filters import instantiate_filters
 from OpenOversight.app.models.config import config
 from OpenOversight.app.models.database import db
+from OpenOversight.app.models.users import AnonymousUser
 from OpenOversight.app.utils.constants import MEGABYTE
 
 
@@ -25,6 +26,7 @@ compress = Compress()
 
 login_manager = LoginManager()
 login_manager.session_protection = "strong"
+login_manager.anonymous_user = AnonymousUser
 login_manager.login_view = "auth.login"
 
 limiter = Limiter(
@@ -138,6 +140,8 @@ def create_app(config_name="default"):
     app.cli.add_command(add_department)
     app.cli.add_command(add_job_title)
     app.cli.add_command(advanced_csv_import)
+
+    # locale.setlocale(locale.LC_ALL, '')
 
     return app
 

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -141,8 +141,6 @@ def create_app(config_name="default"):
     app.cli.add_command(add_job_title)
     app.cli.add_command(advanced_csv_import)
 
-    # locale.setlocale(locale.LC_ALL, '')
-
     return app
 
 

--- a/OpenOversight/app/filters.py
+++ b/OpenOversight/app/filters.py
@@ -92,6 +92,10 @@ def thousands_separator(value: int) -> str:
     return f"{value:,}"
 
 
+def display_currency(value: float) -> str:
+    return f"${value:,.2f}"
+
+
 def instantiate_filters(app: Flask):
     """Instantiate all template filters"""
     app.template_filter("capfirst")(capfirst_filter)
@@ -104,3 +108,4 @@ def instantiate_filters(app: Flask):
     app.template_filter("display_time")(display_time)
     app.template_filter("local_time")(local_time)
     app.template_filter("thousands_separator")(thousands_separator)
+    app.template_filter("display_currency")(display_currency)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -2115,7 +2115,7 @@ main.add_url_rule(
 @sitemap.register_generator
 def sitemap_incidents():
     for incident in Incident.query.all():
-        yield "main.incident_api_get", {"obj_id": incident.id}
+        yield "main.incident_api", {"obj_id": incident.id}
 
 
 class TextApi(ModelView):
@@ -2193,7 +2193,7 @@ def redirect_get_notes(officer_id: int, obj_id=None):
 def redirect_edit_note(officer_id: int, obj_id=None):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        url_for("main.note_api", officer_id=officer_id, obj_id=obj_id),
+        url_for("main.note_api_edit", officer_id=officer_id, obj_id=obj_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -332,12 +332,10 @@ def officer_profile(officer_id: int):
             .all()
         )
         assignments = Assignment.query.filter_by(officer_id=officer_id).all()
-        face_paths = []
-        for face in faces:
-            face_paths.append(serve_image(face.image.filepath))
+        face_paths = [(face, serve_image(face.image.filepath)) for face in faces]
         if not face_paths:
             # Add in the placeholder image if no faces are found
-            face_paths = [url_for("static", filename="images/placeholder.png")]
+            face_paths = [(None, url_for("static", filename="images/placeholder.png"))]
     except:  # noqa: E722
         exception_type, value, full_traceback = sys.exc_info()
         error_str = " ".join([str(exception_type), str(value), format_exc()])
@@ -355,8 +353,7 @@ def officer_profile(officer_id: int):
     return render_template(
         "officer.html",
         officer=officer,
-        paths=face_paths,
-        faces=faces,
+        face_paths=face_paths,
         assignments=assignments,
         form=form,
     )
@@ -2214,7 +2211,7 @@ def redirect_delete_note(officer_id: int, obj_id=None):
 note_view = NoteApi.as_view("note_api")
 main.add_url_rule(
     "/officers/<int:officer_id>/notes/new",
-    endpoint="note_api_new",
+    endpoint="note_api",
     view_func=note_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2332,6 +2329,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/descriptions/<int:obj_id>/delete",
+    endpoint="description_api_delete",
     view_func=description_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -2085,24 +2085,31 @@ incident_view = IncidentApi.as_view("incident_api")
 main.add_url_rule(
     "/incidents/",
     defaults={"obj_id": None},
+    endpoint="incident_api",
     view_func=incident_view,
     methods=[HTTPMethod.GET],
 )
 main.add_url_rule(
     "/incidents/new",
+    endpoint="incident_api_new",
     view_func=incident_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
 main.add_url_rule(
-    "/incidents/<int:obj_id>", view_func=incident_view, methods=[HTTPMethod.GET]
+    "/incidents/<int:obj_id>",
+    endpoint="incident_api",
+    view_func=incident_view,
+    methods=[HTTPMethod.GET],
 )
 main.add_url_rule(
     "/incidents/<int:obj_id>/edit",
+    endpoint="incident_api_edit",
     view_func=incident_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
 main.add_url_rule(
     "/incidents/<int:obj_id>/delete",
+    endpoint="incident_api_delete",
     view_func=incident_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2111,7 +2118,7 @@ main.add_url_rule(
 @sitemap.register_generator
 def sitemap_incidents():
     for incident in Incident.query.all():
-        yield "main.incident_api", {"obj_id": incident.id}
+        yield "main.incident_api_get", {"obj_id": incident.id}
 
 
 class TextApi(ModelView):
@@ -2189,7 +2196,7 @@ def redirect_get_notes(officer_id: int, obj_id=None):
 def redirect_edit_note(officer_id: int, obj_id=None):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        f"{url_for('main.note_api', officer_id=officer_id, obj_id=obj_id)}/edit",
+        url_for("main.note_api", officer_id=officer_id, obj_id=obj_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -2199,7 +2206,7 @@ def redirect_edit_note(officer_id: int, obj_id=None):
 def redirect_delete_note(officer_id: int, obj_id=None):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        f"{url_for('main.note_api', officer_id=officer_id, obj_id=obj_id)}/delete",
+        url_for("main.note_api_delete", officer_id=officer_id, obj_id=obj_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -2207,6 +2214,7 @@ def redirect_delete_note(officer_id: int, obj_id=None):
 note_view = NoteApi.as_view("note_api")
 main.add_url_rule(
     "/officers/<int:officer_id>/notes/new",
+    endpoint="note_api_new",
     view_func=note_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2217,6 +2225,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/notes/<int:obj_id>",
+    endpoint="note_api",
     view_func=note_view,
     methods=[HTTPMethod.GET],
 )
@@ -2227,6 +2236,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/notes/<int:obj_id>/edit",
+    endpoint="note_api_edit",
     view_func=note_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2237,6 +2247,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/notes/<int:obj_id>/delete",
+    endpoint="note_api_delete",
     view_func=note_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2252,7 +2263,7 @@ main.add_url_rule(
 def redirect_new_description(officer_id: int):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        url_for("main.description_api", officer_id=officer_id),
+        url_for("main.description_api_new", officer_id=officer_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -2270,7 +2281,7 @@ def redirect_get_description(officer_id: int, obj_id=None):
 def redirect_edit_description(officer_id: int, obj_id=None):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        f"{url_for('main.description_api', officer_id=officer_id, obj_id=obj_id)}/edit",
+        url_for("main.description_api_edit", officer_id=officer_id, obj_id=obj_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -2280,7 +2291,7 @@ def redirect_edit_description(officer_id: int, obj_id=None):
 def redirect_delete_description(officer_id: int, obj_id=None):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        f"{url_for('main.description_api', officer_id=officer_id, obj_id=obj_id)}/delete",
+        url_for("main.description_api_delete", officer_id=officer_id, obj_id=obj_id),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -2288,6 +2299,7 @@ def redirect_delete_description(officer_id: int, obj_id=None):
 description_view = DescriptionApi.as_view("description_api")
 main.add_url_rule(
     "/officers/<int:officer_id>/descriptions/new",
+    endpoint="description_api_new",
     view_func=description_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
@@ -2298,6 +2310,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/descriptions/<int:obj_id>",
+    endpoint="description_api",
     view_func=description_view,
     methods=[HTTPMethod.GET],
 )
@@ -2308,6 +2321,7 @@ main.add_url_rule(
 )
 main.add_url_rule(
     "/officers/<int:officer_id>/descriptions/<int:obj_id>/edit",
+    endpoint="description_api_edit",
     view_func=description_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -340,6 +340,16 @@ class Salary(BaseModel, TrackUpdates):
     def __repr__(self):
         return f"<Salary: ID {self.officer_id} : {self.salary}"
 
+    @property
+    def total_pay(self) -> float:
+        return self.salary + self.overtime_pay
+
+    @property
+    def year_repr(self) -> str:
+        if self.is_fiscal_year:
+            return f"FY{self.year}"
+        return str(self.year)
+
 
 class Assignment(BaseModel, TrackUpdates):
     __tablename__ = "assignments"
@@ -701,6 +711,11 @@ class User(UserMixin, BaseModel):
         server_default=sql_func.now(),
         unique=False,
     )
+
+    def is_admin_or_coordinator(self, department: Department) -> bool:
+        return self.is_administrator or (
+            self.is_area_coordinator and self.ac_department_id == department.id
+        )
 
     def _jwt_encode(self, payload, expiration):
         secret = current_app.config["SECRET_KEY"]

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -1,3 +1,4 @@
+import operator
 import re
 import time
 import uuid
@@ -294,21 +295,27 @@ class Officer(BaseModel, TrackUpdates):
     def job_title(self):
         if self.assignments:
             return max(
-                self.assignments, key=lambda x: x.start_date or date.min
+                self.assignments, key=operator.attrgetter("start_date_or_min")
             ).job.job_title
 
     def unit_description(self):
         if self.assignments:
-            unit = max(self.assignments, key=lambda x: x.start_date or date.min).unit
+            unit = max(
+                self.assignments, key=operator.attrgetter("start_date_or_min")
+            ).unit
             return unit.description if unit else None
 
     def badge_number(self):
         if self.assignments:
-            return max(self.assignments, key=lambda x: x.start_date or date.min).star_no
+            return max(
+                self.assignments, key=operator.attrgetter("start_date_or_min")
+            ).star_no
 
     def currently_on_force(self):
         if self.assignments:
-            most_recent = max(self.assignments, key=lambda x: x.start_date or date.min)
+            most_recent = max(
+                self.assignments, key=operator.attrgetter("start_date_or_min")
+            )
             return "Yes" if most_recent.resign_date is None else "No"
         return "Uncertain"
 
@@ -380,6 +387,14 @@ class Assignment(BaseModel, TrackUpdates):
 
     def __repr__(self):
         return f"<Assignment: ID {self.officer_id} : {self.star_no}>"
+
+    @property
+    def start_date_or_min(self):
+        return self.start_date or date.min
+
+    @property
+    def start_date_or_max(self):
+        return self.start_date or date.max
 
 
 class Unit(BaseModel, TrackUpdates):

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -3,7 +3,7 @@ import re
 import time
 import uuid
 from datetime import date, datetime
-from typing import List
+from typing import List, Optional
 
 from authlib.jose import JoseError, JsonWebToken
 from cachetools import cached
@@ -727,9 +727,10 @@ class User(UserMixin, BaseModel):
         unique=False,
     )
 
-    def is_admin_or_coordinator(self, department: Department) -> bool:
+    def is_admin_or_coordinator(self, department: Optional[Department]) -> bool:
         return self.is_administrator or (
-            self.is_area_coordinator and self.ac_department_id == department.id
+            department is not None
+            and (self.is_area_coordinator and self.ac_department_id == department.id)
         )
 
     def _jwt_encode(self, payload, expiration):

--- a/OpenOversight/app/models/users.py
+++ b/OpenOversight/app/models/users.py
@@ -1,0 +1,8 @@
+from flask_login import AnonymousUserMixin
+
+from OpenOversight.app.models.database import Department
+
+
+class AnonymousUser(AnonymousUserMixin):
+    def is_admin_or_coordinator(self, department: Department) -> bool:
+        return False

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -9,7 +9,7 @@
 {% block content %}
   <div class="container theme-showcase" role="main">
     {% if current_user and current_user.is_authenticated %}
-      {% if image and current_user.is_disabled == False %}
+      {% if image and not current_user.is_disabled %}
         <div class="row">
           <div class="text-center">
             <h1>
@@ -138,18 +138,12 @@
             </div>
           </div>
           <div class="col-sm-2 text-center skip-button">
-            {% if department %}
-              <a href="{{ url_for('main.label_data', department_id=department.id) }}"
-                 class="btn btn-lg btn-primary"
-                 role="button"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Next Photo</a>
-            {% else %}
-              <a href="{{ url_for("main.label_data") }}"
-                 class="btn btn-lg btn-primary"
-                 role="button"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Next Photo</a>
-            {% endif %}
+            <a href="{{ url_for('main.label_data', department_id=department.id if department else 0) }}"
+               class="btn btn-lg btn-primary"
+               role="button"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Next Photo</a>
           </div>
           <div class="col-sm-2 text-center done-button">
-            <a href="{{ url_for('main.complete_tagging', image_id=image.id, department_id=department.id, contains_cops=0) }}"
+            <a href="{{ url_for('main.complete_tagging', image_id=image.id, department_id=department.id if department else 0, contains_cops=0) }}"
                class="btn btn-sm btn-success">
               <span class="glyphicon glyphicon glyphicon-ok" aria-hidden="true"></span>
               All officers have been identified!
@@ -172,7 +166,7 @@
             </div>
           </div>
         </div>
-      {% elif current_user.is_disabled == True %}
+      {% elif current_user.is_disabled %}
         <h3>Your account has been disabled due to too many incorrect classifications/tags!</h3>
         <p>
           <a href="mailto:info@lucyparsonslabs.com"

--- a/OpenOversight/app/templates/department_add_edit.html
+++ b/OpenOversight/app/templates/department_add_edit.html
@@ -35,7 +35,7 @@
           </div>
           <div class="text-danger">{{ wtf.form_errors(form.jobs, hiddens="only") }}</div>
           {% if form.jobs|length > 1 %}
-            {% for subfield in (form.jobs|rejectattr('data.is_sworn_officer','eq',False)|sort(attribute='data.order')|list) %}
+            {% for subfield in (form.jobs|sort(attribute='data.order')|list) %}
               <fieldset>
                 <div class="input-group {% if subfield.errors %} has-error{% endif -%} {%- if subfield.flags.required %} required{% endif -%}">
                   <div class="input-group-addon">

--- a/OpenOversight/app/templates/description_delete.html
+++ b/OpenOversight/app/templates/description_delete.html
@@ -8,7 +8,7 @@
     <p class="lead">
       Are you sure you want to delete this description?
       This cannot be undone.
-      <form action="{{ '{}/delete'.format(url_for('main.description_api', obj_id=obj.id, officer_id=obj.officer_id) ) }}"
+      <form action="{{ url_for('main.description_api_delete', obj_id=obj.id, officer_id=obj.officer_id) }}"
             method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <button class="btn btn-danger" type="submit">Delete</button>

--- a/OpenOversight/app/templates/description_edit.html
+++ b/OpenOversight/app/templates/description_edit.html
@@ -7,7 +7,7 @@
   {% if form.errors %}
     {% set post_url = url_for('main.description_api', officer_id=obj.officer_id, obj_id=obj.id) %}
   {% else %}
-    {% set post_url = "{}/edit".format(url_for('main.description_api', officer_id=obj.officer_id, obj_id=obj.id)) %}
+    {% set post_url = url_for('main.description_api_edit', officer_id=obj.officer_id, obj_id=obj.id) %}
   {% endif %}
   {{ wtf.quick_form(form, action=post_url, method='post', button_map={'submit':'primary'}) }}
   <br>

--- a/OpenOversight/app/templates/image.html
+++ b/OpenOversight/app/templates/image.html
@@ -83,7 +83,7 @@
                 </tr>
               </tbody>
             </table>
-            {% if current_user.is_admin_or_coordinator(image.department.id) %}
+            {% if current_user.is_admin_or_coordinator(image.department) %}
               <h3>
                 Classify <small>Admin only</small>
               </h3>

--- a/OpenOversight/app/templates/image.html
+++ b/OpenOversight/app/templates/image.html
@@ -83,8 +83,7 @@
                 </tr>
               </tbody>
             </table>
-            {% if current_user.is_administrator
-              or (current_user.is_area_coordinator and current_user.ac_department_id == image.department.id) %}
+            {% if current_user.is_admin_or_coordinator(image.department.id) %}
               <h3>
                 Classify <small>Admin only</small>
               </h3>

--- a/OpenOversight/app/templates/incident_delete.html
+++ b/OpenOversight/app/templates/incident_delete.html
@@ -7,7 +7,7 @@
     <p class="lead">
       Are you sure you want to delete this incident?
       This cannot be undone.
-      <form action="{{ '{}/delete'.format(url_for('main.incident_api', obj_id=obj.id) ) }}"
+      <form action="{{ url_for('main.incident_api_delete', obj_id=obj.id) }}"
             method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <button class="btn btn-danger" type="submit">Delete</button>

--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -63,8 +63,7 @@
         </div>
       </div>
       {% include "partials/links_and_videos_row.html" %}
-      {% if current_user.is_administrator
-        or (current_user.is_area_coordinator and current_user.ac_department_id == incident.department_id) %}
+      {% if current_user.is_admin_or_coordinator(incident.department_id) %}
         <div class="row">
           <div class="col-sm-12 col-md-6">
             <a class="btn btn-primary"

--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -68,10 +68,10 @@
         <div class="row">
           <div class="col-sm-12 col-md-6">
             <a class="btn btn-primary"
-               href="{{ '{}/edit'.format(url_for('main.incident_api', obj_id=incident.id) ) }}"
+               href="{{ url_for('main.incident_api_edit', obj_id=incident.id) }}"
                role="button">Edit</a>
             <a class="btn btn-danger"
-               href="{{ '{}/delete'.format(url_for('main.incident_api', obj_id=incident.id) ) }}"
+               href="{{ url_for('main.incident_api_delete', obj_id=incident.id) }}"
                role="button">Delete</a>
           </div>
         </div>

--- a/OpenOversight/app/templates/incident_detail.html
+++ b/OpenOversight/app/templates/incident_detail.html
@@ -63,7 +63,7 @@
         </div>
       </div>
       {% include "partials/links_and_videos_row.html" %}
-      {% if current_user.is_admin_or_coordinator(incident.department_id) %}
+      {% if current_user.is_admin_or_coordinator(incident.department) %}
         <div class="row">
           <div class="col-sm-12 col-md-6">
             <a class="btn btn-primary"

--- a/OpenOversight/app/templates/incident_edit.html
+++ b/OpenOversight/app/templates/incident_edit.html
@@ -4,11 +4,6 @@
   Update Incident {{ obj.report_number }}
 {% endblock page_title %}
 {% block form %}
-  {% if form.errors %}
-    {% set post_url = url_for('main.incident_api', obj_id=obj.id) %}
-  {% else %}
-    {% set post_url = "{}/edit".format(url_for('main.incident_api', obj_id=obj.id)) %}
-  {% endif %}
   {% include "partials/incident_form.html" %}
 {% endblock form %}
 {% block js_footer %}<script src="{{ url_for('static', filename='js/dynamic_lists.js') }}"></script>{% endblock %}

--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -67,7 +67,7 @@
           {% endif %}
         </ul>
         {% if current_user.is_administrator or current_user.is_area_coordinator %}
-          <a href="{{ url_for("main.incident_api") + 'new' }}"
+          <a href="{{ url_for("main.incident_api_new") }}"
              class="btn btn-primary"
              role="button">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>

--- a/OpenOversight/app/templates/label_data.html
+++ b/OpenOversight/app/templates/label_data.html
@@ -73,7 +73,7 @@
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
             Add New Unit
           </a>
-          <a href="{{ url_for("main.incident_api") + 'new' }}"
+          <a href="{{ url_for("main.incident_api_new") }}"
              class="btn btn-primary"
              role="button">
             <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>

--- a/OpenOversight/app/templates/leaderboard.html
+++ b/OpenOversight/app/templates/leaderboard.html
@@ -11,10 +11,10 @@
         <h2>
           <small>Top Users by Number of Images Sorted</small>
         </h2>
-        {% for sorter in top_sorters %}
+        {% for sorter, count in top_sorters %}
           {{ loop.index }}.
-          <a href="{{ url_for('main.profile', username=sorter[0].username) }}">{{ sorter[0].username }}</a>
-          - {{ sorter[1] }}
+          <a href="{{ url_for('main.profile', username=sorter.username) }}">{{ sorter.username }}</a>
+          - {{ count }}
           <br />
         {% endfor %}
       </div>
@@ -24,10 +24,10 @@
         <h2>
           <small>Top Users by Number of Officers Found</small>
         </h2>
-        {% for tagger in top_taggers %}
+        {% for tagger, count in top_taggers %}
           {{ loop.index }}.
-          <a href="{{ url_for('main.profile', username=tagger[0].username) }}">{{ tagger[0].username }}</a>
-          - {{ tagger[1] }}
+          <a href="{{ url_for('main.profile', username=tagger.username) }}">{{ tagger.username }}</a>
+          - {{ count }}
           <br />
         {% endfor %}
       </div>

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -13,7 +13,7 @@
 {% endblock head %}
 {% block content %}
   <div class="container" role="main">
-    <h1>{{ department.display_name | title }} Officers</h1>
+    <h1>{{ department.display_name }} Officers</h1>
     <div class="row">
       <div class="filter-sidebar col-sm-3">
         <h3 class="sidebar-title">Filter officers</h3>
@@ -80,15 +80,15 @@
                  id="filter-race">
               <div class="panel-body">
                 <div class="form-group checkbox">
-                  {% for choice in choices['race'] %}
+                  {% for race_key, race in choices['race'] %}
                     <label class="form-check">
                       <input type="checkbox"
                              class="form-check-input"
-                             id="race-{{ choice[0] }}"
+                             id="race-{{ race_key }}"
                              name="race"
-                             value="{{ choice[0] }}"
-                             {% if choice[0] in form_data['race'] %}checked="checked"{% endif %} />
-                      {{ choice[1] }}
+                             value="{{ race_key }}"
+                             {% if race_key in form_data['race'] %}checked="checked"{% endif %} />
+                      {{ race }}
                     </label>
                   {% endfor %}
                 </div>
@@ -105,15 +105,15 @@
                  id="filter-gender">
               <div class="panel-body">
                 <div class="form-group radio">
-                  {% for choice in choices['gender'] %}
+                  {% for gender_key, gender in choices['gender'] %}
                     <label class="form-check">
                       <input type="radio"
                              class="form-check-input"
-                             id="gender-{{ choice[0] }}"
+                             id="gender-{{ gender_key }}"
                              name="gender"
-                             value="{{ choice[0] }}"
-                             {% if choice[0] in form_data['gender'] %}checked="checked"{% endif %} />
-                      {{ choice[1] }}
+                             value="{{ gender_key }}"
+                             {% if gender_key in form_data['gender'] %}checked="checked"{% endif %} />
+                      {{ gender }}
                     </label>
                   {% endfor %}
                 </div>
@@ -150,10 +150,10 @@
                             name="rank"
                             class="select2-multi-search"
                             multiple="multiple">
-                      {% for choice in choices['rank'] %}
-                        <option value="{{ choice[0] }}"
-                                {% if choice[0] in form_data['rank'] %}selected="selected"{% endif %}>
-                          {{ choice[1] }}
+                      {% for rank_key, rank in choices['rank'] %}
+                        <option value="{{ rank_key }}"
+                                {% if rank_key in form_data['rank'] %}selected="selected"{% endif %}>
+                          {{ rank }}
                         </option>
                       {% endfor %}
                     </select>
@@ -167,10 +167,10 @@
                             name="unit"
                             class="select2-multi-search"
                             multiple="multiple">
-                      {% for choice in choices['unit'] %}
-                        <option value="{{ choice[0] }}"
-                                {% if choice[0] in form_data['unit'] %}selected="selected"{% endif %}>
-                          {{ choice[1] }}
+                      {% for unit_key, unit in choices['unit'] %}
+                        <option value="{{ unit_key }}"
+                                {% if unit_key in form_data['unit'] %}selected="selected"{% endif %}>
+                          {{ unit }}
                         </option>
                       {% endfor %}
                     </select>

--- a/OpenOversight/app/templates/note_delete.html
+++ b/OpenOversight/app/templates/note_delete.html
@@ -8,7 +8,7 @@
     <p class="lead">
       Are you sure you want to delete this note?
       This cannot be undone.
-      <form action="{{ '{}/delete'.format(url_for('main.note_api', obj_id=obj.id, officer_id=obj.officer_id) ) }}"
+      <form action="{{ url_for('main.note_api_edit', obj_id=obj.id, officer_id=obj.officer_id) }}"
             method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <button class="btn btn-danger" type="submit">Delete</button>

--- a/OpenOversight/app/templates/note_edit.html
+++ b/OpenOversight/app/templates/note_edit.html
@@ -7,7 +7,7 @@
   {% if form.errors %}
     {% set post_url = url_for('main.note_api', officer_id=obj.officer_id, obj_id=obj.id) %}
   {% else %}
-    {% set post_url = "{}/edit".format(url_for('main.note_api', officer_id=obj.officer_id, obj_id=obj.id)) %}
+    {% set post_url = url_for('main.note_api_edit', officer_id=obj.officer_id, obj_id=obj.id) %}
   {% endif %}
   {{ wtf.quick_form(form, action=post_url, method='post', button_map={'submit':'primary'}) }}
   <br>

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -85,7 +85,7 @@
   </script>
 {% endblock meta %}
 {% block content %}
-  {% set is_admin_or_coordinator = current_user.is_admin_or_coordinator(officer.department_id) %}
+  {% set is_admin_or_coordinator = current_user.is_admin_or_coordinator(officer.department) %}
   <div class="container theme-showcase" role="main">
     <div class="page-header">
       <ol class="breadcrumb">

--- a/OpenOversight/app/templates/officer.html
+++ b/OpenOversight/app/templates/officer.html
@@ -85,7 +85,7 @@
   </script>
 {% endblock meta %}
 {% block content %}
-  {% set is_admin_or_coordinator = current_user.is_administrator or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id) %}
+  {% set is_admin_or_coordinator = current_user.is_admin_or_coordinator(officer.department_id) %}
   <div class="container theme-showcase" role="main">
     <div class="page-header">
       <ol class="breadcrumb">

--- a/OpenOversight/app/templates/partials/links_and_videos_row.html
+++ b/OpenOversight/app/templates/partials/links_and_videos_row.html
@@ -30,7 +30,7 @@
       </ul>
     {% endif %}
   {% endfor %}
-  {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)) %}
+  {% if officer and (current_user.is_admin_or_coordinator(officer.department)) %}
     <a href="{{ url_for("main.link_api_new", officer_id=officer.id) }}"
        class="btn btn-primary">New Link/Video</a>
   {% endif %}
@@ -42,7 +42,7 @@
           {% with link_url = link.url.split("v=")[1] %}
             <li class="list-group-item">
               {% if link.title %}<h5>{{ link.title }}</h5>{% endif %}
-              {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)
+              {% if officer and (current_user.is_admin_or_coordinator(officer.department)
                 or link.creator_id == current_user.id) %}
                 <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                   <span class="sr-only">Edit</span>
@@ -81,7 +81,7 @@
         {% for link in list %}
           <li class="list-group-item">
             <a href="{{ link.url }}">{{ link.title or link.url }}</a>
-            {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)
+            {% if officer and (current_user.is_admin_or_coordinator(officer.department)
               or link.creator_id == current_user.id) %}
               <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                 <span class="sr-only">Edit</span>

--- a/OpenOversight/app/templates/partials/links_and_videos_row.html
+++ b/OpenOversight/app/templates/partials/links_and_videos_row.html
@@ -30,8 +30,7 @@
       </ul>
     {% endif %}
   {% endfor %}
-  {% if officer and (current_user.is_administrator
-    or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id)) %}
+  {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)) %}
     <a href="{{ url_for("main.link_api_new", officer_id=officer.id) }}"
        class="btn btn-primary">New Link/Video</a>
   {% endif %}
@@ -43,8 +42,7 @@
           {% with link_url = link.url.split("v=")[1] %}
             <li class="list-group-item">
               {% if link.title %}<h5>{{ link.title }}</h5>{% endif %}
-              {% if officer and (current_user.is_administrator
-                or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id)
+              {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)
                 or link.creator_id == current_user.id) %}
                 <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                   <span class="sr-only">Edit</span>
@@ -83,8 +81,7 @@
         {% for link in list %}
           <li class="list-group-item">
             <a href="{{ link.url }}">{{ link.title or link.url }}</a>
-            {% if officer and (current_user.is_administrator
-              or (current_user.is_area_coordinator and current_user.ac_department_id == officer.department_id)
+            {% if officer and (current_user.is_admin_or_coordinator(officer.department_id)
               or link.creator_id == current_user.id) %}
               <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                 <span class="sr-only">Edit</span>

--- a/OpenOversight/app/templates/partials/officer_assignment_history.html
+++ b/OpenOversight/app/templates/partials/officer_assignment_history.html
@@ -23,34 +23,7 @@
     {% endif %}
   </tr>
   <tbody>
-    {% for assignment in assignments|rejectattr('start_date','ne',None) %}
-      <tr>
-        <td>{{ assignment.job.job_title }}</td>
-        <td>{{ assignment.star_no }}</td>
-        <td>
-          {% if assignment.unit_id %}{{ assignment.unit.description }}{% endif %}
-        </td>
-        <td>
-          {% if assignment.start_date %}
-            {{ assignment.start_date }}
-          {% else %}
-            Unknown
-          {% endif %}
-        </td>
-        <td>
-          {% if assignment.resign_date %}{{ assignment.resign_date }}{% endif %}
-        </td>
-        <td>
-          {% if is_admin_or_coordinator %}
-            <a href="{{ url_for('main.edit_assignment', officer_id=officer.id, assignment_id=assignment.id) }}">
-              <span class="sr-only">Edit</span>
-              <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
-            </a>
-          {% endif %}
-        </td>
-      </tr>
-    {% endfor %}
-    {% for assignment in assignments | rejectattr('start_date', 'none') | sort(attribute='start_date', reverse=True) %}
+    {% for assignment in assignments | sort(attribute='start_date_or_max', reverse=True) %}
       <tr>
         <td>{{ assignment.job.job_title }}</td>
         <td>{{ assignment.star_no }}</td>

--- a/OpenOversight/app/templates/partials/officer_descriptions.html
+++ b/OpenOversight/app/templates/partials/officer_descriptions.html
@@ -9,11 +9,11 @@
         {% if current_user and not current_user.is_anonymous %}<em>{{ description.creator.username }}</em>{% endif %}
         {% if description.created_by == current_user.id or
           current_user.is_administrator %}
-          <a href="{{ url_for('main.description_api', officer_id=officer.id, obj_id=description.id) + '/edit' }}">
+          <a href="{{ url_for('main.description_api_edit', officer_id=officer.id, obj_id=description.id) }}">
             <span class="sr-only">Edit</span>
             <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
           </a>
-          <a href="{{ url_for('main.description_api', officer_id=officer.id, obj_id=description.id) + '/delete' }}">
+          <a href="{{ url_for('main.description_api_delete', officer_id=officer.id, obj_id=description.id) }}">
             <span class="sr-only">Delete</span>
             <i class="fa fa-trash-o" aria-hidden="true"></i>
           </a>
@@ -23,6 +23,6 @@
   </ul>
 {% endif %}
 {% if is_admin_or_coordinator %}
-  <a href="{{ url_for('main.description_api', officer_id=officer.id) }}"
+  <a href="{{ url_for('main.description_api_new', officer_id=officer.id) }}"
      class="btn btn-primary">New description</a>
 {% endif %}

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -3,16 +3,16 @@
      data-interval="false"
      data-ride="carousel">
   <div class="carousel-inner">
-    {% for path in paths %}
+    {% for face, path in face_paths %}
       <div class="item{{ ' active' if loop.index == 1 else '' }}">
-        {# Don't try to link if only image is the placeholder #}
         <div class="row text-center">
           <div class="col-12">
-            {% if faces %}<a href="{{ url_for('main.display_tag', tag_id=faces[loop.index - 1].id) }}">{% endif %}
+            {# Don't try to link if only image is the placeholder #}
+            {% if face %}<a href="{{ url_for('main.display_tag', tag_id=face.id) }}">{% endif %}
               <img class="officer-face officer-profile"
                    src="{{ path }}"
                    alt="Submission">
-              {% if faces %}</a>{% endif %}
+              {% if face %}</a>{% endif %}
           </div>
         </div>
       </div>

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -11,7 +11,7 @@
         <tr>
           <td colspan="2" style="border-top: 0; ">
             <h4>
-              <a href="{{ url_for('main.incident_api_get', obj_id=incident.id) }}">
+              <a href="{{ url_for('main.incident_api', obj_id=incident.id) }}">
                 Incident
                 {% if incident.report_number %}
                   {{ incident.report_number }}

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -11,7 +11,7 @@
         <tr>
           <td colspan="2" style="border-top: 0; ">
             <h4>
-              <a href="{{ url_for('main.incident_api', obj_id=incident.id) }}">
+              <a href="{{ url_for('main.incident_api_get', obj_id=incident.id) }}">
                 Incident
                 {% if incident.report_number %}
                   {{ incident.report_number }}
@@ -20,7 +20,7 @@
                 {% endif %}
               </a>
               {% if current_user.is_admin_or_coordinator(incident.department) %}
-                <a href="{{ url_for('main.incident_api', obj_id=incident.id) + '/edit' }}">
+                <a href="{{ url_for('main.incident_api_edit', obj_id=incident.id) }}">
                   <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
                 </a>
               {% endif %}
@@ -36,7 +36,7 @@
   {% endblock js_footer %}
 {% endif %}
 {% if is_admin_or_coordinator %}
-  <a href="{{ url_for("main.incident_api") + 'new?officer_id={}'.format(officer.id) }}"
+  <a href="{{ url_for("main.incident_api_new", officer_id=officer.id) }}"
      class="btn btn-primary">New
   Incident</a>
 {% endif %}

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -19,8 +19,7 @@
                   {{ incident.id }}
                 {% endif %}
               </a>
-              {% if current_user.is_administrator or (current_user.is_area_coordinator and
-                current_user.ac_department_id == incident.department_id) %}
+              {% if current_user.is_admin_or_coordinator(incident.department) %}
                 <a href="{{ url_for('main.incident_api', obj_id=incident.id) + '/edit' }}">
                   <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
                 </a>

--- a/OpenOversight/app/templates/partials/officer_notes.html
+++ b/OpenOversight/app/templates/partials/officer_notes.html
@@ -7,11 +7,11 @@
       {{ note.text_contents | markdown }}
       <em>{{ note.creator.username }}</em>
       {% if note.created_by == current_user.id or current_user.is_administrator %}
-        <a href="{{ url_for('main.note_api', officer_id=officer.id, obj_id=note.id) + '/edit' }}">
+        <a href="{{ url_for('main.note_api_edit', officer_id=officer.id, obj_id=note.id) }}">
           <span class="sr-only">Edit</span>
           <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
         </a>
-        <a href="{{ url_for('main.note_api', officer_id=officer.id, obj_id=note.id) + '/delete' }}">
+        <a href="{{ url_for('main.note_api_delete', officer_id=officer.id, obj_id=note.id) }}">
           <span class="sr-only">Delete</span>
           <i class="fa fa-trash-o" aria-hidden="true"></i>
         </a>

--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -23,19 +23,19 @@
     <tbody>
       {% for salary in officer.salaries %}
         <tr>
-          <td>{{ '${:,.2f}'.format(salary.salary) }}</td>
+          <td>{{ salary.salary | display_currency }}</td>
           {% if salary.overtime_pay %}
             {% if salary.overtime_pay > 0 %}
-              <td>{{ '${:,.2f}'.format(salary.overtime_pay) }}</td>
+              <td>{{ salary.overtime_pay | display_currency }}</td>
             {% else %}
               <td></td>
             {% endif %}
-            <td>{{ '${:,.2f}'.format(salary.total_pay) }}</td>
+            <td>{{ salary.total_pay | display_currency }}</td>
           {% else %}
             <td></td>
             <td></td>
           {% endif %}
-          <td>salary.year_repr</td>
+          <td>{{ salary.year_repr }}</td>
           {% if is_admin_or_coordinator %}
             <td>
               <a href="{{ url_for('main.edit_salary', officer_id=officer.id, salary_id=salary.id) }}">

--- a/OpenOversight/app/templates/partials/officer_salary.html
+++ b/OpenOversight/app/templates/partials/officer_salary.html
@@ -30,15 +30,12 @@
             {% else %}
               <td></td>
             {% endif %}
-            <td>{{ '${:,.2f}'.format(salary.salary + salary.overtime_pay) }}</td>
+            <td>{{ '${:,.2f}'.format(salary.total_pay) }}</td>
           {% else %}
             <td></td>
             <td></td>
           {% endif %}
-          <td>
-            {% if salary.is_fiscal_year: %}FY{% endif %}
-            {{ salary.year }}
-          </td>
+          <td>salary.year_repr</td>
           {% if is_admin_or_coordinator %}
             <td>
               <a href="{{ url_for('main.edit_salary', officer_id=officer.id, salary_id=salary.id) }}">

--- a/OpenOversight/app/templates/profile.html
+++ b/OpenOversight/app/templates/profile.html
@@ -36,13 +36,10 @@
             {% elif user.is_disabled == False %}
               <p>Enabled</p>
             {% endif %}
-            {% if current_user.is_administrator and user.is_administrator == False %}
+            {% if current_user.is_administrator and not user.is_administrators %}
               <h3>
                 <a href="{{ url_for('auth.edit_user', user_id=user.id) }}">Edit user</a> <small>Admin only</small>
               </h3>
-              <!-- <p>
-            <a href="{{ url_for('auth.edit_user', user_id=user.id) }}">Change user access</a>
-          </p> -->
             {% endif %}
             {% if current_user.is_administrator %}
               <h3>User Email</h3>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -103,8 +103,7 @@
                   </tr>
                 </tbody>
               </table>
-              {% if current_user.is_administrator
-                or (current_user.is_area_coordinator and current_user.ac_department_id == face.image.department_id) %}
+              {% if current_user.is_admin_or_coordinator(face.image.department_id) %}
                 <h3>
                   Remove tag <small>Admin only</small>
                 </h3>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -103,7 +103,7 @@
                   </tr>
                 </tbody>
               </table>
-              {% if current_user.is_admin_or_coordinator(face.image.department_id) %}
+              {% if current_user.is_admin_or_coordinator(face.image.department) %}
                 <h3>
                   Remove tag <small>Admin only</small>
                 </h3>

--- a/OpenOversight/tests/routes/test_descriptions.py
+++ b/OpenOversight/tests/routes/test_descriptions.py
@@ -58,7 +58,7 @@ def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
         form = TextForm(text_contents=text_contents, officer_id=officer.id)
 
         rv = client.post(
-            url_for("main.description_api", officer_id=officer.id),
+            url_for("main.description_api_new", officer_id=officer.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -77,7 +77,7 @@ def test_admins_can_create_descriptions(mockdata, client, session):
         form = TextForm(text_contents=text_contents, officer_id=officer.id)
 
         rv = client.post(
-            url_for("main.description_api", officer_id=officer.id),
+            url_for("main.description_api_new", officer_id=officer.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -102,7 +102,7 @@ def test_acs_can_create_descriptions(mockdata, client, session):
         form = TextForm(text_contents=description, officer_id=officer.id)
 
         rv = client.post(
-            url_for("main.description_api", officer_id=officer.id),
+            url_for("main.description_api_new", officer_id=officer.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -143,9 +143,10 @@ def test_admins_can_edit_descriptions(mockdata, client, session):
 
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             data=form.data,
             follow_redirects=True,
         )
@@ -183,9 +184,10 @@ def test_ac_can_edit_their_descriptions_in_their_department(mockdata, client, se
 
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             data=form.data,
             follow_redirects=True,
         )
@@ -223,9 +225,10 @@ def test_ac_can_edit_others_descriptions(mockdata, client, session):
 
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             data=form.data,
             follow_redirects=True,
         )
@@ -263,9 +266,10 @@ def test_ac_cannot_edit_descriptions_not_in_their_department(mockdata, client, s
 
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             data=form.data,
             follow_redirects=True,
         )
@@ -279,11 +283,10 @@ def test_admins_can_delete_descriptions(mockdata, client, session):
         description_id = description.id
         rv = client.post(
             url_for(
-                "main.description_api",
+                "main.description_api_delete",
                 officer_id=description.officer_id,
                 obj_id=description_id,
-            )
-            + "/delete",
+            ),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -309,9 +312,10 @@ def test_acs_can_delete_their_descriptions_in_their_department(
         description_id = description.id
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/delete",
+                "main.description_api_delete",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -339,9 +343,10 @@ def test_acs_cannot_delete_descriptions_not_in_their_department(
         description_id = description.id
         rv = client.post(
             url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + "/delete",
+                "main.description_api_delete",
+                officer_id=officer.id,
+                obj_id=description.id,
+            ),
             follow_redirects=True,
         )
 
@@ -362,9 +367,10 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         db.session.commit()
         rv = client.get(
             url_for(
-                "main.description_api", obj_id=description.id, officer_id=officer.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                obj_id=description.id,
+                officer_id=officer.id,
+            ),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -385,9 +391,10 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
         db.session.commit()
         rv = client.get(
             url_for(
-                "main.description_api", obj_id=description.id, officer_id=officer.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                obj_id=description.id,
+                officer_id=officer.id,
+            ),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -408,9 +415,10 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
         db.session.commit()
         rv = client.get(
             url_for(
-                "main.description_api", obj_id=description.id, officer_id=officer.id
-            )
-            + "/edit",
+                "main.description_api_edit",
+                obj_id=description.id,
+                officer_id=officer.id,
+            ),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.FORBIDDEN

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -89,7 +89,7 @@ def test_admins_can_create_basic_incidents(report_number, mockdata, client, sess
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api") + "new", data=data, follow_redirects=True
+            url_for("main.incident_api_new"), data=data, follow_redirects=True
         )
         assert rv.status_code == HTTPStatus.OK
         assert "created" in rv.data.decode(ENCODING_UTF_8)
@@ -131,7 +131,7 @@ def test_admins_cannot_create_incident_with_invalid_report_number(
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api") + "new", data=data, follow_redirects=True
+            url_for("main.incident_api_new"), data=data, follow_redirects=True
         )
 
         assert rv.status_code == HTTPStatus.OK
@@ -182,7 +182,7 @@ def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -236,7 +236,7 @@ def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session, 
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -284,7 +284,7 @@ def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -322,7 +322,7 @@ def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
 
         incident_count_before = Incident.query.count()
         rv = client.post(
-            url_for("main.incident_api") + "new", data=data, follow_redirects=True
+            url_for("main.incident_api_new"), data=data, follow_redirects=True
         )
         assert rv.status_code == HTTPStatus.OK
         assert "Must select a state." in rv.data.decode(ENCODING_UTF_8)
@@ -370,7 +370,7 @@ def test_admins_cannot_make_incidents_with_multiple_validation_errors(
 
         incident_count_before = Incident.query.count()
         rv = client.post(
-            url_for("main.incident_api") + "new", data=data, follow_redirects=True
+            url_for("main.incident_api_new"), data=data, follow_redirects=True
         )
         assert rv.status_code == HTTPStatus.OK
         assert "Must also select a state." in rv.data.decode(ENCODING_UTF_8)
@@ -431,7 +431,7 @@ def test_admins_can_edit_incident_officers(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -491,7 +491,7 @@ def test_admins_cannot_edit_non_existing_officers(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -541,7 +541,7 @@ def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -596,7 +596,7 @@ def test_ac_cannot_edit_incidents_not_in_their_department(mockdata, client, sess
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )
@@ -609,7 +609,7 @@ def test_admins_can_delete_incidents(mockdata, client, session):
         incident = Incident.query.first()
         inc_id = incident.id
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc_id) + "/delete",
+            url_for("main.incident_api_delete", obj_id=inc_id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -623,7 +623,7 @@ def test_acs_can_delete_incidents_in_their_department(mockdata, client, session)
         incident = Incident.query.filter_by(department_id=AC_DEPT).first()
         inc_id = incident.id
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc_id) + "/delete",
+            url_for("main.incident_api_delete", obj_id=inc_id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -639,7 +639,7 @@ def test_acs_cannot_delete_incidents_not_in_their_department(mockdata, client, s
         ).first()
         inc_id = incident.id
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc_id) + "/delete",
+            url_for("main.incident_api_delete", obj_id=inc_id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.FORBIDDEN
@@ -652,7 +652,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         login_ac(client)
         incident = Incident.query.filter_by(department_id=AC_DEPT).first()
         rv = client.get(
-            url_for("main.incident_api", obj_id=incident.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=incident.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -666,7 +666,7 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
             Incident.query.filter_by(department_id=AC_DEPT)
         ).first()
         rv = client.get(
-            url_for("main.incident_api", obj_id=incident.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=incident.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.FORBIDDEN
@@ -719,7 +719,7 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer_id = "1234"
-        rv = client.get(url_for("main.incident_api") + f"new?officer_id={officer_id}")
+        rv = client.get(url_for("main.incident_api_new", officer_id=officer_id))
         assert officer_id in rv.data.decode(ENCODING_UTF_8)
 
 
@@ -776,7 +776,7 @@ def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api", obj_id=inc.id) + "/edit",
+            url_for("main.incident_api_edit", obj_id=inc.id),
             data=data,
             follow_redirects=True,
         )

--- a/OpenOversight/tests/routes/test_notes.py
+++ b/OpenOversight/tests/routes/test_notes.py
@@ -135,7 +135,7 @@ def test_admins_can_edit_notes(mockdata, client, session, faker):
         assert has_database_cache_entry(*cache_params) is True
 
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/edit",
+            url_for("main.note_api_edit", officer_id=officer.id, obj_id=note.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -167,7 +167,7 @@ def test_ac_can_edit_their_notes_in_their_department(mockdata, client, session, 
         )
 
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/edit",
+            url_for("main.note_api_edit", officer_id=officer.id, obj_id=note.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -201,7 +201,7 @@ def test_ac_can_edit_others_notes(mockdata, client, session):
         )
 
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/edit",
+            url_for("main.note_api_edit", officer_id=officer.id, obj_id=note.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -238,7 +238,7 @@ def test_ac_cannot_edit_notes_not_in_their_department(mockdata, client, session)
         )
 
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/edit",
+            url_for("main.note_api_edit", officer_id=officer.id, obj_id=note.id),
             data=form.data,
             follow_redirects=True,
         )
@@ -256,8 +256,7 @@ def test_admins_can_delete_notes(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is True
 
         rv = client.post(
-            url_for("main.note_api", officer_id=note.officer_id, obj_id=note.id)
-            + "/delete",
+            url_for("main.note_api_delete", officer_id=note.officer_id, obj_id=note.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -282,7 +281,7 @@ def test_acs_can_delete_their_notes_in_their_department(mockdata, client, sessio
         db.session.add(note)
         db.session.commit()
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/delete",
+            url_for("main.note_api_delete", officer_id=officer.id, obj_id=note.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -310,7 +309,7 @@ def test_acs_cannot_delete_notes_not_in_their_department(
         db.session.add(note)
         db.session.commit()
         rv = client.post(
-            url_for("main.note_api", officer_id=officer.id, obj_id=note.id) + "/delete",
+            url_for("main.note_api_delete", officer_id=officer.id, obj_id=note.id),
             follow_redirects=True,
         )
 
@@ -335,7 +334,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         db.session.add(note)
         db.session.commit()
         rv = client.get(
-            url_for("main.note_api", obj_id=note.id, officer_id=officer.id) + "/edit",
+            url_for("main.note_api_edit", obj_id=note.id, officer_id=officer.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -358,7 +357,7 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
         db.session.add(note)
         db.session.commit()
         rv = client.get(
-            url_for("main.note_api", obj_id=note.id, officer_id=officer.id) + "/edit",
+            url_for("main.note_api_edit", obj_id=note.id, officer_id=officer.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.OK
@@ -383,7 +382,7 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
         db.session.add(note)
         db.session.commit()
         rv = client.get(
-            url_for("main.note_api", obj_id=note.id, officer_id=officer.id) + "/edit",
+            url_for("main.note_api_edit", obj_id=note.id, officer_id=officer.id),
             follow_redirects=True,
         )
         assert rv.status_code == HTTPStatus.FORBIDDEN

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1821,7 +1821,7 @@ def test_incidents_csv(mockdata, client, session, department, faker):
         )
         # add the incident
         rv = client.post(
-            url_for("main.incident_api") + "new",
+            url_for("main.incident_api_new"),
             data=process_form_data(form.data),
             follow_redirects=True,
         )

--- a/OpenOversight/tests/routes/test_singular_redirects.py
+++ b/OpenOversight/tests/routes/test_singular_redirects.py
@@ -97,7 +97,7 @@ def test_redirect_with_department_id(client, session, source_route, target_route
         ("main.redirect_edit_officer", "main.edit_officer"),
         ("main.redirect_submit_officer_images", "main.submit_officer_images"),
         ("main.redirect_new_note", "main.note_api"),
-        ("main.redirect_new_description", "main.description_api"),
+        ("main.redirect_new_description", "main.description_api_new"),
         ("main.redirect_new_link", "main.link_api_new"),
     ],
 )
@@ -507,14 +507,14 @@ def test_redirect_upload(client, session):
 
 
 @pytest.mark.parametrize(
-    "source_route, target_suffix",
+    "source_route, target_route",
     [
-        ("main.redirect_get_notes", ""),
-        ("main.redirect_edit_note", "/edit"),
-        ("main.redirect_delete_note", "/delete"),
+        ("main.redirect_get_notes", "main.note_api"),
+        ("main.redirect_edit_note", "main.note_api_edit"),
+        ("main.redirect_delete_note", "main.note_api_delete"),
     ],
 )
-def test_redirect_note(client, session, source_route, target_suffix):
+def test_redirect_note(client, session, source_route, target_route):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.filter_by(id=AC_DEPT).first()
@@ -534,22 +534,20 @@ def test_redirect_note(client, session, source_route, target_suffix):
             follow_redirects=True,
         )
         assert resp_redirect.status_code == HTTPStatus.OK
-        assert (
-            resp_redirect.request.path
-            == url_for("main.note_api", officer_id=officer.id, obj_id=note.id)
-            + target_suffix
+        assert resp_redirect.request.path == url_for(
+            target_route, officer_id=officer.id, obj_id=note.id
         )
 
 
 @pytest.mark.parametrize(
-    "source_route, target_suffix",
+    "source_route, target_route",
     [
-        ("main.redirect_get_description", ""),
-        ("main.redirect_edit_description", "/edit"),
-        ("main.redirect_delete_description", "/delete"),
+        ("main.redirect_get_description", "main.description_api"),
+        ("main.redirect_edit_description", "main.description_api_edit"),
+        ("main.redirect_delete_description", "main.description_api_delete"),
     ],
 )
-def test_redirect_description(client, session, source_route, target_suffix):
+def test_redirect_description(client, session, source_route, target_route):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.filter_by(id=AC_DEPT).first()
@@ -577,23 +575,19 @@ def test_redirect_description(client, session, source_route, target_suffix):
             follow_redirects=True,
         )
         assert resp_redirect.status_code == HTTPStatus.OK
-        assert (
-            resp_redirect.request.path
-            == url_for(
-                "main.description_api", officer_id=officer.id, obj_id=description.id
-            )
-            + target_suffix
+        assert resp_redirect.request.path == url_for(
+            target_route, officer_id=officer.id, obj_id=description.id
         )
 
 
 @pytest.mark.parametrize(
-    "source_route, target_suffix",
+    "source_route, target_route",
     [
         ("main.redirect_edit_link", "main.link_api_edit"),
         ("main.redirect_delete_link", "main.link_api_delete"),
     ],
 )
-def test_redirect_link(client, session, source_route, target_suffix):
+def test_redirect_link(client, session, source_route, target_route):
     with current_app.test_request_context():
         login_admin(client)
         officer = (
@@ -626,5 +620,5 @@ def test_redirect_link(client, session, source_route, target_suffix):
         )
         assert resp_redirect.status_code == HTTPStatus.OK
         assert resp_redirect.request.path == url_for(
-            target_suffix, officer_id=officer.id, obj_id=officer.links[0].id
+            target_route, officer_id=officer.id, obj_id=officer.links[0].id
         )

--- a/OpenOversight/tests/test_database_cache.py
+++ b/OpenOversight/tests/test_database_cache.py
@@ -147,7 +147,7 @@ def test_documented_incidents(mockdata, client, faker):
         data = process_form_data(form.data)
 
         rv = client.post(
-            url_for("main.incident_api") + "new", data=data, follow_redirects=True
+            url_for("main.incident_api_new"), data=data, follow_redirects=True
         )
 
         assert rv.status_code == HTTPStatus.OK

--- a/OpenOversight/tests/test_email_client.py
+++ b/OpenOversight/tests/test_email_client.py
@@ -1,3 +1,4 @@
+import time
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from unittest.mock import MagicMock, patch
@@ -145,5 +146,7 @@ def test_smtp_email_provider_send_email(app, mockdata):
         provider = SMTPEmailProvider()
         provider.mail = mail
         provider.send_email(msg)
+
+        time.sleep(0.5)  # wait for async "sending" of email
 
         mail.send.assert_called_once()


### PR DESCRIPTION
## Description of Changes
Some of the `ModelView` based endpoints were missing a distinct name that could be used for `url_for`, and instead string concatenation was used (mostly in templates). I also moved some logic out of templates (e.g. calculation of total pay), added helper methods and made some other changed to reduce the code needed in the templates and improve readability a little bit.

I also added an anonymous user class that is useful to call things like `.is_admin_or_coordinator(department)` on any `current_user` object, without first making sure the user is not anonymous.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
