### PR TITLE
Remove `create_empty_secret` from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: ## Build containers
 	docker-compose build
 
 .PHONY: build_with_version
-build_with_version: create_empty_secret
+build_with_version:
 	docker-compose build --build-arg MAKE_PYTHON_VERSION=$(PYTHON_VERSION)
 
 .PHONY: test_with_version
@@ -88,10 +88,3 @@ help: ## Print this message and exit
 .PHONY: attach
 attach:
 	docker-compose exec postgres psql -h localhost -U openoversight openoversight-dev
-
-.PHONY: create_empty_secret
-create_empty_secret: ## This is needed to make sure docker doesn't create an empty directory, or delete that directory first
-	touch service_account_key.json || \
-	(echo "Need to delete that empty directory first"; \
-	 sudo rm -d service_account_key.json/; \
-	 touch service_account_key.json)


### PR DESCRIPTION
## Description of Changes
With the addition of @sea-kelp's work on the email class, we should no longer need this cover up function for testing.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
