### PR TITLE
Replace inline styles with external css

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,4 +116,4 @@ repos:
           - OpenOversight/app/templates
           - --profile=jinja
           - --use-gitignore
-          - --ignore=H006,T028,H031,H021,H013,H011
+          - --ignore=H006,T028,H031,H013,H011

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -654,3 +654,28 @@ tr:hover .row-actions {
     visibility: hidden;
     width: auto
 }
+
+.red {
+  color: #a00;
+}
+
+.no-box-shadow {
+  box-shadow: none;
+}
+
+.no-border-top {
+  border-top: none;
+}
+
+.no-display {
+  display: none;
+}
+
+.slightly-above {
+  position: relative;
+  top: -0.8em;
+}
+
+.bottom-margin {
+  margin-bottom: 2rem;
+}

--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -55,7 +55,7 @@
                 </div>
                 {% for error in form.dataX.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <div class="input-group input-group-sm">
@@ -68,7 +68,7 @@
                 <div class="input-group input-group-sm"></div>
                 {% for error in form.dataY.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <div class="input-group input-group-sm">
@@ -80,7 +80,7 @@
                 </div>
                 {% for error in form.dataWidth.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <div class="input-group input-group-sm">
@@ -92,7 +92,7 @@
                 </div>
                 {% for error in form.dataHeight.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <div class="input-group input-group-sm id-input">
@@ -105,7 +105,7 @@
                 </div>
                 {% for error in form.officer_id.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <input type="text"
@@ -116,7 +116,7 @@
                        value="{{ image.id }}">
                 {% for error in form.image_id.errors %}
                   <p>
-                    <span style="color: red;">Image: [{{ error }}]</span>
+                    <span class="red">Image: [{{ error }}]</span>
                   </p>
                 {% endfor %}
                 <p>

--- a/OpenOversight/app/templates/incident_list.html
+++ b/OpenOversight/app/templates/incident_list.html
@@ -45,7 +45,7 @@
                     </tr>
                   {% endif %}
                   <tr>
-                    <td colspan="2" style="border-top: 0; ">
+                    <td colspan="2" class="no-border-top">
                       <h3>
                         <a href="{{ url_for('main.incident_api', obj_id=incident.id) }}">
                           Incident

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -65,7 +65,7 @@
             <div class="input-group input-group-lg col-md-4 col-md-offset-4">{{ form.dept(class="form-control") }}</div>
             {% for error in form.dept.errors %}
               <p>
-                <span style="color: red;">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
             <br>
@@ -88,7 +88,7 @@
               {{ form.last_name(class="form-control") }}
               {% for error in form.last_name.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -99,7 +99,7 @@
               {{ form.first_name(class="form-control") }}
               {% for error in form.first_name.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -110,7 +110,7 @@
               {{ form.badge(class="form-control") }}
               {% for error in form.badge.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -122,7 +122,7 @@
                 {{ form.unique_internal_identifier(class="form-control") }}
                 {% for error in form.unique_internal_identifier.errors %}
                   <p>
-                    <span style="color: red;">[{{ error }}]</span>
+                    <span class="red">[{{ error }}]</span>
                   </p>
                 {% endfor %}
               </div>
@@ -149,7 +149,7 @@
               {{ form.rank(class="form-control") }}
               {% for error in form.rank.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -158,7 +158,7 @@
                 <a id="show-img">Show rank shoulder patches as reference</a>
               </p>
             </div>
-            <div id="hidden-img" style="display:none;">
+            <div id="hidden-img" class="no-display">
               <p>
                 <a id="hide-img">Hide rank shoulder patches</a>
               </p>
@@ -173,19 +173,19 @@
               {{ form.unit(class="form-control") }}
               {% for error in form.unit.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
             <h2>
               <small>Currently Employed</small>
             </h2>
-            <span class="text-muted" style="position: relative; top: -0.8em">(in this unit and/or rank, if specified)</span>
+            <span class="text-muted slightly-above">(in this unit and/or rank, if specified)</span>
             <div class="input-group input-group-sm col-md-4 col-md-offset-4">
-              {{ form.current_job(class="form-control", style="box-shadow: none") }}
+              {{ form.current_job(class="form-control no-box-shadow") }}
               {% for error in form.current_job.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -211,7 +211,7 @@
               {{ form.race(class="form-control") }}
               {% for error in form.race.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -222,7 +222,7 @@
               {{ form.gender(class="form-control") }}
               {% for error in form.gender.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -233,12 +233,12 @@
               {{ form.min_age(size=4, class="form-control") }} to {{ form.max_age(size=4, class="form-control") }}
               {% for error in form.min_age.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
               {% for error in form.max_age.errors %}
                 <p>
-                  <span style="color: red;">[{{ error }}]</span>
+                  <span class="red">[{{ error }}]</span>
                 </p>
               {% endfor %}
             </div>
@@ -253,7 +253,7 @@
                      id="user-notification"
                      name="submit-officer-search-form" />
               <img id="loader"
-                   style="display:none"
+                   class="no-display"
                    src="{{ url_for('static', filename='images/page-loader.gif') }}">
             </div>
           </div>

--- a/OpenOversight/app/templates/partials/incident_fields.html
+++ b/OpenOversight/app/templates/partials/incident_fields.html
@@ -65,8 +65,8 @@
         data-incident='{{ incident.id | tojson }}'>{{ incident.description | markdown }}</td>
   </tr>
   <tr id="description-overflow-row_{{ incident.id }}">
-    <td style="border-top: none"></td>
-    <td style="border-top: none"
+    <td class="no-border-top"></td>
+    <td class="no-border-top"
         id="description-overflow-cell_{{ incident.id }}">
       <button id="description-overflow-button_{{ incident.id }}">Click to read more</button>
     </td>

--- a/OpenOversight/app/templates/partials/officer_assignment_history.html
+++ b/OpenOversight/app/templates/partials/officer_assignment_history.html
@@ -69,7 +69,7 @@
             {{ form.star_no }}
             {% for error in form.star_no.errors %}
               <p>
-                <span style="color: red">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
           </td>
@@ -82,7 +82,7 @@
             {{ form.job_title }}
             {% for error in form.job_title.errors %}
               <p>
-                <span style="color: red">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
           </td>
@@ -95,7 +95,7 @@
             {{ form.unit }}
             {% for error in form.unit.errors %}
               <p>
-                <span style="color: red">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
           </td>
@@ -108,7 +108,7 @@
             {{ form.start_date }}
             {% for error in form.start_date.errors %}
               <p>
-                <span style="color: red">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
           </td>
@@ -121,7 +121,7 @@
             {{ form.resign_date }}
             {% for error in form.resign_date.errors %}
               <p>
-                <span style="color: red">[{{ error }}]</span>
+                <span class="red">[{{ error }}]</span>
               </p>
             {% endfor %}
           </td>

--- a/OpenOversight/app/templates/partials/officer_incidents.html
+++ b/OpenOversight/app/templates/partials/officer_incidents.html
@@ -9,7 +9,7 @@
           </tr>
         {% endif %}
         <tr>
-          <td colspan="2" style="border-top: 0; ">
+          <td colspan="2" class="no-border-top">
             <h4>
               <a href="{{ url_for('main.incident_api', obj_id=incident.id) }}">
                 Incident

--- a/OpenOversight/app/templates/partials/subform.html
+++ b/OpenOversight/app/templates/partials/subform.html
@@ -12,8 +12,6 @@
     {% endif %}
   {% endfor %}
   {% if not no_remove %}
-    <button class="btn btn-danger js-remove-button"
-            style="margin-bottom: 2rem"
-            disabled>Remove</button>
+    <button class="btn btn-danger js-remove-button bottom-margin" disabled>Remove</button>
   {% endif %}
 </fieldset>


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commits are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md

If this pull request is not ready for review yet, please submit it as a draft.
-->
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/969

## Description of Changes
Removes the H021 tag and does the relevant clean-up. In this case, inline styles are refactored into external CSS via pre-existing stylesheets.

Unsure of the CSS class names, very open to changes. One in particular I really disliked, but left a note-to-self. Historically more of a back-end dev, so apologies if I missed something obvious with these changes!

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
  
(`pre-commit` technically fails on some .py files and migrations, but none of the new changes it seems)