### PR TITLE
Add missing <img> alt tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,4 +116,4 @@ repos:
           - OpenOversight/app/templates
           - --profile=jinja
           - --use-gitignore
-          - --ignore=H006,T028,H031,H021,H013,H011
+          - --ignore=H006,T028,H031,H011

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -23,6 +23,14 @@ We use [pre-commit](https://pre-commit.com/) for automated linting and style che
 
 You can run `pre-commit run --all-files` or `make lint` to run pre-commit over your local codebase, or `pre-commit run` to run it only over the currently stages files.
 
+### Accessibility
+Keep in mind when adding images that `alt` tags are required for screen readers. If text outside of the image explains what the image is or is referring to, the tag can be an empty string (`alt=""`). The tag can also be empty if the image is decoration and does not add information or context. If the image has text or important information, use the present tense to describe what is happening in the image.
+
+For further reading:
+- https://www.a11yproject.com/
+- https://www.w3.org/WAI/tutorials/images/decision-tree/
+- https://accessibility.huit.harvard.edu/describe-content-images
+
 ## Development Environment
 You can use our Docker-compose environment to stand up a development OpenOversight.
 

--- a/OpenOversight/app/templates/input_find_officer.html
+++ b/OpenOversight/app/templates/input_find_officer.html
@@ -164,7 +164,8 @@
               </p>
               <img src="{{ url_for('static', filename='images/OfficerRank.png') }}"
                    width="50%"
-                   height="50%">
+                   height="50%"
+                   alt="A chart representing officer ranks and their symbols/shoulder patches. Superintendent: Four stars. First Deputy Superintendent: Three stars. Chief: Two stars. Deputy Chief: One star. Commander: A silver oak leaf. Captain: Two parallel vertical bars that can be gold or silver. Lieutenant: A vertical bar that is gold or silver. Sergeant: Three chevrons or stripes. Field Training Officer: A single chevron with a horizontal line across the bottom with the letters FTO inside. The following do not have a symbol or patch: Police Officer/Assigned as: Detective, Youth Officer, Gang Specialist, Police Agent, Major Accident Investigator.">
             </div>
             <h2>
               <small>Officer Unit</small>
@@ -254,7 +255,8 @@
                      name="submit-officer-search-form" />
               <img id="loader"
                    style="display:none"
-                   src="{{ url_for('static', filename='images/page-loader.gif') }}">
+                   src="{{ url_for('static', filename='images/page-loader.gif') }}"
+                   alt="">
             </div>
           </div>
         </div>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -35,7 +35,9 @@
                    src="{{ path }}"
                    alt="{{ face.officer.full_name() | title }}" />
             {% else %}
-              <img id="face-img" src="{{ path }}" alt="" />
+              <img id="face-img"
+                   src="{{ path }}"
+                   alt="{{ face.officer.full_name() | title }}'s profile image" />
             {% endif %}
             <div id="face-tag-frame"></div>
           </div>

--- a/OpenOversight/app/templates/tag.html
+++ b/OpenOversight/app/templates/tag.html
@@ -32,9 +32,10 @@
                    data-top="{{ face.face_position_y }}"
                    data-width="{{ face.face_width }}"
                    data-height="{{ face.face_height }}"
-                   src="{{ path }}" />
+                   src="{{ path }}"
+                   alt="{{ face.officer.full_name() | title }}" />
             {% else %}
-              <img id="face-img" src="{{ path }}" />
+              <img id="face-img" src="{{ path }}" alt="" />
             {% endif %}
             <div id="face-tag-frame"></div>
           </div>

--- a/OpenOversight/app/templates/tutorial.html
+++ b/OpenOversight/app/templates/tutorial.html
@@ -25,7 +25,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/pick_task.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
     </div>
@@ -40,7 +41,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/sort.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
     </div>
@@ -50,7 +52,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/pick_face.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
       <p>
@@ -62,7 +65,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/tag_search.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
       <p>
@@ -73,7 +77,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/officer_found.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
       <p>
@@ -82,7 +87,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/add_face.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
       <p>
@@ -92,7 +98,8 @@
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <img src="{{ url_for('static', filename='images/done.png') }}"
-               class="img-thumbnail img-responsive">
+               class="img-thumbnail img-responsive"
+               alt="">
         </div>
       </div>
       <br>

--- a/OpenOversight/app/templates/tutorial.html
+++ b/OpenOversight/app/templates/tutorial.html
@@ -23,7 +23,7 @@
         In the <a href="{{ url_for("main.get_started_labeling") }}">Volunteer</a> page, you will see under each law enforcement agency links to the two volunteer tasks when logged in:
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/pick_task.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -39,7 +39,7 @@
         If you prefer to skip an image, just click <b>Next Photo</b>.
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/sort.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -50,7 +50,7 @@
       <h3>Task 2: Identify Officers</h3>
       <p>In this task, you will map faces in each image to an entry in our roster.</p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/pick_face.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -63,7 +63,7 @@
         Open the search tool by clicking <b>Launch roster search form</b>.
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/tag_search.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -75,7 +75,7 @@
         Once you find the officer, look at their <b>OpenOversight ID</b> number in green:
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/officer_found.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -85,7 +85,7 @@
         Type this ID into the form next to their selected face, and and click <b>Add identified face</b>:
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/add_face.png') }}"
                class="img-thumbnail img-responsive"
                alt="">
@@ -96,7 +96,7 @@
         officer from the image you are able to, click <b>All officers have been identified</b>:
       </p>
       <div class="row">
-        <div class="col-sm-6 col-md-6">
+        <div class="col-sm-6">
           <img src="{{ url_for('static', filename='images/done.png') }}"
                class="img-thumbnail img-responsive"
                alt="">


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/970

## Description of Changes
Removes H013 from pre-commit ignore list and adds alt tag + text to <img>s where needed. Adds some tips and resources in the CONTRIB.md for folks who encounter this in the future.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.