### PR TITLE
Test code on 🐍 `3.12`

### DIFF
--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -19,7 +19,7 @@ jobs:
       FLASK_APP: OpenOversight.app
     strategy:
       matrix:
-        python-version: ["3.11", "3.12-rc"]
+        python-version: ["3.11", "3.12"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -19,7 +19,7 @@ jobs:
       FLASK_APP: OpenOversight.app
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -19,7 +19,7 @@ jobs:
       FLASK_APP: OpenOversight.app
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12-rc"]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAKE_PYTHON_VERSION
 ARG DOCKER_BUILD_ENV
-FROM python:${MAKE_PYTHON_VERSION:-3.11}-buster
+FROM python:${MAKE_PYTHON_VERSION:-3.11}-slim-bullseye
 
 WORKDIR /usr/src/app
 

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAKE_PYTHON_VERSION
 ARG DOCKER_BUILD_ENV
-FROM python:${MAKE_PYTHON_VERSION:-3.11}-slim-bullseye
+FROM python:${MAKE_PYTHON_VERSION:-3.11}-bullseye
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/1031

## Description of Changes
Update 🐍 version matrix to include `3.12`. At some point I'd like to move the application to `3.12`, but I think now isn't the time.

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
