### PR TITLE
Add default Officer Overtime value

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -171,7 +171,9 @@ class SalaryForm(Form):
         "Salary", validators=[NumberRange(min=0, max=1000000), validate_money]
     )
     overtime_pay = DecimalField(
-        "Overtime Pay", validators=[NumberRange(min=0, max=1000000), validate_money]
+        "Overtime Pay", 
+        default=0,
+        validators=[NumberRange(min=0, max=1000000), validate_money]
     )
     year = IntegerField(
         "Year",

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -171,9 +171,9 @@ class SalaryForm(Form):
         "Salary", validators=[NumberRange(min=0, max=1000000), validate_money]
     )
     overtime_pay = DecimalField(
-        "Overtime Pay", 
+        "Overtime Pay",
         default=0,
-        validators=[NumberRange(min=0, max=1000000), validate_money]
+        validators=[NumberRange(min=0, max=1000000), validate_money],
     )
     year = IntegerField(
         "Year",


### PR DESCRIPTION
## Fixes issue
#856 

## Description of Changes
Adds default of $0 in officer "Overtime Pay" field. Users don't have to fill this in if they don't have any overtime pay information and use the form faster!

## Testing and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
