### PR TITLE
Fix link edit/delete buttons showing when not logged in

### DIFF
--- a/OpenOversight/app/templates/partials/links_and_videos_row.html
+++ b/OpenOversight/app/templates/partials/links_and_videos_row.html
@@ -6,7 +6,7 @@
         {% for link in list %}
           <li class="list-group-item">
             <a href="{{ link.url }}" rel="noopener noreferrer" target="_blank">{{ link.title or link.url }}</a>
-            {% if officer and (is_admin_or_coordinator or link.creator_id == current_user.id) %}
+            {% if officer and (is_admin_or_coordinator or link.created_by == current_user.id) %}
               <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                 <span class="sr-only">Edit</span>
                 <i class="fa-solid fa-pencil-square" aria-hidden="true"></i>
@@ -43,7 +43,7 @@
             <li class="list-group-item">
               {% if link.title %}<h5>{{ link.title }}</h5>{% endif %}
               {% if officer and (current_user.is_admin_or_coordinator(officer.department)
-                or link.creator_id == current_user.id) %}
+                or link.created_by == current_user.id) %}
                 <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                   <span class="sr-only">Edit</span>
                   <i class="fa-solid fa-pencil-square" aria-hidden="true"></i>
@@ -82,7 +82,7 @@
           <li class="list-group-item">
             <a href="{{ link.url }}">{{ link.title or link.url }}</a>
             {% if officer and (current_user.is_admin_or_coordinator(officer.department)
-              or link.creator_id == current_user.id) %}
+              or link.created_by == current_user.id) %}
               <a href="{{ url_for("main.link_api_edit", officer_id=officer.id, obj_id=link.id) }}">
                 <span class="sr-only">Edit</span>
                 <i class="fa-solid fa-pencil-square" aria-hidden="true"></i>


### PR DESCRIPTION
## Fixes issue
Fixes #1085

## Description of Changes
This is a cherry-pick of https://github.com/OrcaCollective/OpenOversight/pull/403

---

Currently, the link edit and delete buttons show up on the officer page when visiting as an anonymous user. (see: https://openoversight.com/officers/83835)

This is NOT a security issue as the user is asked to log in after clicking the link but may be confusing to users.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
