### PR TITLE
Add validation to Incident form

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -516,12 +516,19 @@ class IncidentForm(DateFieldForm):
     # In line validator for the officers field. Check to see if the officers are within the selected department
     def validate_officers(form, field):
         department = form.department.data
+
+        if not department:
+            return
+        
         department_id = department.id
         department_name = department.name
 
         for field_data in field.data:
             officer = Officer.query.get(field_data['oo_id'])
 
+            if not officer:
+                return
+            
             if officer.department.id is not department_id:
                 raise ValidationError(f"Officer {officer.full_name()} (OpenOversight ID: {field_data['oo_id']}) is not in {department_name}")
         

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -515,7 +515,7 @@ class OOIdForm(Form):
 
 class IncidentForm(DateFieldForm):
     # In line validator for the officers field. Check to see if the officers are within the selected department
-    def validate_officers(self, field: FieldList) -> None: 
+    def validate_officers(self, field: FieldList) -> None:
         department = self.department.data
 
         if not department:

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -512,6 +512,7 @@ def validate_oo_id(self, oo_id):
 class OOIdForm(Form):
     oo_id = StringField("OO Officer ID", validators=[validate_oo_id])
 
+
 class IncidentForm(DateFieldForm):
     # In line validator for the officers field. Check to see if the officers are within the selected department
     def validate_officers(form, field):
@@ -519,19 +520,21 @@ class IncidentForm(DateFieldForm):
 
         if not department:
             return
-        
+
         department_id = department.id
         department_name = department.name
 
         for field_data in field.data:
-            officer = Officer.query.get(field_data['oo_id'])
+            officer = Officer.query.get(field_data["oo_id"])
 
             if not officer:
                 return
-            
+
             if officer.department.id is not department_id:
-                raise ValidationError(f"Officer {officer.full_name()} (OpenOversight ID: {field_data['oo_id']}) is not in {department_name}")
-        
+                raise ValidationError(
+                    f"Officer {officer.full_name()} (OpenOversight ID: {field_data['oo_id']}) is not in {department_name}"
+                )
+
     report_number = StringField(
         validators=[
             Regexp(

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -515,8 +515,8 @@ class OOIdForm(Form):
 
 class IncidentForm(DateFieldForm):
     # In line validator for the officers field. Check to see if the officers are within the selected department
-    def validate_officers(form, field):
-        department = form.department.data
+    def validate_officers(self, field: FieldList) -> None: 
+        department = self.department.data
 
         if not department:
             return
@@ -528,7 +528,7 @@ class IncidentForm(DateFieldForm):
             officer = Officer.query.get(field_data["oo_id"])
 
             if not officer:
-                return
+                return None
 
             if officer.department.id is not department_id:
                 raise ValidationError(

--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -512,8 +512,19 @@ def validate_oo_id(self, oo_id):
 class OOIdForm(Form):
     oo_id = StringField("OO Officer ID", validators=[validate_oo_id])
 
-
 class IncidentForm(DateFieldForm):
+    # In line validator for the officers field. Check to see if the officers are within the selected department
+    def validate_officers(form, field):
+        department = form.department.data
+        department_id = department.id
+        department_name = department.name
+
+        for field_data in field.data:
+            officer = Officer.query.get(field_data['oo_id'])
+
+            if officer.department.id is not department_id:
+                raise ValidationError(f"Officer {officer.full_name()} (OpenOversight ID: {field_data['oo_id']}) is not in {department_name}")
+        
     report_number = StringField(
         validators=[
             Regexp(

--- a/OpenOversight/app/templates/partials/incident_form.html
+++ b/OpenOversight/app/templates/partials/incident_form.html
@@ -1,7 +1,7 @@
 {% import "bootstrap/wtf.html" as wtf %}
 <form class="form" method="post" role="form">
   {{ form.hidden_tag() }}
-  <div class="text-danger">{{ wtf.form_errors(form, hiddens="only") }}</div>
+  <div class="text-danger">{{ wtf.form_errors(form) }}</div>
   {{ wtf.form_field(form.date_field, autofocus="autofocus") }}
   {{ wtf.form_field(form.time_field) }}
   {{ wtf.form_field(form.report_number) }}

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -139,6 +139,7 @@ def test_admins_cannot_create_incident_with_invalid_report_number(
             ENCODING_UTF_8
         )
 
+
 def test_cannot_create_incident_with_invalid_officer():
     with current_app.test_request_context():
         test_date = datetime(2000, 5, 25, 1, 45)
@@ -148,14 +149,14 @@ def test_cannot_create_incident_with_invalid_officer():
             cross_street1="BBBBB",
             city="FFFFF",
             state="IA",
-            zip_code="03435"
+            zip_code="03435",
         )
 
-        department = Department.query.filter_by(id = "1").first()
+        department = Department.query.filter_by(id="1").first()
 
         # These officers are from different departments
-        officer_1 = Officer.query.filter_by(department_id = "1").first()
-        officer_2 = Officer.query.filter_by(department_id = "2").first()
+        officer_1 = Officer.query.filter_by(department_id="1").first()
+        officer_2 = Officer.query.filter_by(department_id="2").first()
 
         form = IncidentForm(
             date_field=test_date.date(),
@@ -168,6 +169,7 @@ def test_cannot_create_incident_with_invalid_officer():
         )
 
         assert form.validate() is False
+
 
 def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
     with current_app.test_request_context():

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -139,6 +139,35 @@ def test_admins_cannot_create_incident_with_invalid_report_number(
             ENCODING_UTF_8
         )
 
+def test_cannot_create_incident_with_invalid_officer():
+    with current_app.test_request_context():
+        test_date = datetime(2000, 5, 25, 1, 45)
+
+        address_form = LocationForm(
+            street_name="AAAAA",
+            cross_street1="BBBBB",
+            city="FFFFF",
+            state="IA",
+            zip_code="03435"
+        )
+
+        department = Department.query.filter_by(id = "1").first()
+
+        # These officers are from different departments
+        officer_1 = Officer.query.filter_by(department_id = "1").first()
+        officer_2 = Officer.query.filter_by(department_id = "2").first()
+
+        form = IncidentForm(
+            date_field=test_date.date(),
+            time_field=test_date.time(),
+            report_number="42",
+            description="Something happened",
+            department=department,
+            address=address_form.data,
+            officers=[officer_1, officer_2],
+        )
+
+        assert form.validate() is False
 
 def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
     with current_app.test_request_context():


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commits are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md

If this pull request is not ready for review yet, please submit it as a draft.

Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the
dispatcher where…", "Improve our handling of…", etc.
-->
## Fixes issue

Fixes #839 

## Description of Changes

Adds inline validator to `IncidentForm` that checks to see if the officer entities linked to the instance are in the same department as the incident.

## Notes for Deployment


## Screenshots (if appropriate)
![Screen Shot 2024-01-11 at 2 25 45 AM](https://github.com/lucyparsons/OpenOversight/assets/17299952/c4d2b805-bf33-415c-b0a1-b34b7242a456)


## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
