### PR TITLE
Fix issue where carousel controls were no longer showing up

### DIFF
--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -18,7 +18,7 @@
       </div>
     {% endfor %}
   </div>
-  {% if paths | length > 1 %}
+  {% if face_paths | length > 1 %}
     <a class="left carousel-control"
        href="#face-carousel"
        role="button"


### PR DESCRIPTION
<!-- New Contributor? Welcome!

We recommend you check your privacy settings, so the name and email associated with
the commits are what you want them to be. See the contribution guide at
https://github.com/lucyparsons/OpenOversight/blob/develop/CONTRIB.md#recommended-privacy-settings for more infos.

Also make sure you have read and abide by the code of conduct:
https://github.com/lucyparsons/OpenOversight/blob/develop/CODE_OF_CONDUCT.md

If this pull request is not ready for review yet, please submit it as a draft.

Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the
dispatcher where…", "Improve our handling of…", etc.
-->

## Description of Changes
Copied over from https://github.com/OrcaCollective/OpenOversight/pull/409

The carousel controls are not showing up.

This was caused by a commit that changed `paths` to `face_paths`
https://github.com/lucyparsons/OpenOversight/pull/1070/files#diff-cb0d1be5137549bba7d2d657912ea708497d8a757e0623cb76d9d5557fe484e5

But the line controlling whether we show carousel controls is still using `paths`.
https://github.com/OrcaCollective/OpenOversight/blob/7bf658c8d431d2db12154ba5c90017d46f19cf14/OpenOversight/app/templates/partials/officer_faces.html#L21

This commit fixes this issue.

## Notes for Deployment
N/A

## Screenshots (if appropriate)


## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
