### PR TITLE
Remove broken DB details link

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -5,5 +5,3 @@ Running `make dev` in the docker environment will create and persist the databas
 
 ## Database Diagram
 ![](database_relationships.Sept2023.png)
-
-See more detailed database schema information [here](https://disman.tl/oo-docs/).


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/1091

## Description of Changes
Removed a link to a non-existent page. Since the schema underwent significant changes over the last summer, it's likely that even if they link was active it wouldn't be up date date. The current picture in the `README` gives an in-depth look at the relationships between tables, etc.  What we have now should be sufficient.