### PR TITLE
Remove `jsonify` and use `Response`

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -3,7 +3,7 @@ import os
 from http import HTTPStatus
 from logging.handlers import RotatingFileHandler
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, Response, render_template, request
 from flask_bootstrap import Bootstrap
 from flask_compress import Compress
 from flask_limiter import Limiter
@@ -92,7 +92,7 @@ def create_app(config_name="default"):
 
         def _handler_method(e):
             if request.accept_mimetypes.best == "application/json":
-                return jsonify(error=error), code
+                return Response(error, status=code)
             return render_template(template), code
 
         return _handler_method

--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -3,7 +3,7 @@ import os
 from http import HTTPStatus
 from logging.handlers import RotatingFileHandler
 
-from flask import Flask, Response, render_template, request
+from flask import Flask, render_template, request
 from flask_bootstrap import Bootstrap
 from flask_compress import Compress
 from flask_limiter import Limiter
@@ -92,7 +92,7 @@ def create_app(config_name="default"):
 
         def _handler_method(e):
             if request.accept_mimetypes.best == "application/json":
-                return Response(error, status=code)
+                return error, code
             return render_template(template), code
 
         return _handler_method

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -376,10 +376,7 @@ def redirect_add_assignment(officer_id: int):
     )
 
 
-@main.route(
-    "/officers/<int:officer_id>/assignments/new",
-    methods=[HTTPMethod.POST],
-)
+@main.route("/officers/<int:officer_id>/assignments/new", methods=[HTTPMethod.POST])
 @ac_or_admin_required
 def add_assignment(officer_id: int):
     form = AssignmentForm()

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -366,7 +366,7 @@ def sitemap_officers():
 
 @main.route(
     "/officer/<int:officer_id>/assignment/new",
-    methods=[HTTPMethod.GET, HTTPMethod.POST],
+    methods=[HTTPMethod.POST],
 )
 @ac_or_admin_required
 def redirect_add_assignment(officer_id: int):
@@ -378,7 +378,7 @@ def redirect_add_assignment(officer_id: int):
 
 @main.route(
     "/officers/<int:officer_id>/assignments/new",
-    methods=[HTTPMethod.GET, HTTPMethod.POST],
+    methods=[HTTPMethod.POST],
 )
 @ac_or_admin_required
 def add_assignment(officer_id: int):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -277,12 +277,12 @@ def sort_images(department_id: int):
 
 
 @sitemap_include
-@main.route("/tutorial")
+@main.route("/tutorial", methods=[HTTPMethod.GET])
 def get_tutorial():
     return render_template("tutorial.html")
 
 
-@main.route("/user/<username>")
+@main.route("/user/<username>", methods=[HTTPMethod.GET])
 @login_required
 def profile(username: str):
     if re.search("^[A-Za-z][A-Za-z0-9_.]*$", username):
@@ -376,7 +376,10 @@ def redirect_add_assignment(officer_id: int):
     )
 
 
-@main.route("/officers/<int:officer_id>/assignments/new", methods=[HTTPMethod.POST])
+@main.route(
+    "/officers/<int:officer_id>/assignments/new",
+    methods=[HTTPMethod.GET, HTTPMethod.POST],
+)
 @ac_or_admin_required
 def add_assignment(officer_id: int):
     form = AssignmentForm()
@@ -578,7 +581,7 @@ def edit_salary(officer_id: int, salary_id: int):
     return render_template("add_edit_salary.html", form=form, update=True)
 
 
-@main.route("/image/<int:image_id>")
+@main.route("/image/<int:image_id>", methods=[HTTPMethod.GET])
 @login_required
 def redirect_display_submission(image_id: int):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
@@ -588,7 +591,7 @@ def redirect_display_submission(image_id: int):
     )
 
 
-@main.route("/images/<int:image_id>")
+@main.route("/images/<int:image_id>", methods=[HTTPMethod.GET])
 @login_required
 def display_submission(image_id: int):
     try:
@@ -599,7 +602,7 @@ def display_submission(image_id: int):
     return render_template("image.html", image=image, path=proper_path)
 
 
-@main.route("/tag/<int:tag_id>")
+@main.route("/tag/<int:tag_id>", methods=[HTTPMethod.GET])
 def redirect_display_tag(tag_id: int):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
@@ -608,7 +611,7 @@ def redirect_display_tag(tag_id: int):
     )
 
 
-@main.route("/tags/<int:tag_id>")
+@main.route("/tags/<int:tag_id>", methods=[HTTPMethod.GET])
 def display_tag(tag_id: int):
     try:
         tag = Face.query.filter_by(id=tag_id).one()
@@ -840,7 +843,7 @@ def edit_department(department_id: int):
         )
 
 
-@main.route("/department/<int:department_id>")
+@main.route("/department/<int:department_id>", methods=[HTTPMethod.GET])
 def redirect_list_officer(
     department_id: int,
     page: int = 1,
@@ -880,7 +883,7 @@ def redirect_list_officer(
     )
 
 
-@main.route("/departments/<int:department_id>")
+@main.route("/departments/<int:department_id>", methods=[HTTPMethod.GET])
 def list_officer(
     department_id: int,
     page: int = 1,
@@ -1330,7 +1333,7 @@ def set_featured_tag(tag_id: int):
     return redirect(url_for("main.officer_profile", officer_id=tag.officer_id))
 
 
-@main.route("/leaderboard")
+@main.route("/leaderboard", methods=[HTTPMethod.GET])
 @login_required
 def leaderboard():
     top_sorters, top_taggers = compute_leaderboard_stats()
@@ -1468,7 +1471,7 @@ def label_data(department_id: int = 0, image_id: int = 0):
     )
 
 
-@main.route("/image/tagged/<int:image_id>")
+@main.route("/image/tagged/<int:image_id>", methods=[HTTPMethod.GET])
 @login_required
 def redirect_complete_tagging(image_id: int):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
@@ -1478,7 +1481,7 @@ def redirect_complete_tagging(image_id: int):
     )
 
 
-@main.route("/images/tagged/<int:image_id>")
+@main.route("/images/tagged/<int:image_id>", methods=[HTTPMethod.GET])
 @login_required
 def complete_tagging(image_id: int):
     # Select a random untagged image from the database
@@ -1908,13 +1911,13 @@ def upload(department_id: int = 0, officer_id: int = 0):
 
 
 @sitemap_include
-@main.route("/about")
+@main.route("/about", methods=[HTTPMethod.GET])
 def about_oo():
     return render_template("about.html")
 
 
 @sitemap_include
-@main.route("/privacy")
+@main.route("/privacy", methods=[HTTPMethod.GET])
 def privacy_oo():
     return render_template("privacy.html")
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -7,7 +7,6 @@ from traceback import format_exc
 from typing import Optional
 
 from flask import (
-    Response,
     abort,
     current_app,
     flash,
@@ -163,7 +162,7 @@ def set_session_timezone():
             session[KEY_TIMEZONE] = timezone
         else:
             session[KEY_TIMEZONE] = current_app.config.get(KEY_TIMEZONE)
-    return Response("User timezone saved", status=HTTPStatus.OK)
+    return "User timezone saved", HTTPStatus.OK
 
 
 @sitemap_include
@@ -1057,7 +1056,7 @@ def list_officer(
     )
 
 
-@main.route("/department/<int:department_id>/ranks")
+@main.route("/department/<int:department_id>/ranks", methods=[HTTPMethod.GET])
 def redirect_get_dept_ranks(department_id: int = 0, is_sworn_officer: bool = False):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
@@ -1070,8 +1069,8 @@ def redirect_get_dept_ranks(department_id: int = 0, is_sworn_officer: bool = Fal
     )
 
 
-@main.route("/departments/<int:department_id>/ranks")
-@main.route("/ranks")
+@main.route("/departments/<int:department_id>/ranks", methods=[HTTPMethod.GET])
+@main.route("/ranks", methods=[HTTPMethod.GET])
 def get_dept_ranks(department_id: int = 0, is_sworn_officer: bool = False):
     if not department_id:
         department_id = request.args.get("department_id")
@@ -1093,10 +1092,10 @@ def get_dept_ranks(department_id: int = 0, is_sworn_officer: bool = False):
             key=lambda x: x[1],
         )
 
-    return rank_list
+    return rank_list, HTTPStatus.OK
 
 
-@main.route("/department/<int:department_id>/units")
+@main.route("/department/<int:department_id>/units", methods=[HTTPMethod.GET])
 def redirect_get_dept_units(department_id: int = 0):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
@@ -1105,8 +1104,8 @@ def redirect_get_dept_units(department_id: int = 0):
     )
 
 
-@main.route("/departments/<int:department_id>/units")
-@main.route("/units")
+@main.route("/departments/<int:department_id>/units", methods=[HTTPMethod.GET])
+@main.route("/units", methods=[HTTPMethod.GET])
 def get_dept_units(department_id: int = 0):
     if not department_id:
         department_id = request.args.get("department_id")
@@ -1123,7 +1122,7 @@ def get_dept_units(department_id: int = 0):
             key=lambda x: x[1],
         )
 
-    return unit_list
+    return unit_list, HTTPStatus.OK
 
 
 @main.route("/officer/new", methods=[HTTPMethod.GET, HTTPMethod.POST])
@@ -1860,7 +1859,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
     if officer_id:
         officer = Officer.query.filter_by(id=officer_id).first()
         if not officer:
-            return Response("This officer does not exist.", status=HTTPStatus.NOT_FOUND)
+            return "This officer does not exist.", HTTPStatus.NOT_FOUND
         if not (
             current_user.is_administrator
             or (
@@ -1869,18 +1868,12 @@ def upload(department_id: int = 0, officer_id: int = 0):
             )
         ):
             return (
-                Response(
-                    "You are not authorized to upload photos of this officer.",
-                    status=HTTPStatus.FORBIDDEN,
-                ),
+                "You are not authorized to upload photos of this officer.",
+                HTTPStatus.FORBIDDEN,
             )
     file_to_upload = request.files["file"]
     if not allowed_file(file_to_upload.filename):
-        return (
-            Response(
-                "File type not allowed!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE
-            ),
-        )
+        return ("File type not allowed!", HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
 
     try:
         image = save_image_to_s3_and_db(
@@ -1888,7 +1881,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
         )
     except ValueError:
         # Raised if MIME type not allowed
-        return Response("Invalid data type!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        return "Invalid data type!", HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
     if image:
         db.session.add(image)
@@ -1906,13 +1899,11 @@ def upload(department_id: int = 0, officer_id: int = 0):
             )
             db.session.add(face)
             db.session.commit()
-        return Response("Success!", status=HTTPStatus.OK)
+        return "Success!", HTTPStatus.OK
     else:
         return (
-            Response(
-                "Server error encountered. Try again later.",
-                status=HTTPStatus.INTERNAL_SERVER_ERROR,
-            ),
+            "Server error encountered. Try again later.",
+            HTTPStatus.INTERNAL_SERVER_ERROR,
         )
 
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1870,13 +1870,16 @@ def upload(department_id: int = 0, officer_id: int = 0):
         ):
             return (
                 Response(
-                    "You are not authorized to upload photos of this officer.", status=HTTPStatus.FORBIDDEN
+                    "You are not authorized to upload photos of this officer.",
+                    status=HTTPStatus.FORBIDDEN,
                 ),
             )
     file_to_upload = request.files["file"]
     if not allowed_file(file_to_upload.filename):
         return (
-            Response("File type not allowed!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE),
+            Response(
+                "File type not allowed!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+            ),
         )
 
     try:
@@ -1906,7 +1909,10 @@ def upload(department_id: int = 0, officer_id: int = 0):
         return Response("Success!", status=HTTPStatus.OK)
     else:
         return (
-            Response("Server error encountered. Try again later.", status=HTTPStatus.INTERNAL_SERVER_ERROR),
+            Response(
+                "Server error encountered. Try again later.",
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+            ),
         )
 
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -148,8 +148,8 @@ def redirect_url(default="main.index"):
 
 
 @sitemap_include
-@main.route("/")
-@main.route("/index")
+@main.route("/", methods=[HTTPMethod.GET])
+@main.route("/index", methods=[HTTPMethod.GET])
 def index():
     return render_template("index.html")
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1873,7 +1873,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
             )
     file_to_upload = request.files["file"]
     if not allowed_file(file_to_upload.filename):
-        return ("File type not allowed!", HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        return "File type not allowed!", HTTPStatus.UNSUPPORTED_MEDIA_TYPE
 
     try:
         image = save_image_to_s3_and_db(

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -11,7 +11,6 @@ from flask import (
     abort,
     current_app,
     flash,
-    jsonify,
     redirect,
     render_template,
     request,
@@ -1094,7 +1093,7 @@ def get_dept_ranks(department_id: int = 0, is_sworn_officer: bool = False):
             key=lambda x: x[1],
         )
 
-    return jsonify(rank_list)
+    return rank_list
 
 
 @main.route("/department/<int:department_id>/units")
@@ -1124,7 +1123,7 @@ def get_dept_units(department_id: int = 0):
             key=lambda x: x[1],
         )
 
-    return jsonify(unit_list)
+    return unit_list
 
 
 @main.route("/officer/new", methods=[HTTPMethod.GET, HTTPMethod.POST])
@@ -1861,7 +1860,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
     if officer_id:
         officer = Officer.query.filter_by(id=officer_id).first()
         if not officer:
-            return jsonify(error="This officer does not exist."), HTTPStatus.NOT_FOUND
+            return Response("This officer does not exist.", status=HTTPStatus.NOT_FOUND)
         if not (
             current_user.is_administrator
             or (
@@ -1870,16 +1869,14 @@ def upload(department_id: int = 0, officer_id: int = 0):
             )
         ):
             return (
-                jsonify(
-                    error="You are not authorized to upload photos of this officer."
+                Response(
+                    "You are not authorized to upload photos of this officer.", status=HTTPStatus.FORBIDDEN
                 ),
-                HTTPStatus.FORBIDDEN,
             )
     file_to_upload = request.files["file"]
     if not allowed_file(file_to_upload.filename):
         return (
-            jsonify(error="File type not allowed!"),
-            HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+            Response("File type not allowed!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE),
         )
 
     try:
@@ -1888,7 +1885,7 @@ def upload(department_id: int = 0, officer_id: int = 0):
         )
     except ValueError:
         # Raised if MIME type not allowed
-        return jsonify(error="Invalid data type!"), HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+        return Response("Invalid data type!", status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
 
     if image:
         db.session.add(image)
@@ -1906,11 +1903,10 @@ def upload(department_id: int = 0, officer_id: int = 0):
             )
             db.session.add(face)
             db.session.commit()
-        return jsonify(success="Success!"), HTTPStatus.OK
+        return Response("Success!", status=HTTPStatus.OK)
     else:
         return (
-            jsonify(error="Server error encountered. Try again later."),
-            HTTPStatus.INTERNAL_SERVER_ERROR,
+            Response("Server error encountered. Try again later.", status=HTTPStatus.INTERNAL_SERVER_ERROR),
         )
 
 


### PR DESCRIPTION
## Description of Changes
Flask automatically renders the `Response` as JSON, so the `jsonify` function is redundant. Added missing `HTTPMethods` as well.

## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
