### PR TITLE
Replace `flake8` with `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,14 +76,16 @@ repos:
           args:
             - --quiet
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
     hooks:
-        - id: flake8
-          args:
-            - --ignore=E203,E402,E501,E800,W503,W391,E261,W504
-            - --select=B,C,E,F,W,T4,B9
-            - --exclude=./OpenOversight/app/db_repository/versions/
+      - id: ruff
+        types_or: [python, pyi, jupyter]
+        args:
+          - --fix
+          - --select=B,C,E,F,W
+          - --ignore=E203,E402,E501,W391,E261
+          - --exclude=./OpenOversight/app/db_repository/versions/
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
         args:
           - --fix
           - --select=B,C,E,F,W
-          - --ignore=E203,E402,E501,W391,E261
+          - --ignore=C901,E203,E402,E501,W391,E261
           - --exclude=./OpenOversight/app/db_repository/versions/
 
   - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,6 @@ repos:
           - --fix
           - --select=B,C,E,F,W
           - --ignore=C901,E203,E402,E501,W391,E261
-          - --exclude=./OpenOversight/app/db_repository/versions/
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -352,7 +352,9 @@ def process_assignment(row, officer, compare=False):
                         current
                         and field_name in row
                         and is_equal(row[field_name], current)
-                    ) or (not current and (field_name not in row or not row[field_name])):
+                    ) or (
+                        not current and (field_name not in row or not row[field_name])
+                    ):
                         i += 1
                 if i == len(assignment_field_names):
                     job_title = job.job_title

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -230,7 +230,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                     new_value = parse(row[field_name])
                     if isinstance(old_value, date):
                         new_value = new_value.date()
-                except Exception as e:
+                except Exception as err:
                     msg = (
                         'Field {} is a date-type, but "{}" was specified for '
                         "Officer {} {} and cannot be parsed as a date-type.\nError "
@@ -239,10 +239,10 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                             row[field_name],
                             officer.first_name,
                             officer.last_name,
-                            e,
+                            err,
                         )
                     )
-                    raise Exception(msg) from e
+                    raise Exception(msg) from err
             else:
                 new_value = row[field_name]
             if old_value is None:

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -230,7 +230,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                     new_value = parse(row[field_name])
                     if isinstance(old_value, date):
                         new_value = new_value.date()
-                except ValueError as err:
+                except ValueError as e:
                     msg = (
                         'Field {} is a date-type, but "{}" was specified for '
                         "Officer {} {} and cannot be parsed as a date-type.\nError "
@@ -242,7 +242,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                             e,
                         )
                     )
-                    raise Exception(msg) from err
+                    raise Exception(msg) from e
             else:
                 new_value = row[field_name]
             if old_value is None:

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -230,7 +230,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                     new_value = parse(row[field_name])
                     if isinstance(old_value, date):
                         new_value = new_value.date()
-                except ValueError as e:
+                except ValueError as err:
                     msg = (
                         'Field {} is a date-type, but "{}" was specified for '
                         "Officer {} {} and cannot be parsed as a date-type.\nError "
@@ -242,7 +242,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                             e,
                         )
                     )
-                    raise Exception(msg)
+                    raise Exception(msg) from err
             else:
                 new_value = row[field_name]
             if old_value is None:

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -230,7 +230,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                     new_value = parse(row[field_name])
                     if isinstance(old_value, date):
                         new_value = new_value.date()
-                except Exception as e:
+                except ValueError as e:
                     msg = (
                         'Field {} is a date-type, but "{}" was specified for '
                         "Officer {} {} and cannot be parsed as a date-type.\nError "

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -194,11 +194,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
         ):
             ImportLog.log_change(
                 officer,
-                "Updated {}: {} --> {}".format(
-                    officer_field_name,
-                    getattr(officer, officer_field_name),
-                    row[officer_field_name],
-                ),
+                f"Updated {officer_field_name}: {getattr(officer, officer_field_name)} --> {row[officer_field_name]}",
             )
             setattr(officer, officer_field_name, row[officer_field_name])
 
@@ -232,15 +228,10 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                         new_value = new_value.date()
                 except Exception as err:
                     msg = (
-                        'Field {} is a date-type, but "{}" was specified for '
-                        "Officer {} {} and cannot be parsed as a date-type.\nError "
-                        "message from dateutil: {}".format(
-                            field_name,
-                            row[field_name],
-                            officer.first_name,
-                            officer.last_name,
-                            err,
-                        )
+                        f'Field {field_name} is a date-type, but "{row[field_name]}"'
+                        f" was specified for Officer {officer.first_name} "
+                        f"{officer.last_name} and cannot be parsed as a "
+                        f"date-type.\nError message from dateutil: {err}"
                     )
                     raise Exception(msg) from err
             else:
@@ -248,12 +239,10 @@ def update_officer_from_row(row, officer, update_static_fields=False):
             if old_value is None:
                 update_officer_field(field_name)
             elif str(old_value) != str(new_value):
-                msg = "Officer {} {} has differing {} field. Old: {}, new: {}".format(
-                    officer.first_name,
-                    officer.last_name,
-                    field_name,
-                    old_value,
-                    new_value,
+                msg = (
+                    f"Officer {officer.first_name} {officer.last_name} has "
+                    f"differing {field_name} field. Old: {old_value}, "
+                    f"new: {new_value}"
                 )
                 if update_static_fields:
                     print(msg)
@@ -539,9 +528,8 @@ def bulk_add_officers(filename, no_create, update_by_name, update_static_fields)
                     )
                 else:
                     raise Exception(
-                        "Officer {} {} missing badge number and unique identifier".format(
-                            row["first_name"], row["last_name"]
-                        )
+                        f"Officer {row['first_name']} {row['last_name']} "
+                        "missing badge number and unique identifier"
                     )
             else:
                 officer = Officer.query.filter_by(

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -338,23 +338,23 @@ def process_assignment(row, officer, compare=False):
                 .all()
             )
             for assignment, job in assignments:
-                assignment_fieldnames = [
+                assignment_field_names = [
                     "star_no",
                     "unit_id",
                     "start_date",
                     "resign_date",
                 ]
                 i = 0
-                for fieldname in assignment_fieldnames:
-                    current = getattr(assignment, fieldname)
+                for field_name in assignment_field_names:
+                    current = getattr(assignment, field_name)
                     # Test if fields match between row and existing assignment
                     if (
                         current
-                        and fieldname in row
-                        and is_equal(row[fieldname], current)
-                    ) or (not current and (fieldname not in row or not row[fieldname])):
+                        and field_name in row
+                        and is_equal(row[field_name], current)
+                    ) or (not current and (field_name not in row or not row[field_name])):
                         i += 1
-                if i == len(assignment_fieldnames):
+                if i == len(assignment_field_names):
                     job_title = job.job_title
                     if (
                         job_title and row.get("job_title", "Not Sure") == job_title

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -230,7 +230,7 @@ def update_officer_from_row(row, officer, update_static_fields=False):
                     new_value = parse(row[field_name])
                     if isinstance(old_value, date):
                         new_value = new_value.date()
-                except ValueError as e:
+                except Exception as e:
                     msg = (
                         'Field {} is a date-type, but "{}" was specified for '
                         "Officer {} {} and cannot be parsed as a date-type.\nError "

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -373,10 +373,7 @@ def process_assignment(row, officer, compare=False):
                 num_existing_ranks = len(
                     Job.query.filter_by(department_id=officer.department_id).all()
                 )
-                if num_existing_ranks > 0:
-                    auto_order = num_existing_ranks + 1
-                else:
-                    auto_order = 0
+                auto_order = num_existing_ranks + 1 if num_existing_ranks > 0 else 0
                 # create new job
                 job = Job(
                     is_sworn_officer=False,

--- a/OpenOversight/app/commands.py
+++ b/OpenOversight/app/commands.py
@@ -373,7 +373,10 @@ def process_assignment(row, officer, compare=False):
                 num_existing_ranks = len(
                     Job.query.filter_by(department_id=officer.department_id).all()
                 )
-                auto_order = num_existing_ranks + 1 if num_existing_ranks > 0 else 0
+                if num_existing_ranks > 0:
+                    auto_order = num_existing_ranks + 1
+                else:
+                    auto_order = 0
                 # create new job
                 job = Job(
                     is_sworn_officer=False,

--- a/OpenOversight/app/csv_imports.py
+++ b/OpenOversight/app/csv_imports.py
@@ -214,7 +214,7 @@ def _handle_assignments_csv(
             if len(wrong_department) > 0:
                 raise Exception(
                     f"Referenced {len(wrong_department)} officers in assignment "
-                    "csv that belong to different department. Example ids"
+                    "csv that belong to different department. Example IDs"
                     f": {', '.join(map(str, list(wrong_department)[:3]))}"
                 )
             print(

--- a/OpenOversight/app/csv_imports.py
+++ b/OpenOversight/app/csv_imports.py
@@ -213,16 +213,12 @@ def _handle_assignments_csv(
             }
             if len(wrong_department) > 0:
                 raise Exception(
-                    "Referenced {} officers in assignment csv that belong to different "
-                    "department. Example ids: {}".format(
-                        len(wrong_department),
-                        ", ".join(map(str, list(wrong_department)[:3])),
-                    )
+                    f"Referenced {len(wrong_department)} officers in assignment "
+                    "csv that belong to different department. Example ids"
+                    f": {', '.join(map(str, list(wrong_department)[:3]))}"
                 )
             print(
-                "Deleting assignments from {} officers to overwrite.".format(
-                    len(all_rel_officers)
-                )
+                f"Deleting assignments from {len(all_rel_officers)} officers to overwrite."
             )
             (
                 db.session.query(Assignment)
@@ -245,9 +241,7 @@ def _handle_assignments_csv(
             officer = all_officers.get(row["officer_id"])
             if not officer:
                 raise Exception(
-                    "Officer with id {} does not exist (in this department)".format(
-                        row["officer_id"]
-                    )
+                    f"Officer with id {row['officer_id']} does not exist (in this department)"
                 )
             if row.get("unit_id"):
                 assert (
@@ -331,9 +325,7 @@ def _handle_salaries(
             officer = all_officers.get(row["officer_id"])
             if not officer:
                 raise Exception(
-                    "Officer with id {} does not exist (in this department)".format(
-                        row["officer_id"]
-                    )
+                    f"Officer with id {row['officer_id']} does not exist (in this department)"
                 )
             row["officer_id"] = officer.id
             _create_or_update_model(

--- a/OpenOversight/app/csv_imports.py
+++ b/OpenOversight/app/csv_imports.py
@@ -208,9 +208,9 @@ def _handle_assignments_csv(
                 officer_id = row["officer_id"]
                 if officer_id != "" and officer_id[0] != "#":
                     all_rel_officers.add(int(officer_id))
-            wrong_department = all_rel_officers - set(
-                [int(oid) for oid in all_officers.keys() if oid[0] != "#"]
-            )
+            wrong_department = all_rel_officers - {
+                int(oid) for oid in all_officers.keys() if oid[0] != "#"
+            }
             if len(wrong_department) > 0:
                 raise Exception(
                     "Referenced {} officers in assignment csv that belong to different "

--- a/OpenOversight/app/formfields.py
+++ b/OpenOversight/app/formfields.py
@@ -36,6 +36,6 @@ class TimeField(StringField):
                 else:
                     raise ValueError
                 self.data = datetime.time(hour, minutes, seconds)
-            except ValueError:
+            except ValueError as err:
                 self.data = None
-                raise ValueError(self.gettext("Not a valid time"))
+                raise ValueError(self.gettext("Not a valid time")) from err

--- a/OpenOversight/app/formfields.py
+++ b/OpenOversight/app/formfields.py
@@ -19,9 +19,9 @@ class TimeField(StringField):
         else:
             return self.data and self.data.strftime(self.format) or ""
 
-    def process_formdata(self, valuelist):
-        if valuelist and valuelist != [""]:
-            time_str = " ".join(valuelist)
+    def process_formdata(self, values):
+        if values and values != [""]:
+            time_str = " ".join(values)
             try:
                 components = time_str.split(":")
                 hour = 0

--- a/OpenOversight/app/main/model_view.py
+++ b/OpenOversight/app/main/model_view.py
@@ -217,7 +217,7 @@ class ModelView(MethodView):
         form.populate_obj(obj)
 
         # if the object doesn't have a creator id set it to current user
-        if hasattr(obj, "created_by") and not getattr(obj, "created_by"):
+        if hasattr(obj, "created_by") and not obj.created_by:
             obj.created_by = current_user.id
         # if the object keeps track of who updated it last, set to current user
         if hasattr(obj, "last_updated_by"):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1087,7 +1087,7 @@ def get_dept_ranks(department_id: Optional[int] = None, is_sworn_officer: bool =
         ranks = Job.query.all()
         # Prevent duplicate ranks
         rank_list = sorted(
-            set((rank.id, rank.job_title) for rank in ranks),
+            {(rank.id, rank.job_title) for rank in ranks},
             key=lambda x: x[1],
         )
 
@@ -1117,7 +1117,7 @@ def get_dept_units(department_id: Optional[int] = None):
         units = Unit.query.all()
         # Prevent duplicate units
         unit_list = sorted(
-            set((unit.id, unit.description) for unit in units),
+            {(unit.id, unit.description) for unit in units},
             key=lambda x: x[1],
         )
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -456,7 +456,7 @@ def edit_assignment(officer_id: int, assignment_id: int):
     )
     form.job_title.data = Job.query.filter_by(id=assignment.job_id).one()
     form.unit.query = unit_choices(officer.department_id)
-    if form.unit.data and type(form.unit.data) == int:
+    if form.unit.data and isinstance(form.unit.data, int):
         form.unit.data = Unit.query.filter_by(id=form.unit.data).one()
     if form.validate_on_submit():
         form.job_title.data = Job.query.filter_by(

--- a/OpenOversight/app/utils/cloud.py
+++ b/OpenOversight/app/utils/cloud.py
@@ -111,8 +111,8 @@ def save_image_to_s3_and_db(image_buf, user_id, department_id=None):
     image_buf.seek(0)
     try:
         pimage = Pimage.open(image_buf)
-    except UnidentifiedImageError:
-        raise ValueError("Attempted to pass an invalid image.")
+    except UnidentifiedImageError as err:
+        raise ValueError("Attempted to pass an invalid image.") from err
     image_format = pimage.format.lower()
     if image_format not in current_app.config[KEY_ALLOWED_EXTENSIONS]:
         raise ValueError(f"Attempted to pass invalid data type: {image_format}")

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -170,35 +170,32 @@ def create_incident(self, form: IncidentForm, user: User) -> Incident:
             db.session.add(location)
         address_model = location
 
-    if "officers" in form.data:
-        for officer in form.data["officers"]:
-            if officer["oo_id"]:
-                of = Officer.query.filter_by(id=int(officer["oo_id"])).one()
-                if of:
-                    officers.append(of)
+    form_officers = [o for o in form.data["officers"] if o["oo_id"]]
+    for officer in form_officers:
+        of = Officer.query.filter_by(id=int(officer["oo_id"])).one()
+        if of:
+            officers.append(of)
 
-    if "license_plates" in form.data:
-        for plate in form.data["license_plates"]:
-            if plate["number"]:
-                lp = LicensePlate.query.filter_by(
-                    number=if_exists_or_none(plate["number"]),
-                    state=if_exists_or_none(plate["state"]),
-                ).first()
-                if not lp:
-                    lp = LicensePlate(
-                        number=if_exists_or_none(plate["number"]),
-                        state=if_exists_or_none(plate["state"]),
-                        created_by=user.id,
-                        last_updated_by=user.id,
-                    )
-                    db.session.add(lp)
-                license_plates.append(lp)
+    form_plates = [p for p in form.data["license_plates"] if p["number"]]
+    for plate in form_plates:
+        lp = LicensePlate.query.filter_by(
+            number=if_exists_or_none(plate["number"]),
+            state=if_exists_or_none(plate["state"]),
+        ).first()
+        if not lp:
+            lp = LicensePlate(
+                number=if_exists_or_none(plate["number"]),
+                state=if_exists_or_none(plate["state"]),
+                created_by=user.id,
+                last_updated_by=user.id,
+            )
+            db.session.add(lp)
+        license_plates.append(lp)
 
-    if "links" in form.data:
-        for link in form.data["links"]:
-            if link["url"]:
-                li = get_or_create_link_from_form(link, user)
-                links.append(li)
+    form_links = [link for link in form.data["links"] if link["url"]]
+    for link in form_links:
+        li = get_or_create_link_from_form(link, user)
+        links.append(li)
 
     return Incident(
         address=address_model,

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -170,32 +170,35 @@ def create_incident(self, form: IncidentForm, user: User) -> Incident:
             db.session.add(location)
         address_model = location
 
-    form_officers = [o for o in form.data["officers"] if o["oo_id"]]
-    for officer in form_officers:
-        of = Officer.query.filter_by(id=int(officer["oo_id"])).one()
-        if of:
-            officers.append(of)
+    if "officers" in form.data:
+        form_officers = [o for o in form.data["officers"] if o["oo_id"]]
+        for officer in form_officers:
+            of = Officer.query.filter_by(id=int(officer["oo_id"])).one()
+            if of:
+                officers.append(of)
 
-    form_plates = [p for p in form.data["license_plates"] if p["number"]]
-    for plate in form_plates:
-        lp = LicensePlate.query.filter_by(
-            number=if_exists_or_none(plate["number"]),
-            state=if_exists_or_none(plate["state"]),
-        ).first()
-        if not lp:
-            lp = LicensePlate(
+    if "license_plates" in form.data:
+        form_plates = [p for p in form.data["license_plates"] if p["number"]]
+        for plate in form_plates:
+            lp = LicensePlate.query.filter_by(
                 number=if_exists_or_none(plate["number"]),
                 state=if_exists_or_none(plate["state"]),
-                created_by=user.id,
-                last_updated_by=user.id,
-            )
-            db.session.add(lp)
-        license_plates.append(lp)
+            ).first()
+            if not lp:
+                lp = LicensePlate(
+                    number=if_exists_or_none(plate["number"]),
+                    state=if_exists_or_none(plate["state"]),
+                    created_by=user.id,
+                    last_updated_by=user.id,
+                )
+                db.session.add(lp)
+            license_plates.append(lp)
 
-    form_links = [link for link in form.data["links"] if link["url"]]
-    for link in form_links:
-        li = get_or_create_link_from_form(link, user)
-        links.append(li)
+    if "links" in form.data:
+        form_links = [link for link in form.data["links"] if link["url"]]
+        for link in form_links:
+            li = get_or_create_link_from_form(link, user)
+            links.append(li)
 
     return Incident(
         address=address_model,

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -86,46 +86,46 @@ def add_officer_profile(form: AddOfficerForm, user: User) -> Officer:
     )
     db.session.add(assignment)
     if form.links.data:
-        for link in form.data["links"]:
-            if link["url"]:
-                li = get_or_create_link_from_form(link, user)
-                officer.links.append(li)
+        form_links = [link for link in form.data["links"] if link["url"]]
+        for link in form_links:
+            li = get_or_create_link_from_form(link, user)
+            officer.links.append(li)
     if form.notes.data:
-        for note in form.data["notes"]:
-            # don't try to create with a blank string
-            if note["text_contents"]:
-                new_note = Note(
-                    text_contents=note["text_contents"],
-                    officer=officer,
-                    created_by=user.id,
-                    last_updated_by=user.id,
-                )
-                db.session.add(new_note)
+        # don't try to create with a blank string
+        form_notes = [n for n in form.data["notes"] if n["text_contents"]]
+        for note in form_notes:
+            new_note = Note(
+                text_contents=note["text_contents"],
+                officer=officer,
+                created_by=user.id,
+                last_updated_by=user.id,
+            )
+            db.session.add(new_note)
     if form.descriptions.data:
-        for description in form.data["descriptions"]:
-            # don't try to create with a blank string
-            if description["text_contents"]:
-                new_description = Description(
-                    text_contents=description["text_contents"],
-                    officer=officer,
-                    created_by=user.id,
-                    last_updated_by=user.id,
-                )
-                db.session.add(new_description)
+        # don't try to create with a blank string
+        form_descriptions = [d for d in form.data["descriptions"] if d["text_contents"]]
+        for description in form_descriptions:
+            new_description = Description(
+                text_contents=description["text_contents"],
+                officer=officer,
+                created_by=user.id,
+                last_updated_by=user.id,
+            )
+            db.session.add(new_description)
     if form.salaries.data:
-        for salary in form.data["salaries"]:
-            # don't try to create with a blank string
-            if salary["salary"]:
-                new_salary = Salary(
-                    officer=officer,
-                    salary=salary["salary"],
-                    overtime_pay=salary["overtime_pay"],
-                    year=salary["year"],
-                    is_fiscal_year=salary["is_fiscal_year"],
-                    created_by=user.id,
-                    last_updated_by=user.id,
-                )
-                db.session.add(new_salary)
+        # don't try to create with a blank string
+        form_salaries = [s for s in form.data["salaries"] if s["salary"]]
+        for salary in form_salaries:
+            new_salary = Salary(
+                officer=officer,
+                salary=salary["salary"],
+                overtime_pay=salary["overtime_pay"],
+                year=salary["year"],
+                is_fiscal_year=salary["is_fiscal_year"],
+                created_by=user.id,
+                last_updated_by=user.id,
+            )
+            db.session.add(new_salary)
 
     db.session.commit()
     return officer

--- a/OpenOversight/app/utils/general.py
+++ b/OpenOversight/app/utils/general.py
@@ -57,7 +57,7 @@ def get_or_create(session, model, defaults=None, **kwargs):
     if instance:
         return instance, False
     else:
-        params = dict((k, v) for k, v in filter_params.items())
+        params = dict(filter_params)
         params.update(defaults or {})
         instance = model(**params)
         session.add(instance)

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -75,13 +75,13 @@ def process_form_data(form_dict: dict) -> dict:
     """Mock the browser-flattening of a form containing embedded data."""
     new_dict = {}
     for key, value in form_dict.items():
-        if type(value) == list:
+        if isinstance(value, list):
             if value[0]:
-                if type(value[0]) is dict:
+                if isinstance(value[0], dict):
                     for idx, item in enumerate(value):
                         for sub_key, sub_value in item.items():
                             new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
-                elif type(value[0]) is str or type(value[0]) is int:
+                elif isinstance(value[0], str) or isinstance(value[0], int):
                     for idx, item in enumerate(value):
                         new_dict[f"{key}-{idx}"] = item
                 else:
@@ -90,7 +90,7 @@ def process_form_data(form_dict: dict) -> dict:
                             type(value[0])
                         )
                     )
-        elif type(value) == dict:
+        elif isinstance(value, dict):
             for sub_key, sub_value in value.items():
                 new_dict[f"{key}-{sub_key}"] = sub_value
         else:

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -75,21 +75,20 @@ def process_form_data(form_dict: dict) -> dict:
     """Mock the browser-flattening of a form containing embedded data."""
     new_dict = {}
     for key, value in form_dict.items():
-        if isinstance(value, list):
-            if value[0]:
-                if isinstance(value[0], dict):
-                    for idx, item in enumerate(value):
-                        for sub_key, sub_value in item.items():
-                            new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
-                elif isinstance(value[0], str) or isinstance(value[0], int):
-                    for idx, item in enumerate(value):
-                        new_dict[f"{key}-{idx}"] = item
-                else:
-                    raise ValueError(
-                        "Lists must contain dicts, strings or ints. {} submitted".format(
-                            type(value[0])
-                        )
+        if isinstance(value, list) and value[0]:
+            if isinstance(value[0], dict):
+                for idx, item in enumerate(value):
+                    for sub_key, sub_value in item.items():
+                        new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
+            elif isinstance(value[0], str) or isinstance(value[0], int):
+                for idx, item in enumerate(value):
+                    new_dict[f"{key}-{idx}"] = item
+            else:
+                raise ValueError(
+                    "Lists must contain dicts, strings or ints. {} submitted".format(
+                        type(value[0])
                     )
+                )
         elif isinstance(value, dict):
             for sub_key, sub_value in value.items():
                 new_dict[f"{key}-{sub_key}"] = sub_value

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -75,20 +75,19 @@ def process_form_data(form_dict: dict) -> dict:
     """Mock the browser-flattening of a form containing embedded data."""
     new_dict = {}
     for key, value in form_dict.items():
-        if isinstance(value, list) and value[0]:
-            if isinstance(value[0], dict):
-                for idx, item in enumerate(value):
-                    for sub_key, sub_value in item.items():
-                        new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
-            elif isinstance(value[0], str) or isinstance(value[0], int):
-                for idx, item in enumerate(value):
-                    new_dict[f"{key}-{idx}"] = item
-            else:
-                raise ValueError(
-                    "Lists must contain dicts, strings or ints. {} submitted".format(
-                        type(value[0])
+        if isinstance(value, list):
+            if value[0]:
+                if isinstance(value[0], dict):
+                    for idx, item in enumerate(value):
+                        for sub_key, sub_value in item.items():
+                            new_dict[f"{key}-{idx}-{sub_key}"] = sub_value
+                elif isinstance(value[0], str) or isinstance(value[0], int):
+                    for idx, item in enumerate(value):
+                        new_dict[f"{key}-{idx}"] = item
+                else:
+                    raise ValueError(
+                        f"Lists must contain dicts, strings or ints. {type(value[0])} submitted"
                     )
-                )
         elif isinstance(value, dict):
             for sub_key, sub_value in value.items():
                 new_dict[f"{key}-{sub_key}"] = sub_value

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1772,8 +1772,7 @@ def test_assignments_csv(mockdata, client, session, department):
             follow_redirects=True,
         )
         csv_data = rv.data.decode(ENCODING_UTF_8)
-        csv_reader = csv.DictReader(csv_data.split("\n"))
-        all_rows = [row for row in csv_reader]
+        all_rows = csv.DictReader(csv_data.split("\n"))
         for row in all_rows:
             assert (
                 Officer.query.get(int(row["officer id"])).department_id == department.id

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1772,7 +1772,7 @@ def test_assignments_csv(mockdata, client, session, department):
             follow_redirects=True,
         )
         csv_data = rv.data.decode(ENCODING_UTF_8)
-        all_rows = csv.DictReader(csv_data.split("\n"))
+        all_rows = list(csv.DictReader(csv_data.split("\n")))
         for row in all_rows:
             assert (
                 Officer.query.get(int(row["officer id"])).department_id == department.id
@@ -2034,9 +2034,7 @@ def test_admin_can_upload_photos_of_dept_officers(
     with current_app.test_request_context():
         login_admin(client)
 
-        data = dict(
-            file=(test_jpg_bytes_io, "204Cat.png"),
-        )
+        data = {"file": (test_jpg_bytes_io, "204Cat.png")}
 
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[3]
@@ -2076,9 +2074,7 @@ def test_upload_photo_sends_500_on_s3_error(
     with current_app.test_request_context():
         login_admin(client)
 
-        data = dict(
-            file=(test_png_bytes_io, "204Cat.png"),
-        )
+        data = {"file": (test_png_bytes_io, "204Cat.png")}
 
         department = Department.query.filter_by(id=AC_DEPT).first()
         mock = MagicMock(return_value=None)
@@ -2101,9 +2097,7 @@ def test_upload_photo_sends_500_on_s3_error(
 def test_upload_photo_sends_415_for_bad_file_type(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)
-        data = dict(
-            file=(BytesIO(b"my file contents"), "test_cop1.png"),
-        )
+        data = {"file": (BytesIO(b"my file contents"), "test_cop1.png")}
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[0]
         mock = MagicMock(return_value=False)
@@ -2122,9 +2116,7 @@ def test_upload_photo_sends_415_for_bad_file_type(mockdata, client, session):
 def test_user_cannot_upload_officer_photo(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
-        data = dict(
-            file=(BytesIO(b"my file contents"), "test_cop1.png"),
-        )
+        data = {"file": (BytesIO(b"my file contents"), "test_cop1.png")}
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[0]
         rv = client.post(
@@ -2141,9 +2133,9 @@ def test_ac_can_upload_photos_of_dept_officers(
 ):
     with current_app.test_request_context():
         login_ac(client)
-        data = dict(
-            file=(test_png_bytes_io, "204Cat.png"),
-        )
+        data = {
+            "file": (test_png_bytes_io, "204Cat.png"),
+        }
         department = Department.query.filter_by(id=AC_DEPT).first()
         officer = department.officers[4]
         officer_face_count = len(officer.face)

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -287,25 +287,23 @@ def test_officer_form_has_units_alpha_sorted(mockdata, browser, server_port):
     login_admin(browser, server_port)
 
     # get the units from the DB in the sort we expect
-    db_units_sorted = list(
-        map(
-            lambda x: x.description,
-            db.session.query(Unit).order_by(Unit.description.asc()).all(),
-        )
-    )
+    db_units_sorted = [
+        x.description
+        for x in db.session.query(Unit).order_by(Unit.description.asc()).all()
+    ]
     # the Select tag in the interface has a 'None' value at the start
     db_units_sorted.insert(0, "None")
 
     # Check for the Unit sort on the 'add officer' form
     browser.get(f"http://localhost:{server_port}/officers/new")
     unit_select = Select(browser.find_element_by_id("unit"))
-    select_units_sorted = list(map(lambda x: x.text, unit_select.options))
+    select_units_sorted = [x.text for x in unit_select.options]
     assert db_units_sorted == select_units_sorted
 
     # Check for the Unit sort on the 'add assignment' form
     browser.get(f"http://localhost:{server_port}/officers/1")
     unit_select = Select(browser.find_element_by_id("unit"))
-    select_units_sorted = list(map(lambda x: x.text, unit_select.options))
+    select_units_sorted = [x.text for x in unit_select.options]
     assert db_units_sorted == select_units_sorted
 
 

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -178,6 +178,7 @@ def test_password_not_printed(mockdata):
         print(user.password)
     except Exception as e:
         assert isinstance(e, AttributeError)
+        assert str(e) == "password is not a readable attribute"
 
 
 def test_password_set_success(mockdata):

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -173,8 +173,7 @@ def test_salary_repr(mockdata):
 
 def test_password_not_printed(mockdata):
     user = User(password="bacon")
-    with raises(AttributeError):
-        user.password
+    assert "bacon" not in repr(user)
 
 
 def test_password_set_success(mockdata):

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -172,6 +172,7 @@ def test_salary_repr(mockdata):
 
 
 def test_password_not_printed(mockdata):
+    """Validate that password fields cannot be directly accessed."""
     user = User(password="bacon")
     try:
         print(user.password)

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -173,7 +173,10 @@ def test_salary_repr(mockdata):
 
 def test_password_not_printed(mockdata):
     user = User(password="bacon")
-    assert "bacon" not in repr(user)
+    try:
+        print(user.password)
+    except Exception as e:
+        assert isinstance(e, AttributeError)
 
 
 def test_password_set_success(mockdata):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -318,9 +318,9 @@ def test_filter_by_form_filter_unit(
     for officer in officers:
         found = False
         if has_officers_with_unit:
-            found = found or any([a.unit_id == unit_id for a in officer.assignments])
+            found = found or any(a.unit_id == unit_id for a in officer.assignments)
         if has_officers_with_no_unit:
-            found = found or any([a.unit_id is None for a in officer.assignments])
+            found = found or any(a.unit_id is None for a in officer.assignments)
         assert found
 
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -309,7 +309,7 @@ def test_crop_image_calls_save_image_to_s3_and_db_with_user_id(mockdata, client)
 def test_filter_by_form_filter_unit(
     mockdata, units, has_officers_with_unit, has_officers_with_no_unit
 ):
-    form_data = dict(unit=units)
+    form_data = {"unit": units}
     unit_id = Unit.query.filter_by(description="Donut Devourers").one().id
     department_id = Department.query.first().id
 


### PR DESCRIPTION
## Description of Changes
Replacing `flake8` with `ruff`, which has approximate parity and is more than 10x faster: https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8

## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
