### PR TITLE
Disable __pycache__ generation

### DIFF
--- a/dockerfiles/web/Dockerfile-dev
+++ b/dockerfiles/web/Dockerfile-dev
@@ -6,6 +6,7 @@ ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf -L --max-redirs 1 -O"
 
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # install apt dependencies
 RUN apt-get update && apt-get install -y xvfb libpq-dev python3-dev && \

--- a/dockerfiles/web/Dockerfile-prod
+++ b/dockerfiles/web/Dockerfile-prod
@@ -5,8 +5,8 @@ RUN echo "Building image based on python $PYTHON_VERSION"
 
 WORKDIR /usr/src/app
 
-# Avoid writing .pyc files in the image.
-ARG PYTHONDONTWRITEBYTECODE=1
+# Avoid writing .pyc and __pycache__ files in the image.
+ENV PYTHONDONTWRITEBYTECODE=1
 # Prevent installer from attempting to show dialog boxes during image build.
 ARG DEBIAN_FRONTEND=noninteractive
 # Make sure stdout and stderr are immediately flushed.

--- a/dockerfiles/web/Dockerfile-test
+++ b/dockerfiles/web/Dockerfile-test
@@ -7,6 +7,7 @@ ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf -L --max-redirs 1 -O"
 
 ENV DEBIAN-FRONTEND noninteractive
 ENV DISPLAY=:1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # install apt dependencies
 RUN apt-get update && apt-get install -y xvfb firefox-esr libpq-dev python3-dev && \


### PR DESCRIPTION
## Description of Changes
Disable __pycache__ generation

On the first `make test` run,  `__pycache__` directories are written in the OpenOversight directory, which is bind mounted in the container. The second run fails when it tries to read the `__pycache__` files created in the container:   
```
error checking context: 'no permission to read from '/path/to/repo//OpenOversight/tests/__pycache__/test_alembic.cpython-311-pytest-7.4.0.pyc''.
```

```
$ ls -l OpenOversight/tests/__pycache__/test_alembic.cpython-311-pytest-7.4.0.pyc
-rw------- 1 root root 2008 Jun 24 00:10 OpenOversight/tests/__pycache__/test_alembic.cpython-311-pytest-7.4.0.pyc
```

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
