### PR TITLE
Fix nav bar links on mobile

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -83,27 +83,28 @@
           <ul class="navbar-nav">
             {% if current_user and current_user.is_authenticated %}
               <li class="dropdown nav-item">
-                <button class="btn dropdown-toggle"
-                        data-bs-toggle="dropdown"
-                        aria-expanded="false">
+                <a class="nav-link dropdown-toggle"
+                   data-bs-toggle="dropdown"
+                   aria-expanded="false">
                   Account <b class="caret"></b>
-                </button>
+                </a>
                 <ul class="dropdown-menu dropdown-menu-end">
-                  <li class="nav-item">
-                    <a class="nav-link"
+                  <li>
+                    <a class="dropdown-item"
                        href="{{ url_for('main.profile', username=current_user.username) }}">Profile</a>
                   </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for("auth.change_password") }}">Change Password</a>
+                  <li>
+                    <a class="dropdown-item" href="{{ url_for("auth.change_password") }}">Change Password</a>
                   </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for("auth.change_email_request") }}">Change Email</a>
+                  <li>
+                    <a class="dropdown-item"
+                       href="{{ url_for("auth.change_email_request") }}">Change Email</a>
                   </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for("auth.change_dept") }}">Change Default Department</a>
+                  <li>
+                    <a class="dropdown-item" href="{{ url_for("auth.change_dept") }}">Change Default Department</a>
                   </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for("auth.logout") }}">Log Out</a>
+                  <li>
+                    <a class="dropdown-item" href="{{ url_for("auth.logout") }}">Log Out</a>
                   </li>
                 </ul>
               </li>

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -58,7 +58,7 @@
           <span class="navbar-toggler-icon"></span>
         </button>
         <div id="navbar" class="collapse navbar-collapse">
-          <ul class="navbar-nav">
+          <ul class="navbar-nav me-auto">
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for("main.browse") }}">Browse</a>
             </li>
@@ -80,7 +80,7 @@
               </li>
             {% endif %}
           </ul>
-          <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
+          <ul class="navbar-nav">
             {% if current_user and current_user.is_authenticated %}
               <li class="dropdown nav-item">
                 <button class="btn dropdown-toggle"


### PR DESCRIPTION
## Description of Changes
*Cherry-picked from https://github.com/OrcaCollective/OpenOversight/pull/471*
Fix the "Register" and "Login" buttons being on the same line in the menu and update the styling of the "Account" dropdown in when logged in

## Notes for Deployment
None!

## Screenshots (if appropriate)

|    | Before | After |
|---|-----------|-------|
| Desktop View (No change) | ![1](https://github.com/OrcaCollective/OpenOversight/assets/66500457/c49a7ddf-feb6-4a9b-85d8-02aef8238994) | ![2](https://github.com/OrcaCollective/OpenOversight/assets/66500457/b0556724-9999-4103-a643-b419dd2cfddb) |
| Mobile (Unauthenticated) | ![3](https://github.com/OrcaCollective/OpenOversight/assets/66500457/73bab076-4dd3-42a2-8558-a96969dffd20) | ![4](https://github.com/OrcaCollective/OpenOversight/assets/66500457/06304a53-b7d8-4617-a64e-d2866d311617) |
| Mobile (Authenticated) | ![5](https://github.com/OrcaCollective/OpenOversight/assets/66500457/5d88ec45-64cd-429b-9aa8-39ddb637d067) |  ![6](https://github.com/OrcaCollective/OpenOversight/assets/66500457/2357dd3d-86cf-4481-a026-b6f71fea4c5e) |

## Tests and linting

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
