### PR TITLE
Fix `Donate` link

### DIFF
--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -67,7 +67,7 @@
               Note: We are an IRS 501(c)3 not-for-profit and all donations are tax-deductible!
             </p>
             <a class="btn btn-lg btn-secondary"
-               href="https://lucyparsonslabs.com/support/"
+               href="https://www.lucyparsonslabs.com/donate"
                target="_blank">Donate</a>
           </div>
         </div>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -67,7 +67,7 @@
               Note: We are an IRS 501(c)3 not-for-profit and all donations are tax deductible!
             </p>
             <a class="btn btn-lg btn-secondary"
-               href="https://www.lucyparsonslabs.com/donate"
+               href="https://lucyparsonslabs.com/donate"
                target="_blank">Donate</a>
           </div>
         </div>

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -64,7 +64,7 @@
               We are entirely volunteer funded and directed. Donations are greatly appreciated, and can be funded
               through PayPal, YouCaring, or Bitcoin.
               <br>
-              Note: We are an IRS 501(c)3 not-for-profit and all donations are tax deductible!
+              Note: We are an IRS 501(c)3 not-for-profit and all donations are tax-deductible!
             </p>
             <a class="btn btn-lg btn-secondary"
                href="https://lucyparsonslabs.com/support/"

--- a/OpenOversight/app/templates/index.html
+++ b/OpenOversight/app/templates/index.html
@@ -64,7 +64,7 @@
               We are entirely volunteer funded and directed. Donations are greatly appreciated, and can be funded
               through PayPal, YouCaring, or Bitcoin.
               <br>
-              Note: We are an IRS 501(c)3 not-for-profit and all donations are tax-deductible!
+              Note: We are an IRS 501(c)3 not-for-profit and all donations are tax deductible!
             </p>
             <a class="btn btn-lg btn-secondary"
                href="https://www.lucyparsonslabs.com/donate"


### PR DESCRIPTION
## Description of Changes
Fixed the `Donate` link `href` to the correct page.

Old page:
<img width="1467" alt="Screenshot 2024-07-14 at 1 58 46 AM" src="https://github.com/user-attachments/assets/34895335-5f39-463d-b97d-12e9cd17d4b3">

New page:
<img width="1470" alt="Screenshot 2024-07-14 at 1 58 51 AM" src="https://github.com/user-attachments/assets/79953dc2-e1da-4893-8d72-af184182fa7e">

## Tests and Linting
 - [x] This branch is up-to-date with the `develop` branch.
 - [x] `pytest` passes on my local development environment.
 - [x] `pre-commit` passes on my local development environment.
