### PR TITLE
Add user profile tests

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -288,7 +288,10 @@ def get_tutorial():
 @login_required
 def profile(username: str):
     if re.search("^[A-Za-z][A-Za-z0-9_.]*$", username):
-        user = User.by_username(username).one()
+        try:
+            user = User.by_username(username).one()
+        except NoResultFound:
+            abort(HTTPStatus.NOT_FOUND)
     else:
         abort(HTTPStatus.NOT_FOUND)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -295,6 +295,9 @@ def profile(username: str):
     else:
         abort(HTTPStatus.NOT_FOUND)
 
+    if current_user.username != user.username and not current_user.is_administrator:
+        abort(HTTPStatus.FORBIDDEN)
+
     pref = db.session.get(User, current_user.id).dept_pref
     department = db.session.get(Department, pref).name if pref else None
     return render_template("profile.html", user=user, department=department)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -295,7 +295,7 @@ def profile(username: str):
     else:
         abort(HTTPStatus.NOT_FOUND)
 
-    if current_user.username != user.username and not current_user.is_administrator:
+    if current_user.username != user.username:
         abort(HTTPStatus.FORBIDDEN)
 
     pref = db.session.get(User, current_user.id).dept_pref

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -295,9 +295,6 @@ def profile(username: str):
     else:
         abort(HTTPStatus.NOT_FOUND)
 
-    if current_user.username != user.username:
-        abort(HTTPStatus.FORBIDDEN)
-
     pref = db.session.get(User, current_user.id).dept_pref
     department = db.session.get(Department, pref).name if pref else None
     return render_template("profile.html", user=user, department=department)

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -1,0 +1,15 @@
+from http import HTTPStatus
+
+from flask import current_app
+
+from OpenOversight.app.utils.constants import ENCODING_UTF_8
+from OpenOversight.tests.routes.route_helpers import login_user
+
+
+def test_user_can_see_own_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        _, user = login_user(client)
+        rv = client.get(f"/user/{user.username}")
+
+        assert rv.status_code == HTTPStatus.OK
+        assert bytes(f"Profile: {user.username}", ENCODING_UTF_8) in rv.data

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -4,7 +4,7 @@ from flask import current_app
 
 from OpenOversight.app.models.database import User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
-from OpenOversight.tests.constants import GENERAL_USER_EMAIL
+from OpenOversight.tests.constants import AC_USER_EMAIL, GENERAL_USER_EMAIL
 from OpenOversight.tests.routes.route_helpers import login_user
 
 
@@ -15,6 +15,7 @@ def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
 
         # Assert that there is a redirect
         assert rv.status_code == HTTPStatus.FOUND
+
 
 def test_user_profile_for_invalid_regex_username(mockdata, client, session):
     with current_app.test_request_context():
@@ -41,3 +42,13 @@ def test_user_can_see_own_profile(mockdata, client, session):
 
         assert rv.status_code == HTTPStatus.OK
         assert bytes(f"Profile: {user.username}", ENCODING_UTF_8) in rv.data
+
+
+def test_user_cannot_see_other_users_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+        other_user = User.query.filter_by(email=AC_USER_EMAIL).first()
+        rv = client.get(f"/user/{other_user.username}")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.FORBIDDEN

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -5,7 +5,7 @@ from flask import current_app
 from OpenOversight.app.models.database import User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
 from OpenOversight.tests.constants import AC_USER_EMAIL, GENERAL_USER_EMAIL
-from OpenOversight.tests.routes.route_helpers import login_ac, login_user, login_admin
+from OpenOversight.tests.routes.route_helpers import login_ac, login_admin, login_user
 
 
 def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
@@ -62,6 +62,7 @@ def test_ac_user_cannot_see_other_users_profile(mockdata, client, session):
 
         # Assert page returns error
         assert rv.status_code == HTTPStatus.FORBIDDEN
+
 
 def test_admin_user_cannot_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -2,8 +2,36 @@ from http import HTTPStatus
 
 from flask import current_app
 
+from OpenOversight.app.models.database import User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
+from OpenOversight.tests.constants import GENERAL_USER_EMAIL
 from OpenOversight.tests.routes.route_helpers import login_user
+
+
+def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
+    with current_app.test_request_context():
+        user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
+        rv = client.get(f"/user/{user.username}")
+
+        # Assert that there is a redirect
+        assert rv.status_code == HTTPStatus.FOUND
+
+def test_user_profile_for_invalid_regex_username(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+        rv = client.get("/user/this_name_is_mad]]bogus")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_user_profile_for_invalid_username(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+        rv = client.get("/user/this_name_is_mad_bogus")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_user_can_see_own_profile(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -5,7 +5,7 @@ from flask import current_app
 from OpenOversight.app.models.database import User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
 from OpenOversight.tests.constants import AC_USER_EMAIL, GENERAL_USER_EMAIL
-from OpenOversight.tests.routes.route_helpers import login_user
+from OpenOversight.tests.routes.route_helpers import login_ac, login_user
 
 
 def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
@@ -48,6 +48,16 @@ def test_user_cannot_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
         other_user = User.query.filter_by(email=AC_USER_EMAIL).first()
+        rv = client.get(f"/user/{other_user.username}")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_ac_user_cannot_see_other_users_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        login_ac(client)
+        other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
         rv = client.get(f"/user/{other_user.username}")
 
         # Assert page returns error

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -53,31 +53,31 @@ def test_user_can_see_own_profile(mockdata, client, session):
         assert bytes(f"Profile: {user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_user_cannot_see_other_users_profile(mockdata, client, session):
+def test_user_can_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
         other_user = User.query.filter_by(email=AC_USER_EMAIL).first()
         rv = client.get(f"/user/{other_user.username}")
 
-        # Assert page returns error
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+        assert rv.status_code == HTTPStatus.OK
+        assert bytes(f"Profile: {other_user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_ac_user_cannot_see_other_users_profile(mockdata, client, session):
+def test_ac_user_can_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
         other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
         rv = client.get(f"/user/{other_user.username}")
 
-        # Assert page returns error
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+        assert rv.status_code == HTTPStatus.OK
+        assert bytes(f"Profile: {other_user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_admin_user_cannot_see_other_users_profile(mockdata, client, session):
+def test_admin_user_can_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)
         other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
         rv = client.get(f"/user/{other_user.username}")
 
-        # Assert page returns error
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+        assert rv.status_code == HTTPStatus.OK
+        assert bytes(f"Profile: {other_user.username}", ENCODING_UTF_8) in rv.data

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -5,7 +5,7 @@ from flask import current_app
 from OpenOversight.app.models.database import User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
 from OpenOversight.tests.constants import AC_USER_EMAIL, GENERAL_USER_EMAIL
-from OpenOversight.tests.routes.route_helpers import login_ac, login_user
+from OpenOversight.tests.routes.route_helpers import login_ac, login_user, login_admin
 
 
 def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
@@ -57,6 +57,15 @@ def test_user_cannot_see_other_users_profile(mockdata, client, session):
 def test_ac_user_cannot_see_other_users_profile(mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
+        other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
+        rv = client.get(f"/user/{other_user.username}")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.FORBIDDEN
+
+def test_admin_user_cannot_see_other_users_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
         other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
         rv = client.get(f"/user/{other_user.username}")
 

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -35,6 +35,15 @@ def test_user_profile_for_invalid_username(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
+def test_user_profile_does_not_use_id(mockdata, client, session):
+    with current_app.test_request_context():
+        _, user = login_user(client)
+        rv = client.get(f"/user/{user.id}")
+
+        # Assert page returns error
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_user_can_see_own_profile(mockdata, client, session):
     with current_app.test_request_context():
         _, user = login_user(client)

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -41,12 +41,8 @@ def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
 def test_ac_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
-        if HTTPMethod.GET in methods:
-            rv = client.get(route)
-            assert rv.status_code == HTTPStatus.FORBIDDEN
-        if HTTPMethod.POST in methods:
-            rv = client.post(route)
-            assert rv.status_code == HTTPStatus.FORBIDDEN
+        rv = client.get(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_admin_can_update_users_to_ac(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -33,12 +33,8 @@ def test_user_api_login_required(route, methods, client, mockdata):
 def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
-        if HTTPMethod.GET in methods:
-            rv = client.get(route)
-            assert rv.status_code == HTTPStatus.FORBIDDEN
-        if HTTPMethod.POST in methods:
-            rv = client.post(route)
-            assert rv.status_code == HTTPStatus.FORBIDDEN
+        rv = client.get(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -25,15 +25,23 @@ routes_methods = [
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route,methods", routes_methods)
 def test_user_api_login_required(route, methods, client, mockdata):
-    rv = client.get(route)
-    assert rv.status_code == HTTPStatus.FORBIDDEN
+    if HTTPMethod.GET in methods:
+        rv = client.get(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
+    if HTTPMethod.POST in methods:
+        rv = client.post(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)
 def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
+    if HTTPMethod.GET in methods:
         rv = client.get(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
+    if HTTPMethod.POST in methods:
+        rv = client.post(route)
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
@@ -41,7 +49,11 @@ def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
 def test_ac_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
+    if HTTPMethod.GET in methods:
         rv = client.get(route)
+        assert rv.status_code == HTTPStatus.FORBIDDEN
+    if HTTPMethod.POST in methods:
+        rv = client.post(route)
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -37,24 +37,24 @@ def test_user_api_login_required(route, methods, client, mockdata):
 def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
-    if HTTPMethod.GET in methods:
-        rv = client.get(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
-    if HTTPMethod.POST in methods:
-        rv = client.post(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+        if HTTPMethod.GET in methods:
+            rv = client.get(route)
+            assert rv.status_code == HTTPStatus.FORBIDDEN
+        if HTTPMethod.POST in methods:
+            rv = client.post(route)
+            assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)
 def test_ac_cannot_access_user_api(route, methods, mockdata, client, session):
     with current_app.test_request_context():
         login_ac(client)
-    if HTTPMethod.GET in methods:
-        rv = client.get(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
-    if HTTPMethod.POST in methods:
-        rv = client.post(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+        if HTTPMethod.GET in methods:
+            rv = client.get(route)
+            assert rv.status_code == HTTPStatus.FORBIDDEN
+        if HTTPMethod.POST in methods:
+            rv = client.post(route)
+            assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_admin_can_update_users_to_ac(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -25,12 +25,8 @@ routes_methods = [
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route,methods", routes_methods)
 def test_user_api_login_required(route, methods, client, mockdata):
-    if HTTPMethod.GET in methods:
-        rv = client.get(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
-    if HTTPMethod.POST in methods:
-        rv = client.post(route)
-        assert rv.status_code == HTTPStatus.FORBIDDEN
+    rv = client.get(route)
+    assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/436

## Description of Changes
Added tests to validate `/user/` route logic and correct profile logic to match pre-specified tests.

<img width="497" alt="Screenshot 2024-07-31 at 5 27 37 PM" src="https://github.com/user-attachments/assets/78703665-1623-4703-8fa9-a1cca59ba319">

There is not a `/users/` route, so I marked it out.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
