### PR TITLE
Fix database fixture and password unit test

### DIFF
--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -311,15 +311,14 @@ def db(app):
 @pytest.fixture(scope="function")
 def session(db):
     """Creates a new database session for a test."""
-    with db.engine.connect() as connection:
-        with connection.begin() as tx:
-            db.session = scoped_session(sessionmaker(bind=connection))
+    with db.engine.connect() as connection, connection.begin() as tx:
+        db.session = scoped_session(sessionmaker(bind=connection))
 
-            try:
-                yield db.session
-            finally:
-                db.session.remove()
-                tx.rollback()
+        try:
+            yield db.session
+        finally:
+            db.session.remove()
+            tx.rollback()
 
 
 @pytest.fixture

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -318,7 +318,9 @@ def session(db):
             yield db.session
         finally:
             db.session.remove()
-            tx.rollback()
+            # If an error was raised during test, tx is already rolled back
+            if tx.is_active:
+                tx.rollback()
 
 
 @pytest.fixture

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -173,11 +173,8 @@ def test_salary_repr(mockdata):
 def test_password_not_printed(mockdata):
     """Validate that password fields cannot be directly accessed."""
     user = User(password="bacon")
-    try:
+    with raises(AttributeError):
         print(user.password)
-    except Exception as e:
-        assert isinstance(e, AttributeError)
-        assert str(e) == "password is not a readable attribute"
 
 
 def test_password_set_success(mockdata):


### PR DESCRIPTION
## Description of Changes
1. Simplify database fixtures
2. Fix password unit test - This test currently doesn't fail if `user.password` returns a value. Using `pytest.raises` fails the test if AttributeError is not raised.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
