### PR TITLE
Use docker compose v2 plugin

### DIFF
--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       FLASK_APP: OpenOversight.app
     strategy:

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -138,9 +138,9 @@ You'll first have to start the Docker instance for the OpenOversight app using t
 
 ```shell
 $ make start
-docker-compose build
+docker compose build
 ...
-docker-compose up -d
+docker compose up -d
 [+] Running 2/0
  ✔ Container openoversight-postgres-1  Running                                                                                                                                                             0.0s
  ✔ Container openoversight-web-1       Running
@@ -273,7 +273,7 @@ Next, in your terminal run `docker ps` to find the container id of the `openover
 ## Debugging OpenOversight - Use pdb with a test
 If you want to run an individual test in debug mode, use the below command.
 ```shell
-docker-compose run --rm web pytest --pdb -v tests/ -k <test_name_here>
+docker compose run --rm web pytest --pdb -v tests/ -k <test_name_here>
 ```
 
 where `<test_name_here>` is the name of a single test function, such as `test_ac_cannot_add_new_officer_not_in_their_dept`
@@ -281,7 +281,7 @@ where `<test_name_here>` is the name of a single test function, such as `test_ac
 Similarly, you can run all the tests in a file by specifying the file path:
 
 ```shell
-docker-compose run --rm web pytest --pdb -v path/to/test/file
+docker compose run --rm web pytest --pdb -v path/to/test/file
 ```
 
 where `path/to/test/file` is the relative file path, minus the initial `OpenOversight`, such as

--- a/Makefile
+++ b/Makefile
@@ -5,35 +5,35 @@ default: build start create_db populate test stop clean
 # Build containers
 .PHONY: build
 build:
-	docker-compose build
+	docker compose build
 
 .PHONY: build_with_version
 build_with_version: create_empty_secret
-	docker-compose build --build-arg MAKE_PYTHON_VERSION=$(PYTHON_VERSION)
+	docker compose build --build-arg MAKE_PYTHON_VERSION=$(PYTHON_VERSION)
 
 .PHONY: test_with_version
 test_with_version: build_with_version assets
 	touch OpenOversight/tests/coverage.xml
-	docker-compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start
 start: build
-	docker-compose up -d
+	docker compose up -d
 
 .PHONY: create_db
 create_db: start
-	@until docker-compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+	@until docker compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
 		echo "Postgres is unavailable - sleeping..."; \
 		sleep 1; \
 	done
 	@echo "Postgres is up"
 	## Creating database
-	docker-compose run --rm web alembic --config=./OpenOversight/migrations/alembic.ini stamp head
+	docker compose run --rm web alembic --config=./OpenOversight/migrations/alembic.ini stamp head
 
 .PHONY: assets
 assets:
-	docker-compose run --rm web yarn build
+	docker compose run --rm web yarn build
 
 .PHONY: dev
 dev: create_empty_secret build start create_db populate
@@ -41,21 +41,21 @@ dev: create_empty_secret build start create_db populate
 # Build and run containers
 .PHONY: populate
 populate: create_db
-	@until docker-compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
+	@until docker compose exec postgres psql -h localhost -U openoversight -c '\l' postgres &>/dev/null; do \
 		echo "Postgres is unavailable - sleeping..."; \
 		sleep 1; \
 	done
 	@echo "Postgres is up"
 	## Populate database with test data
-	docker-compose run --rm web python ./test_data.py -p
+	docker compose run --rm web python ./test_data.py -p
 
 # Run tests
 .PHONY: test
 test: start
 	if [ -z "$(name)" ]; then \
-		docker-compose run --rm web-test pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
+		docker compose run --rm web-test pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-		docker-compose run --rm web-test pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
+		docker compose run --rm web-test pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint
@@ -69,17 +69,17 @@ clean_assets:
 # Stop containers
 .PHONY: stop
 stop:
-	docker-compose stop
+	docker compose stop
 
 # Remove containers
 .PHONY: clean
 clean: clean_assets stop
-	docker-compose rm -f
+	docker compose rm -f
 
 # Wipe database
 .PHONY: clean_all
 clean_all: clean stop
-	docker-compose down -v
+	docker compose down -v
 
 # Build project documentation in live reload for editing
 .PHONY: docs
@@ -97,7 +97,7 @@ help:
 
 .PHONY: attach
 attach:
-	docker-compose exec postgres psql -h localhost -U openoversight openoversight-dev
+	docker compose exec postgres psql -h localhost -U openoversight openoversight-dev
 
 # This is needed to make sure docker doesn't create an empty directory, or delete that directory first
 .PHONY: create_empty_secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
    secrets:
      - source: service-account-key
        target: /usr/src/app/service_account_key.json
-   user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID' and run docker-compose again}"
+   user: "${UID:?Docker-compose needs UID set to the current user id number. Try 'export UID' and run docker compose again}"
    links:
      - postgres:postgres
    expose:


### PR DESCRIPTION
## Description of Changes
Use docker compose v2 plugin (`docker compose`) instead of `docker-compose`. This should fix https://github.com/lucyparsons/OpenOversight/actions/runs/10220422966/job/28280806483

This is similar to https://github.com/OrcaCollective/OpenOversight/pull/467

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
