### PR TITLE
Add invalid ID tests for `main.views`

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -321,11 +321,6 @@ def officer_profile(officer_id: int):
         officer = Officer.query.filter_by(id=officer_id).one()
     except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
-    except:  # noqa: E722
-        exception_type, value, full_traceback = sys.exc_info()
-        error_str = " ".join([str(exception_type), str(value), format_exc()])
-        current_app.logger.error(f"Error finding officer: {error_str}")
-        abort(HTTPStatus.NOT_FOUND)
     form.job_title.query = (
         Job.query.filter_by(department_id=officer.department_id)
         .order_by(Job.order.asc())

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -263,9 +263,14 @@ def redirect_sort_images(department_id: int):
 )
 @login_required
 def sort_images(department_id: int):
+    try:
+        department = Department.query.filter_by(id=department_id).one()
+    except NoResultFound:
+        abort(HTTPStatus.NOT_FOUND)
+
     # Select a random unsorted image from the database
     image_query = Image.query.filter_by(contains_cops=None).filter_by(
-        department_id=department_id
+        department_id=department.id
     )
     image = get_random_image(image_query)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -618,9 +618,10 @@ def redirect_display_tag(tag_id: int):
 def display_tag(tag_id: int):
     try:
         tag = db.session.get(Face, tag_id)
-        proper_path = serve_image(tag.original_image.filepath)
     except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
+
+    proper_path = serve_image(tag.original_image.filepath)
     return render_template(
         "tag.html", face=tag, path=proper_path, jsloads=["js/tag.js"]
     )
@@ -903,6 +904,10 @@ def list_officer(
     current_job=None,
     require_photo: Optional[bool] = None,
 ):
+    department = db.session.get(Department, department_id)
+    if not department:
+        abort(HTTPStatus.NOT_FOUND)
+
     form = BrowseForm()
     form.rank.query = (
         Job.query.filter_by(department_id=department_id, is_sworn_officer=True)
@@ -922,10 +927,6 @@ def list_officer(
     form_data["current_job"] = current_job
     form_data["unique_internal_identifier"] = unique_internal_identifier
     form_data["require_photo"] = require_photo
-
-    department = db.session.get(Department, department_id)
-    if not department:
-        abort(HTTPStatus.NOT_FOUND)
 
     age_range = {ac[0] for ac in AGE_CHOICES}
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -386,14 +386,15 @@ def redirect_add_assignment(officer_id: int):
 def add_assignment(officer_id: int):
     form = AssignmentForm()
     officer = db.session.get(Officer, officer_id)
+    if not officer:
+        flash("Officer not found")
+        abort(HTTPStatus.NOT_FOUND)
+
     form.job_title.query = (
         Job.query.filter_by(department_id=officer.department_id)
         .order_by(Job.order.asc())
         .all()
     )
-    if not officer:
-        flash("Officer not found")
-        abort(HTTPStatus.NOT_FOUND)
 
     if form.validate_on_submit():
         if current_user.is_administrator or (

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -616,9 +616,8 @@ def redirect_display_tag(tag_id: int):
 
 @main.route("/tags/<int:tag_id>")
 def display_tag(tag_id: int):
-    try:
-        tag = db.session.get(Face, tag_id)
-    except NoResultFound:
+    tag = db.session.get(Face, tag_id)
+    if not tag:
         abort(HTTPStatus.NOT_FOUND)
 
     proper_path = serve_image(tag.original_image.filepath)

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -380,8 +380,9 @@ def redirect_add_assignment(officer_id: int):
 @ac_or_admin_required
 def add_assignment(officer_id: int):
     form = AssignmentForm()
-    officer = db.session.get(Officer, officer_id)
-    if not officer:
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultFound:
         flash("Officer not found")
         abort(HTTPStatus.NOT_FOUND)
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -444,7 +444,11 @@ def redirect_edit_assignment(officer_id: int, assignment_id: int):
 @login_required
 @ac_or_admin_required
 def edit_assignment(officer_id: int, assignment_id: int):
-    officer = db.session.get(Officer, officer_id)
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultFound:
+        flash("Officer not found")
+        abort(HTTPStatus.NOT_FOUND)
 
     if current_user.is_area_coordinator and not current_user.is_administrator:
         if not ac_can_edit_officer(officer, current_user):
@@ -494,8 +498,9 @@ def redirect_add_salary(officer_id: int):
 @ac_or_admin_required
 def add_salary(officer_id: int):
     form = SalaryForm()
-    officer = db.session.get(Officer, officer_id)
-    if not officer:
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultFound:
         flash("Officer not found")
         abort(HTTPStatus.NOT_FOUND)
 
@@ -559,7 +564,12 @@ def redirect_edit_salary(officer_id: int, salary_id: int):
 @login_required
 @ac_or_admin_required
 def edit_salary(officer_id: int, salary_id: int):
-    officer = db.session.get(Officer, officer_id)
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultFound:
+        flash("Officer not found")
+        abort(HTTPStatus.NOT_FOUND)
+
     if current_user.is_area_coordinator and not current_user.is_administrator:
         if not ac_can_edit_officer(officer, current_user):
             abort(HTTPStatus.FORBIDDEN)
@@ -594,10 +604,11 @@ def redirect_display_submission(image_id: int):
 @login_required
 def display_submission(image_id: int):
     try:
-        image = db.session.get(Image, image_id)
-        proper_path = serve_image(image.filepath)
+        image = Image.query.filter_by(id=image_id).one()
     except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
+
+    proper_path = serve_image(image.filepath)
     return render_template("image.html", image=image, path=proper_path)
 
 
@@ -612,8 +623,9 @@ def redirect_display_tag(tag_id: int):
 
 @main.route("/tags/<int:tag_id>")
 def display_tag(tag_id: int):
-    tag = db.session.get(Face, tag_id)
-    if not tag:
+    try:
+        tag = Face.query.filter_by(id=tag_id).one()
+    except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
 
     proper_path = serve_image(tag.original_image.filepath)
@@ -746,7 +758,11 @@ def redirect_edit_department(department_id: int):
 @login_required
 @admin_required
 def edit_department(department_id: int):
-    department = db.get_or_404(Department, department_id)
+    try:
+        department = Department.query.filter_by(id=department_id).one()
+    except NoResultFound:
+        abort(HTTPStatus.NOT_FOUND)
+
     previous_name = department.name
     form = EditDepartmentForm(obj=department)
     original_ranks = department.jobs
@@ -899,8 +915,9 @@ def list_officer(
     current_job=None,
     require_photo: Optional[bool] = None,
 ):
-    department = db.session.get(Department, department_id)
-    if not department:
+    try:
+        department = Department.query.filter_by(id=department_id).one()
+    except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
 
     form = BrowseForm()
@@ -1192,7 +1209,10 @@ def redirect_edit_officer(officer_id: int):
 @login_required
 @ac_or_admin_required
 def edit_officer(officer_id: int):
-    officer = db.session.get(Officer, officer_id)
+    try:
+        officer = Officer.query.filter_by(id=officer_id).one()
+    except NoResultFound:
+        abort(HTTPStatus.NOT_FOUND)
     form = EditOfficerForm(obj=officer)
 
     if request.method == HTTPMethod.GET:
@@ -1268,9 +1288,9 @@ def redirect_delete_tag(tag_id: int):
 @login_required
 @ac_or_admin_required
 def delete_tag(tag_id: int):
-    tag = db.session.get(Face, tag_id)
-
-    if not tag:
+    try:
+        tag = Face.query.filter_by(id=tag_id).one()
+    except NoResultFound:
         flash("Tag not found")
         abort(HTTPStatus.NOT_FOUND)
 
@@ -1304,9 +1324,9 @@ def redirect_set_featured_tag(tag_id: int):
 @login_required
 @ac_or_admin_required
 def set_featured_tag(tag_id: int):
-    tag = db.session.get(Face, tag_id)
-
-    if not tag:
+    try:
+        tag = Face.query.filter_by(id=tag_id).one()
+    except NoResultFound:
         flash("Tag not found")
         abort(HTTPStatus.NOT_FOUND)
 
@@ -1485,9 +1505,11 @@ def redirect_complete_tagging(image_id: int):
 @login_required
 def complete_tagging(image_id: int):
     # Select a random untagged image from the database
-    image = db.session.get(Image, image_id)
-    if not image:
+    try:
+        image = Image.query.filter_by(id=image_id).one()
+    except NoResultFound:
         abort(HTTPStatus.NOT_FOUND)
+
     image.is_tagged = True
     image.last_updated_by = current_user.id
     db.session.commit()
@@ -1858,8 +1880,9 @@ def redirect_upload(department_id: int, officer_id: Optional[int] = None):
 @limiter.limit("250/minute")
 def upload(department_id: int, officer_id: Optional[int] = None):
     if officer_id:
-        officer = db.session.get(Officer, officer_id)
-        if not officer:
+        try:
+            officer = Officer.query.filter_by(id=officer_id).one()
+        except NoResultFound:
             return jsonify(error="This officer does not exist."), HTTPStatus.NOT_FOUND
         if not (
             current_user.is_administrator

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -325,6 +325,7 @@ def officer_profile(officer_id: int):
         exception_type, value, full_traceback = sys.exc_info()
         error_str = " ".join([str(exception_type), str(value), format_exc()])
         current_app.logger.error(f"Error finding officer: {error_str}")
+        abort(HTTPStatus.NOT_FOUND)
     form.job_title.query = (
         Job.query.filter_by(department_id=officer.department_id)
         .order_by(Job.order.asc())

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -279,7 +279,7 @@ def sort_images(department_id: int):
     else:
         proper_path = None
     return render_template(
-        "sort.html", image=image, path=proper_path, department_id=department_id
+        "sort.html", image=image, path=proper_path, department_id=department.id
     )
 
 

--- a/OpenOversight/tests/constants.py
+++ b/OpenOversight/tests/constants.py
@@ -1,6 +1,9 @@
 # File Mode Constants
 FILE_MODE_WRITE = "w"
 
+# Miscellaneous Constants
+INVALID_ID = 4000000
+
 # User Constants
 AC_USER_EMAIL = "raq929@example.org"
 AC_USER_PASSWORD = "horse"

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -272,7 +272,7 @@ def test_user_cannot_tag_officer_mismatched_with_department(mockdata, client, se
         ) in rv.data
 
 
-def test_invalid_id_complete_tagging(mockdata, client, session):
+def test_invalid_id_complete_tagging(client, session):
     with current_app.test_request_context():
         login_user(client)
 

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -46,6 +46,14 @@ def test_route_login_required(route, client, mockdata):
     assert rv.status_code == HTTPStatus.FOUND
 
 
+def test_invalid_department_image_sorting(client, session):
+    with current_app.test_request_context():
+        login_user(client)
+
+        rv = client.get(url_for("main.sort_images", department_id=44000))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 # POST-only routes
 @pytest.mark.parametrize(
     "route",

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -11,6 +11,7 @@ from OpenOversight.app.main.forms import FaceTag
 from OpenOversight.app.models.database import Department, Face, Image, Officer, User
 from OpenOversight.app.utils.constants import ENCODING_UTF_8
 from OpenOversight.tests.conftest import AC_DEPT
+from OpenOversight.tests.constants import INVALID_ID
 from OpenOversight.tests.routes.route_helpers import login_ac, login_admin, login_user
 
 
@@ -50,7 +51,7 @@ def test_invalid_department_image_sorting(client, session):
     with current_app.test_request_context():
         login_user(client)
 
-        rv = client.get(url_for("main.sort_images", department_id=44000))
+        rv = client.get(url_for("main.sort_images", department_id=INVALID_ID))
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -110,6 +110,14 @@ def test_user_can_view_tag(mockdata, client, session):
             assert attribute in rv.data
 
 
+def test_invalid_id_delete_tag(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.post(url_for("main.delete_tag", tag_id=INVALID_ID))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_admin_can_delete_tag(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -272,7 +272,15 @@ def test_user_cannot_tag_officer_mismatched_with_department(mockdata, client, se
         ) in rv.data
 
 
-def test_user_can_finish_tagging(mockdata, client, session):
+def test_invalid_id_complete_tagging(mockdata, client, session):
+    with current_app.test_request_context():
+        login_user(client)
+
+        rv = client.get(url_for("main.complete_tagging", image_id=INVALID_ID))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_complete_tagging(mockdata, client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         image_id = 4

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -80,6 +80,16 @@ def test_logged_in_user_can_access_sort_form(mockdata, client, session):
         assert b"Do you see uniformed law enforcement officers in the photo" in rv.data
 
 
+def test_invalid_officer_id_display_submission(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.get(
+            url_for("main.display_submission", image_id=INVALID_ID),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_user_can_view_submission(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)
@@ -90,7 +100,7 @@ def test_user_can_view_submission(mockdata, client, session):
         assert b"Image ID" in rv.data
 
 
-def test_invalid_tag_id_view_tag(client, session):
+def test_invalid_tag_id_display_tag(client, session):
     with current_app.test_request_context():
         login_user(client)
 

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -313,6 +313,16 @@ def test_user_is_redirected_to_correct_department_after_tagging(
         assert department.name in rv.data.decode(ENCODING_UTF_8)
 
 
+def test_invalid_id_set_featured_tag(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.post(
+            url_for("main.set_featured_tag", tag_id=INVALID_ID), follow_redirects=True
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_admin_can_set_featured_tag(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -90,6 +90,14 @@ def test_user_can_view_submission(mockdata, client, session):
         assert b"Image ID" in rv.data
 
 
+def test_invalid_tag_id_view_tag(client, session):
+    with current_app.test_request_context():
+        login_user(client)
+
+        rv = client.get(url_for("main.display_tag", tag_id=INVALID_ID))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_user_can_view_tag(mockdata, client, session):
     with current_app.test_request_context():
         login_user(client)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -58,6 +58,7 @@ from OpenOversight.tests.conftest import (
     SPRINGFIELD_PD,
     PoliceDepartment,
 )
+from OpenOversight.tests.constants import INVALID_ID
 from OpenOversight.tests.routes.route_helpers import (
     login_ac,
     login_admin,
@@ -189,7 +190,7 @@ def test_invalid_officer_id_add_assignment(mockdata, client, session):
         login_admin(client)
 
         rv = client.post(
-            url_for("main.add_assignment", officer_id=4000000),
+            url_for("main.add_assignment", officer_id=INVALID_ID),
         )
         assert rv.status_code == HTTPStatus.NOT_FOUND
 

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -184,6 +184,16 @@ def test_ac_cannot_access_admin_on_non_dept_officer_profile(mockdata, client, se
         assert "Admin only" not in rv.data.decode(ENCODING_UTF_8)
 
 
+def test_invalid_officer_id_add_assignment(mockdata, client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.post(
+            url_for("main.add_assignment", officer_id=4000000),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_admin_can_add_assignment(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -1709,6 +1709,15 @@ def test_admin_can_add_new_officer_with_suffix(
         assert officer.suffix == "Jr"
 
 
+def test_invalid_officer_id_upload_photos(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.post(url_for("main.upload", department_id=1, officer_id=INVALID_ID))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+        assert "This officer does not exist." in rv.data.decode(ENCODING_UTF_8)
+
+
 def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(
     mockdata, client, session
 ):

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -310,6 +310,16 @@ def test_ac_cannot_add_non_dept_assignment(mockdata, client, session):
         assert assignments is None
 
 
+def test_invalid_officer_id_edit_assignment(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.get(
+            url_for("main.edit_assignment", officer_id=INVALID_ID, assignment_id=1),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_admin_can_edit_assignment(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)
@@ -2321,6 +2331,16 @@ def test_ac_cannot_add_non_dept_salary(mockdata, client, session):
         )
 
         assert rv.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_invalid_officer_id_edit_salary(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.get(
+            url_for("main.edit_salary", officer_id=INVALID_ID, salary_id=1),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_admin_can_edit_salary(mockdata, client, session):

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -114,7 +114,6 @@ def test_route_post_only(route, client, mockdata):
 def test_invalid_id_officer_profile(mockdata, client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.officer_profile", officer_id=400000))
-
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -2223,6 +2223,16 @@ def test_edit_officers_with_blank_uids(mockdata, client, session):
         assert officer2.unique_internal_identifier is None
 
 
+def test_invalid_officer_id_add_salary(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.post(
+            url_for("main.add_salary", officer_id=INVALID_ID),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_admin_can_add_salary(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -111,6 +111,13 @@ def test_route_post_only(route, client, mockdata):
     assert rv.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
+def test_invalid_id_officer_profile(mockdata, client, session):
+    with current_app.test_request_context():
+        rv = client.get(url_for("main.officer_profile", officer_id=400000))
+
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_user_can_access_officer_profile(mockdata, client, session):
     with current_app.test_request_context():
         rv = client.get(

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -126,6 +126,12 @@ def test_user_can_access_officer_profile(mockdata, client, session):
         assert "Officer Detail" in rv.data.decode(ENCODING_UTF_8)
 
 
+def test_invalid_officer_id_officer_list(client, session):
+    with current_app.test_request_context():
+        rv = client.get(url_for("main.list_officer", department_id=INVALID_ID))
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_user_can_access_officer_list(mockdata, client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.list_officer", department_id=2))

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -2210,6 +2210,16 @@ def test_ac_can_upload_photos_of_dept_officers(
                 assert len(officer.face) == officer_face_count + 1
 
 
+def test_invalid_officer_id_edit_officer(client, session):
+    with current_app.test_request_context():
+        login_admin(client)
+
+        rv = client.get(
+            url_for("main.edit_officer", officer_id=INVALID_ID),
+        )
+        assert rv.status_code == HTTPStatus.NOT_FOUND
+
+
 def test_edit_officers_with_blank_uids(mockdata, client, session):
     with current_app.test_request_context():
         login_admin(client)


### PR DESCRIPTION
## Description of Changes
There were a handful of routes where we did not validate the initial ID parameters. Additionally, I standardized how object querying was done within the `main.views` file.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
