### PR TITLE
Remove unnecessary `mockdata` parameters

### DIFF
--- a/OpenOversight/tests/routes/test_auth.py
+++ b/OpenOversight/tests/routes/test_auth.py
@@ -39,7 +39,7 @@ from OpenOversight.tests.routes.route_helpers import (
         "/auth/reset",
     ],
 )
-def test_routes_ok(route, client, mockdata):
+def test_routes_ok(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.OK
 
@@ -57,19 +57,19 @@ def test_routes_ok(route, client, mockdata):
         "/auth/change-email/abcd1234",
     ],
 )
-def test_route_login_required(route, client, mockdata):
+def test_route_login_required(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.FOUND
 
 
-def test_valid_user_can_login(mockdata, client, session):
+def test_valid_user_can_login(client, session):
     with current_app.test_request_context():
         rv, _ = login_user(client)
         assert rv.status_code == HTTPStatus.FOUND
         assert urlparse(rv.location).path == "/index"
 
 
-def test_valid_user_can_login_with_email_differently_cased(mockdata, client, session):
+def test_valid_user_can_login_with_email_differently_cased(client, session):
     with current_app.test_request_context():
         form = LoginForm(email="JEN@EXAMPLE.ORG", password="dog", remember_me=True)
         rv = client.post(url_for("auth.login"), data=form.data, follow_redirects=False)
@@ -77,7 +77,7 @@ def test_valid_user_can_login_with_email_differently_cased(mockdata, client, ses
         assert urlparse(rv.location).path == "/index"
 
 
-def test_invalid_user_cannot_login(mockdata, client, session):
+def test_invalid_user_cannot_login(client, session):
     with current_app.test_request_context():
         form = LoginForm(
             email=UNCONFIRMED_USER_EMAIL, password="bruteforce", remember_me=True
@@ -86,7 +86,7 @@ def test_invalid_user_cannot_login(mockdata, client, session):
         assert b"Invalid username or password." in rv.data
 
 
-def test_user_can_logout(mockdata, client, session):
+def test_user_can_logout(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -94,7 +94,7 @@ def test_user_can_logout(mockdata, client, session):
         assert b"You have been logged out." in rv.data
 
 
-def test_user_cannot_register_with_existing_email(mockdata, client, session):
+def test_user_cannot_register_with_existing_email(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = RegistrationForm(
@@ -112,9 +112,7 @@ def test_user_cannot_register_with_existing_email(mockdata, client, session):
         assert b"Email already registered" in rv.data
 
 
-def test_user_cannot_register_with_existing_email_differently_cased(
-    mockdata, client, session
-):
+def test_user_cannot_register_with_existing_email_differently_cased(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = RegistrationForm(
@@ -132,7 +130,7 @@ def test_user_cannot_register_with_existing_email_differently_cased(
         assert b"Email already registered" in rv.data
 
 
-def test_user_cannot_register_if_passwords_dont_match(mockdata, client, session):
+def test_user_cannot_register_if_passwords_dont_match(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = RegistrationForm(
@@ -150,7 +148,7 @@ def test_user_cannot_register_if_passwords_dont_match(mockdata, client, session)
         assert b"Passwords must match" in rv.data
 
 
-def test_user_can_register_with_legit_credentials(mockdata, client, session, faker):
+def test_user_can_register_with_legit_credentials(client, session, faker):
     with (
         current_app.test_request_context(),
         TestCase.assertLogs(current_app.logger) as log,
@@ -173,7 +171,7 @@ def test_user_can_register_with_legit_credentials(mockdata, client, session, fak
         )
 
 
-def test_user_cannot_register_with_weak_password(mockdata, client, session):
+def test_user_cannot_register_with_weak_password(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = RegistrationForm(
@@ -189,7 +187,7 @@ def test_user_cannot_register_with_weak_password(mockdata, client, session):
         assert b"A confirmation email has been sent to you." not in rv.data
 
 
-def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
+def test_user_can_get_a_confirmation_token_resent(client, session):
     with (
         current_app.test_request_context(),
         TestCase.assertLogs(current_app.logger) as log,
@@ -205,7 +203,7 @@ def test_user_can_get_a_confirmation_token_resent(mockdata, client, session):
         )
 
 
-def test_user_can_get_password_reset_token_sent(mockdata, client, session):
+def test_user_can_get_password_reset_token_sent(client, session):
     with (
         current_app.test_request_context(),
         TestCase.assertLogs(current_app.logger) as log,
@@ -227,7 +225,7 @@ def test_user_can_get_password_reset_token_sent(mockdata, client, session):
 
 
 def test_user_can_get_password_reset_token_sent_with_differently_cased_email(
-    mockdata, client, session
+    client, session
 ):
     with (
         current_app.test_request_context(),
@@ -249,7 +247,7 @@ def test_user_can_get_password_reset_token_sent_with_differently_cased_email(
         )
 
 
-def test_user_can_get_reset_password_with_valid_token(mockdata, client, session):
+def test_user_can_get_reset_password_with_valid_token(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = PasswordResetForm(
@@ -267,7 +265,7 @@ def test_user_can_get_reset_password_with_valid_token(mockdata, client, session)
 
 
 def test_user_can_get_reset_password_with_valid_token_differently_cased(
-    mockdata, client, session
+    client, session
 ):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
@@ -285,7 +283,7 @@ def test_user_can_get_reset_password_with_valid_token_differently_cased(
         assert b"Your password has been updated." in rv.data
 
 
-def test_user_cannot_reset_password_with_invalid_token(mockdata, client, session):
+def test_user_cannot_reset_password_with_invalid_token(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(is_administrator=True).first()
         form = PasswordResetForm(
@@ -302,9 +300,7 @@ def test_user_cannot_reset_password_with_invalid_token(mockdata, client, session
         assert b"Your password has been updated." not in rv.data
 
 
-def test_user_cannot_reset_password_multiple_times_with_same_token(
-    mockdata, client, session
-):
+def test_user_cannot_reset_password_multiple_times_with_same_token(client, session):
     with current_app.test_request_context():
         form = PasswordResetForm(
             email="jen@example.org", password="catdog", password2="catdog"
@@ -327,9 +323,7 @@ def test_user_cannot_reset_password_multiple_times_with_same_token(
         assert b"Your password has been updated." not in rv.data
 
 
-def test_user_cannot_get_email_reset_token_sent_without_valid_password(
-    mockdata, client, session
-):
+def test_user_cannot_get_email_reset_token_sent_without_valid_password(client, session):
     with current_app.test_request_context():
         login_user(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -342,9 +336,7 @@ def test_user_cannot_get_email_reset_token_sent_without_valid_password(
         assert b"An email with instructions to confirm your new email" not in rv.data
 
 
-def test_user_cannot_get_email_reset_token_sent_to_existing_email(
-    mockdata, client, session
-):
+def test_user_cannot_get_email_reset_token_sent_to_existing_email(client, session):
     with current_app.test_request_context():
         login_user(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -358,7 +350,7 @@ def test_user_cannot_get_email_reset_token_sent_to_existing_email(
 
 
 def test_user_cannot_get_email_reset_token_sent_to_existing_email_differently_cased(
-    mockdata, client, session
+    client, session
 ):
     with current_app.test_request_context():
         login_user(client)
@@ -372,9 +364,7 @@ def test_user_cannot_get_email_reset_token_sent_to_existing_email_differently_ca
         assert b"An email with instructions to confirm your new email" not in rv.data
 
 
-def test_user_can_get_email_reset_token_sent_with_password(
-    mockdata, client, session, faker
-):
+def test_user_can_get_email_reset_token_sent_with_password(client, session, faker):
     with current_app.test_request_context():
         login_user(client)
         form = ChangeEmailForm(email=faker.ascii_email(), password="dog")
@@ -386,7 +376,7 @@ def test_user_can_get_email_reset_token_sent_with_password(
         assert b"An email with instructions to confirm your new email" in rv.data
 
 
-def test_user_can_change_email_with_valid_reset_token(mockdata, client, session):
+def test_user_can_change_email_with_valid_reset_token(client, session):
     with current_app.test_request_context():
         login_user(client)
         user = User.query.filter_by(is_administrator=False, is_disabled=False).first()
@@ -399,7 +389,7 @@ def test_user_can_change_email_with_valid_reset_token(mockdata, client, session)
         assert b"Your email address has been updated." in rv.data
 
 
-def test_user_cannot_change_email_with_invalid_reset_token(mockdata, client, session):
+def test_user_cannot_change_email_with_invalid_reset_token(client, session):
     with current_app.test_request_context():
         login_user(client)
         token = "beepboopbeep"
@@ -411,7 +401,7 @@ def test_user_cannot_change_email_with_invalid_reset_token(mockdata, client, ses
         assert b"Your email address has been updated." not in rv.data
 
 
-def test_user_can_confirm_account_with_valid_token(mockdata, client, session):
+def test_user_can_confirm_account_with_valid_token(client, session):
     with current_app.test_request_context():
         login_unconfirmed_user(client)
         user = User.query.filter_by(confirmed=False).first()
@@ -422,7 +412,7 @@ def test_user_can_confirm_account_with_valid_token(mockdata, client, session):
         assert b"You have confirmed your account." in rv.data
 
 
-def test_user_can_not_confirm_account_with_invalid_token(mockdata, client, session):
+def test_user_can_not_confirm_account_with_invalid_token(client, session):
     with current_app.test_request_context():
         login_unconfirmed_user(client)
         token = "beepboopbeep"
@@ -432,7 +422,7 @@ def test_user_can_not_confirm_account_with_invalid_token(mockdata, client, sessi
         assert b"The confirmation link is invalid or has expired." in rv.data
 
 
-def test_user_can_change_password_if_they_match(mockdata, client, session):
+def test_user_can_change_password_if_they_match(client, session):
     with (
         current_app.test_request_context(),
         TestCase.assertLogs(current_app.logger) as log,
@@ -453,7 +443,7 @@ def test_user_can_change_password_if_they_match(mockdata, client, session):
         )
 
 
-def test_unconfirmed_user_redirected_to_confirm_account(mockdata, client, session):
+def test_unconfirmed_user_redirected_to_confirm_account(client, session):
     with current_app.test_request_context():
         login_unconfirmed_user(client)
 
@@ -462,13 +452,13 @@ def test_unconfirmed_user_redirected_to_confirm_account(mockdata, client, sessio
         assert b"Please Confirm Your Account" in rv.data
 
 
-def test_disabled_user_cannot_login(mockdata, client, session):
+def test_disabled_user_cannot_login(client, session):
     with current_app.test_request_context():
         rv, _ = login_disabled_user(client)
         assert b"User has been disabled" in rv.data
 
 
-def test_disabled_user_cannot_visit_pages_requiring_auth(mockdata, client, session):
+def test_disabled_user_cannot_visit_pages_requiring_auth(client, session):
     # Don't use modified_disabled_user for anything else! Since we run tests
     # concurrently and this test modifies the user, there's a chance that
     # you'll get unexpected results if both tests run simultaneously.
@@ -490,7 +480,7 @@ def test_disabled_user_cannot_visit_pages_requiring_auth(mockdata, client, sessi
         assert rv.status_code == HTTPStatus.FOUND
 
 
-def test_user_cannot_change_password_if_they_dont_match(mockdata, client, session):
+def test_user_cannot_change_password_if_they_dont_match(client, session):
     with current_app.test_request_context():
         login_user(client)
         form = ChangePasswordForm(old_password="dog", password="cat", password2="butts")
@@ -502,7 +492,7 @@ def test_user_cannot_change_password_if_they_dont_match(mockdata, client, sessio
         assert b"Passwords must match" in rv.data
 
 
-def test_user_can_change_dept_pref(mockdata, client, session):
+def test_user_can_change_dept_pref(client, session):
     with current_app.test_request_context():
         login_user(client)
         form = ChangeDefaultDepartmentForm(dept_pref=AC_DEPT)
@@ -517,7 +507,7 @@ def test_user_can_change_dept_pref(mockdata, client, session):
         assert user.dept_pref == AC_DEPT
 
 
-def test_user_email_update_resets_session_token(mockdata, app, session, faker):
+def test_user_email_update_resets_session_token(app, session, faker):
     client = current_app.test_client()
 
     with current_app.app_context(), current_app.test_request_context():
@@ -541,7 +531,7 @@ def test_user_email_update_resets_session_token(mockdata, app, session, faker):
         assert rv.status_code == HTTPStatus.FOUND
 
 
-def test_user_password_update_resets_session_token(mockdata, app, session):
+def test_user_password_update_resets_session_token(app, session):
     client = current_app.test_client()
 
     with current_app.app_context(), current_app.test_request_context():

--- a/OpenOversight/tests/routes/test_descriptions.py
+++ b/OpenOversight/tests/routes/test_descriptions.py
@@ -40,7 +40,7 @@ def test_route_admin_or_required(route, client, mockdata):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_officer_descriptions_markdown(mockdata, client, session):
+def test_officer_descriptions_markdown(client, session):
     with current_app.test_request_context():
         login_user(client)
         rv = client.get(url_for("main.officer_profile", officer_id=1))
@@ -50,7 +50,7 @@ def test_officer_descriptions_markdown(mockdata, client, session):
         assert "<p>A <strong>test</strong> description!</p>" in html
 
 
-def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
+def test_admins_cannot_inject_unsafe_html(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -69,7 +69,7 @@ def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
         assert "&lt;script&gt;" in rv.data.decode()
 
 
-def test_admins_can_create_descriptions(mockdata, client, session):
+def test_admins_can_create_descriptions(client, session):
     with current_app.test_request_context():
         _, admin = login_admin(client)
         officer = Officer.query.first()
@@ -94,7 +94,7 @@ def test_admins_can_create_descriptions(mockdata, client, session):
         assert created_description.last_updated_by == admin.id
 
 
-def test_acs_can_create_descriptions(mockdata, client, session):
+def test_acs_can_create_descriptions(client, session):
     with current_app.test_request_context():
         _, ac = login_ac(client)
         officer = Officer.query.first()
@@ -119,7 +119,7 @@ def test_acs_can_create_descriptions(mockdata, client, session):
         assert created_description.last_updated_by == ac.id
 
 
-def test_admins_can_edit_descriptions(mockdata, client, session):
+def test_admins_can_edit_descriptions(client, session):
     with current_app.test_request_context():
         _, admin = login_admin(client)
         officer = Officer.query.first()
@@ -160,7 +160,7 @@ def test_admins_can_edit_descriptions(mockdata, client, session):
         assert description.last_updated_by == admin.id
 
 
-def test_ac_can_edit_their_descriptions_in_their_department(mockdata, client, session):
+def test_ac_can_edit_their_descriptions_in_their_department(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -201,7 +201,7 @@ def test_ac_can_edit_their_descriptions_in_their_department(mockdata, client, se
         assert description.last_updated_by == user.id
 
 
-def test_ac_can_edit_others_descriptions(mockdata, client, session):
+def test_ac_can_edit_others_descriptions(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -241,7 +241,7 @@ def test_ac_can_edit_others_descriptions(mockdata, client, session):
         assert description.last_updated_by == user.id
 
 
-def test_ac_cannot_edit_descriptions_not_in_their_department(mockdata, client, session):
+def test_ac_cannot_edit_descriptions_not_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -276,7 +276,7 @@ def test_ac_cannot_edit_descriptions_not_in_their_department(mockdata, client, s
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admins_can_delete_descriptions(mockdata, client, session):
+def test_admins_can_delete_descriptions(client, session):
     with current_app.test_request_context():
         login_admin(client)
         description = Description.query.first()
@@ -294,9 +294,7 @@ def test_admins_can_delete_descriptions(mockdata, client, session):
         assert deleted is None
 
 
-def test_acs_can_delete_their_descriptions_in_their_department(
-    mockdata, client, session
-):
+def test_acs_can_delete_their_descriptions_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -323,9 +321,7 @@ def test_acs_can_delete_their_descriptions_in_their_department(
         assert deleted is None
 
 
-def test_acs_cannot_delete_descriptions_not_in_their_department(
-    mockdata, client, session
-):
+def test_acs_cannot_delete_descriptions_not_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -355,7 +351,7 @@ def test_acs_cannot_delete_descriptions_not_in_their_department(
         assert not_deleted is not None
 
 
-def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
+def test_acs_can_get_edit_form_for_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -377,7 +373,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         assert "Update" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_can_get_others_edit_form(mockdata, client, session):
+def test_acs_can_get_others_edit_form(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -401,7 +397,7 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
         assert "Update" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
+def test_acs_cannot_get_edit_form_for_their_non_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -424,7 +420,7 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_users_can_see_descriptions(mockdata, client, session):
+def test_users_can_see_descriptions(client, session):
     with current_app.test_request_context():
         admin = User.query.filter_by(email=ADMIN_USER_EMAIL).first()
         officer = Officer.query.first()
@@ -446,7 +442,7 @@ def test_users_can_see_descriptions(mockdata, client, session):
         assert text_contents in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admins_can_see_descriptions(mockdata, client, session):
+def test_admins_can_see_descriptions(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -466,7 +462,7 @@ def test_admins_can_see_descriptions(mockdata, client, session):
         assert text_contents in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_can_see_descriptions_in_their_department(mockdata, client, session):
+def test_acs_can_see_descriptions_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -487,7 +483,7 @@ def test_acs_can_see_descriptions_in_their_department(mockdata, client, session)
         assert text_contents in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_can_see_descriptions_not_in_their_department(mockdata, client, session):
+def test_acs_can_see_descriptions_not_in_their_department(client, session):
     with current_app.test_request_context():
         officer = Officer.query.except_(
             Officer.query.filter_by(department_id=AC_DEPT)
@@ -512,7 +508,7 @@ def test_acs_can_see_descriptions_not_in_their_department(mockdata, client, sess
         assert user.username in response_text
 
 
-def test_anonymous_users_cannot_see_description_creators(mockdata, client, session):
+def test_anonymous_users_cannot_see_description_creators(client, session):
     with current_app.test_request_context():
         officer = Officer.query.first()
         ac = User.query.filter_by(ac_department_id=AC_DEPT).first()

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -56,12 +56,12 @@ def test_route_login_required(route, client, mockdata):
         "/images/classify/1/1",
     ],
 )
-def test_route_post_only(route, client, mockdata):
+def test_route_post_only(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-def test_logged_in_user_can_access_sort_form(mockdata, client, session):
+def test_logged_in_user_can_access_sort_form(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -71,7 +71,7 @@ def test_logged_in_user_can_access_sort_form(mockdata, client, session):
         assert b"Do you see uniformed law enforcement officers in the photo" in rv.data
 
 
-def test_user_can_view_submission(mockdata, client, session):
+def test_user_can_view_submission(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -81,7 +81,7 @@ def test_user_can_view_submission(mockdata, client, session):
         assert b"Image ID" in rv.data
 
 
-def test_user_can_view_tag(mockdata, client, session):
+def test_user_can_view_tag(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -93,7 +93,7 @@ def test_user_can_view_tag(mockdata, client, session):
             assert attribute in rv.data
 
 
-def test_admin_can_delete_tag(mockdata, client, session):
+def test_admin_can_delete_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -101,7 +101,7 @@ def test_admin_can_delete_tag(mockdata, client, session):
         assert b"Deleted this tag" in rv.data
 
 
-def test_ac_can_delete_tag_in_their_dept(mockdata, client, session):
+def test_ac_can_delete_tag_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -118,7 +118,7 @@ def test_ac_can_delete_tag_in_their_dept(mockdata, client, session):
         assert deleted_tag is None
 
 
-def test_ac_cannot_delete_tag_not_in_their_dept(mockdata, client, session):
+def test_ac_cannot_delete_tag_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -144,7 +144,7 @@ def test_ac_cannot_delete_tag_not_in_their_dept(mockdata, client, session):
     "OpenOversight.app.utils.general.serve_image",
     MagicMock(return_value=PROJECT_ROOT + "/app/static/images/test_cop1.png"),
 )
-def test_user_can_add_tag(mockdata, client, session):
+def test_user_can_add_tag(client, session):
     with current_app.test_request_context():
         mock = MagicMock(return_value=Image.query.first())
         with patch("OpenOversight.app.main.views.crop_image", mock):
@@ -171,7 +171,7 @@ def test_user_can_add_tag(mockdata, client, session):
             assert b"Tag added to database" in rv.data
 
 
-def test_user_cannot_add_tag_if_it_exists(mockdata, client, session):
+def test_user_cannot_add_tag_if_it_exists(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
 
@@ -197,7 +197,7 @@ def test_user_cannot_add_tag_if_it_exists(mockdata, client, session):
         )
 
 
-def test_user_cannot_tag_nonexistent_officer(mockdata, client, session):
+def test_user_cannot_tag_nonexistent_officer(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
 
@@ -220,7 +220,7 @@ def test_user_cannot_tag_nonexistent_officer(mockdata, client, session):
         assert b"Invalid officer ID" in rv.data
 
 
-def test_user_cannot_tag_officer_mismatched_with_department(mockdata, client, session):
+def test_user_cannot_tag_officer_mismatched_with_department(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         tag = Face.query.first()
@@ -247,7 +247,7 @@ def test_user_cannot_tag_officer_mismatched_with_department(mockdata, client, se
         ) in rv.data
 
 
-def test_user_can_finish_tagging(mockdata, client, session):
+def test_user_can_finish_tagging(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         image_id = 4
@@ -261,7 +261,7 @@ def test_user_can_finish_tagging(mockdata, client, session):
         assert image.last_updated_by == user.id
 
 
-def test_user_can_view_leaderboard(mockdata, client, session):
+def test_user_can_view_leaderboard(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -269,9 +269,7 @@ def test_user_can_view_leaderboard(mockdata, client, session):
         assert b"Top Users by Number of Images Sorted" in rv.data
 
 
-def test_user_is_redirected_to_correct_department_after_tagging(
-    mockdata, client, session
-):
+def test_user_is_redirected_to_correct_department_after_tagging(client, session):
     with current_app.test_request_context():
         login_user(client)
         department_id = 2
@@ -288,7 +286,7 @@ def test_user_is_redirected_to_correct_department_after_tagging(
         assert department.name in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_can_set_featured_tag(mockdata, client, session):
+def test_admin_can_set_featured_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -298,7 +296,7 @@ def test_admin_can_set_featured_tag(mockdata, client, session):
         assert b"Successfully set this tag as featured" in rv.data
 
 
-def test_ac_can_set_featured_tag_in_their_dept(mockdata, client, session):
+def test_ac_can_set_featured_tag_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -318,7 +316,7 @@ def test_ac_can_set_featured_tag_in_their_dept(mockdata, client, session):
         assert featured_tag is not None
 
 
-def test_ac_cannot_set_featured_tag_not_in_their_dept(mockdata, client, session):
+def test_ac_cannot_set_featured_tag_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -347,7 +345,7 @@ def test_ac_cannot_set_featured_tag_not_in_their_dept(mockdata, client, session)
     "OpenOversight.app.utils.general.serve_image",
     MagicMock(return_value=PROJECT_ROOT + "/app/static/images/test_cop1.png"),
 )
-def test_featured_tag_replaces_others(mockdata, client, session):
+def test_featured_tag_replaces_others(client, session):
     with current_app.test_request_context():
         _, user = login_admin(client)
 

--- a/OpenOversight/tests/routes/test_image_tagging.py
+++ b/OpenOversight/tests/routes/test_image_tagging.py
@@ -90,7 +90,7 @@ def test_invalid_officer_id_display_submission(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_can_view_submission(mockdata, client, session):
+def test_user_can_view_submission(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -108,7 +108,7 @@ def test_invalid_tag_id_display_tag(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_can_view_tag(mockdata, client, session):
+def test_user_can_view_tag(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -120,7 +120,7 @@ def test_user_can_view_tag(mockdata, client, session):
             assert attribute in rv.data
 
 
-def test_invalid_id_delete_tag(mockdata, client, session):
+def test_invalid_id_delete_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -128,7 +128,7 @@ def test_invalid_id_delete_tag(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_delete_tag(mockdata, client, session):
+def test_admin_can_delete_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -290,7 +290,7 @@ def test_invalid_id_complete_tagging(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_complete_tagging(mockdata, client, session):
+def test_complete_tagging(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         image_id = 4
@@ -329,7 +329,7 @@ def test_user_is_redirected_to_correct_department_after_tagging(client, session)
         assert department.name in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_invalid_id_set_featured_tag(mockdata, client, session):
+def test_invalid_id_set_featured_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -339,7 +339,7 @@ def test_invalid_id_set_featured_tag(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_set_featured_tag(mockdata, client, session):
+def test_admin_can_set_featured_tag(client, session):
     with current_app.test_request_context():
         login_admin(client)
 

--- a/OpenOversight/tests/routes/test_incidents.py
+++ b/OpenOversight/tests/routes/test_incidents.py
@@ -35,7 +35,7 @@ def test_routes_ok(route, client, mockdata):
 @pytest.mark.parametrize(
     "route", ["incidents/1/edit", "incidents/new", "incidents/1/delete"]
 )
-def test_route_login_required(route, client, mockdata):
+def test_route_login_required(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.FOUND
 
@@ -59,7 +59,7 @@ def test_route_admin_or_required(route, client, mockdata):
         "PPP Case 92",
     ],
 )
-def test_admins_can_create_basic_incidents(report_number, mockdata, client, session):
+def test_admins_can_create_basic_incidents(report_number, client, session):
     with current_app.test_request_context():
         login_admin(client)
         test_date = datetime(2000, 5, 25, 1, 45)
@@ -107,7 +107,7 @@ def test_admins_can_create_basic_incidents(report_number, mockdata, client, sess
     ],
 )
 def test_admins_can_create_incidents_with_links(
-    mockdata, client, session, link_type, expected_text
+    client, session, link_type, expected_text
 ):
     with current_app.test_request_context():
         login_admin(client)
@@ -160,9 +160,7 @@ def test_admins_can_create_incidents_with_links(
         assert expected_text in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admins_cannot_create_incident_with_invalid_report_number(
-    mockdata, client, session
-):
+def test_admins_cannot_create_incident_with_invalid_report_number(client, session):
     with current_app.test_request_context():
         login_admin(client)
         test_date = datetime(2000, 5, 25, 1, 45)
@@ -202,7 +200,7 @@ def test_admins_cannot_create_incident_with_invalid_report_number(
         )
 
 
-def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
+def test_admins_can_edit_incident_date_and_address(client, session):
     with current_app.test_request_context():
         login_admin(client)
         inc = Incident.query.options(
@@ -256,7 +254,7 @@ def test_admins_can_edit_incident_date_and_address(mockdata, client, session):
         assert updated.address.street_name == street_name
 
 
-def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session, faker):
+def test_admins_can_edit_incident_links_and_licenses(client, session, faker):
     with current_app.test_request_context():
         login_admin(client)
         inc = Incident.query.options(
@@ -319,7 +317,7 @@ def test_admins_can_edit_incident_links_and_licenses(mockdata, client, session, 
         assert new_number in [lp.number for lp in inc.license_plates]
 
 
-def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
+def test_admins_cannot_make_ancient_incidents(client, session):
     with current_app.test_request_context():
         login_admin(client)
         inc = Incident.query.options(
@@ -359,7 +357,7 @@ def test_admins_cannot_make_ancient_incidents(mockdata, client, session):
         assert "Incidents prior to 1900 not allowed." in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
+def test_admins_cannot_make_incidents_without_state(client, session):
     with current_app.test_request_context():
         login_admin(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -396,9 +394,7 @@ def test_admins_cannot_make_incidents_without_state(mockdata, client, session):
         assert incident_count_before == Incident.query.count()
 
 
-def test_admins_cannot_make_incidents_with_multiple_validation_errors(
-    mockdata, client, session
-):
+def test_admins_cannot_make_incidents_with_multiple_validation_errors(client, session):
     with current_app.test_request_context():
         login_admin(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -446,7 +442,7 @@ def test_admins_cannot_make_incidents_with_multiple_validation_errors(
         assert incident_count_before == Incident.query.count()
 
 
-def test_admins_can_edit_incident_officers(mockdata, client, session):
+def test_admins_can_edit_incident_officers(client, session):
     with current_app.test_request_context():
         login_admin(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -509,7 +505,7 @@ def test_admins_can_edit_incident_officers(mockdata, client, session):
         assert new_officer.id in [off.id for off in inc.officers]
 
 
-def test_admins_cannot_edit_non_existing_officers(mockdata, client, session):
+def test_admins_cannot_edit_non_existing_officers(client, session):
     with current_app.test_request_context():
         login_admin(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -568,7 +564,7 @@ def test_admins_cannot_edit_non_existing_officers(mockdata, client, session):
             assert officer in inc.officers
 
 
-def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
+def test_ac_can_edit_incidents_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         user = User.query.filter_by(ac_department_id=AC_DEPT).first()
@@ -619,7 +615,7 @@ def test_ac_can_edit_incidents_in_their_department(mockdata, client, session):
         assert inc.address.street_name == street_name
 
 
-def test_ac_cannot_edit_incidents_not_in_their_department(mockdata, client, session):
+def test_ac_cannot_edit_incidents_not_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         user = User.query.filter_by(
@@ -670,7 +666,7 @@ def test_ac_cannot_edit_incidents_not_in_their_department(mockdata, client, sess
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admins_can_delete_incidents(mockdata, client, session):
+def test_admins_can_delete_incidents(client, session):
     with current_app.test_request_context():
         login_admin(client)
         incident = Incident.query.first()
@@ -684,7 +680,7 @@ def test_admins_can_delete_incidents(mockdata, client, session):
         assert deleted is None
 
 
-def test_acs_can_delete_incidents_in_their_department(mockdata, client, session):
+def test_acs_can_delete_incidents_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         incident = Incident.query.filter_by(department_id=AC_DEPT).first()
@@ -698,7 +694,7 @@ def test_acs_can_delete_incidents_in_their_department(mockdata, client, session)
         assert deleted is None
 
 
-def test_acs_cannot_delete_incidents_not_in_their_department(mockdata, client, session):
+def test_acs_cannot_delete_incidents_not_in_their_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
         incident = Incident.query.except_(
@@ -714,7 +710,7 @@ def test_acs_cannot_delete_incidents_not_in_their_department(mockdata, client, s
         assert not_deleted.id is inc_id
 
 
-def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
+def test_acs_can_get_edit_form_for_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         incident = Incident.query.filter_by(department_id=AC_DEPT).first()
@@ -726,7 +722,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         assert "Update" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
+def test_acs_cannot_get_edit_form_for_their_non_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         incident = Incident.query.except_(
@@ -739,7 +735,7 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_users_can_view_incidents_by_department(mockdata, client, session):
+def test_users_can_view_incidents_by_department(client, session):
     with current_app.test_request_context():
         department = Department.query.first()
         department_incidents = Incident.query.filter_by(department_id=department.id)
@@ -761,28 +757,28 @@ def test_users_can_view_incidents_by_department(mockdata, client, session):
             )
 
 
-def test_admins_can_see_who_created_incidents(mockdata, client, session):
+def test_admins_can_see_who_created_incidents(client, session):
     with current_app.test_request_context():
         login_admin(client)
         rv = client.get(url_for("main.incident_api", obj_id=1))
         assert "Creator" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_cannot_see_who_created_incidents(mockdata, client, session):
+def test_acs_cannot_see_who_created_incidents(client, session):
     with current_app.test_request_context():
         login_ac(client)
         rv = client.get(url_for("main.incident_api", obj_id=1))
         assert "Creator" not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_users_cannot_see_who_created_incidents(mockdata, client, session):
+def test_users_cannot_see_who_created_incidents(client, session):
     with current_app.test_request_context():
         login_ac(client)
         rv = client.get(url_for("main.incident_api", obj_id=1))
         assert "Creator" not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_form_with_officer_id_prepopulates(mockdata, client, session):
+def test_form_with_officer_id_prepopulates(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer_id = "1234"
@@ -790,7 +786,7 @@ def test_form_with_officer_id_prepopulates(mockdata, client, session):
         assert officer_id in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_incident_markdown(mockdata, client, session):
+def test_incident_markdown(client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.incident_api"))
         html = rv.data.decode()
@@ -798,7 +794,7 @@ def test_incident_markdown(mockdata, client, session):
         assert "<p><strong>Markup</strong> description</p>" in html
 
 
-def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
+def test_admins_cannot_inject_unsafe_html(client, session):
     with current_app.test_request_context():
         login_admin(client)
         user = User.query.filter_by(is_administrator=True).first()
@@ -869,7 +865,7 @@ def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
     ],
 )
 def test_users_can_search_incidents(
-    params, included_report_nums, excluded_report_nums, mockdata, client, session
+    params, included_report_nums, excluded_report_nums, client, session
 ):
     with current_app.test_request_context():
         rv = client.get(url_for("main.incident_api", **params))

--- a/OpenOversight/tests/routes/test_notes.py
+++ b/OpenOversight/tests/routes/test_notes.py
@@ -35,7 +35,7 @@ def test_route_admin_or_required(route, client, mockdata):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_officer_notes_markdown(mockdata, client, session):
+def test_officer_notes_markdown(client, session):
     with current_app.test_request_context():
         login_admin(client)  # need to be admin or AC to see notes
         rv = client.get(url_for("main.officer_profile", officer_id=1))
@@ -45,7 +45,7 @@ def test_officer_notes_markdown(mockdata, client, session):
         assert "<p>A <strong>test</strong> note!</p>" in html
 
 
-def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
+def test_admins_cannot_inject_unsafe_html(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -64,7 +64,7 @@ def test_admins_cannot_inject_unsafe_html(mockdata, client, session):
         assert "&lt;script&gt;" in rv.data.decode()
 
 
-def test_admins_can_create_notes(mockdata, client, session, faker):
+def test_admins_can_create_notes(client, session, faker):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -90,7 +90,7 @@ def test_admins_can_create_notes(mockdata, client, session, faker):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_acs_can_create_notes(mockdata, client, session, faker):
+def test_acs_can_create_notes(client, session, faker):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.first()
@@ -111,7 +111,7 @@ def test_acs_can_create_notes(mockdata, client, session, faker):
         assert created_note.created_at is not None
 
 
-def test_admins_can_edit_notes(mockdata, client, session, faker):
+def test_admins_can_edit_notes(client, session, faker):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -147,7 +147,7 @@ def test_admins_can_edit_notes(mockdata, client, session, faker):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_edit_their_notes_in_their_department(mockdata, client, session, faker):
+def test_ac_can_edit_their_notes_in_their_department(client, session, faker):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -178,7 +178,7 @@ def test_ac_can_edit_their_notes_in_their_department(mockdata, client, session, 
         assert note.last_updated_at > original_date
 
 
-def test_ac_can_edit_others_notes(mockdata, client, session):
+def test_ac_can_edit_others_notes(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -212,7 +212,7 @@ def test_ac_can_edit_others_notes(mockdata, client, session):
         assert note.last_updated_at > original_date
 
 
-def test_ac_cannot_edit_notes_not_in_their_department(mockdata, client, session):
+def test_ac_cannot_edit_notes_not_in_their_department(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
 
@@ -245,7 +245,7 @@ def test_ac_cannot_edit_notes_not_in_their_department(mockdata, client, session)
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admins_can_delete_notes(mockdata, client, session):
+def test_admins_can_delete_notes(client, session):
     with current_app.test_request_context():
         login_admin(client)
         note = Note.query.first()
@@ -268,7 +268,7 @@ def test_admins_can_delete_notes(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_acs_can_delete_their_notes_in_their_department(mockdata, client, session):
+def test_acs_can_delete_their_notes_in_their_department(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -292,9 +292,7 @@ def test_acs_can_delete_their_notes_in_their_department(mockdata, client, sessio
         assert deleted is None
 
 
-def test_acs_cannot_delete_notes_not_in_their_department(
-    mockdata, client, session, faker
-):
+def test_acs_cannot_delete_notes_not_in_their_department(client, session, faker):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -321,7 +319,7 @@ def test_acs_cannot_delete_notes_not_in_their_department(
         assert not_deleted is not None
 
 
-def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
+def test_acs_can_get_edit_form_for_their_dept(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -344,7 +342,7 @@ def test_acs_can_get_edit_form_for_their_dept(mockdata, client, session):
         assert "Update" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_can_get_others_edit_form(mockdata, client, session):
+def test_acs_can_get_others_edit_form(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -367,7 +365,7 @@ def test_acs_can_get_others_edit_form(mockdata, client, session):
         assert "Update" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
+def test_acs_cannot_get_edit_form_for_their_non_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -391,7 +389,7 @@ def test_acs_cannot_get_edit_form_for_their_non_dept(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_users_cannot_see_notes(mockdata, client, session, faker):
+def test_users_cannot_see_notes(client, session, faker):
     with current_app.test_request_context():
         officer = Officer.query.first()
         text_contents = faker.sentence(nb_words=20)
@@ -416,7 +414,7 @@ def test_users_cannot_see_notes(mockdata, client, session, faker):
         assert text_contents not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admins_can_see_notes(mockdata, client, session):
+def test_admins_can_see_notes(client, session):
     with current_app.test_request_context():
         _, user = login_admin(client)
         officer = Officer.query.first()
@@ -441,7 +439,7 @@ def test_admins_can_see_notes(mockdata, client, session):
         assert text_contents in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_can_see_notes_in_their_department(mockdata, client, session):
+def test_acs_can_see_notes_in_their_department(client, session):
     with current_app.test_request_context():
         _, user = login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -467,7 +465,7 @@ def test_acs_can_see_notes_in_their_department(mockdata, client, session):
         assert text_contents in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_acs_cannot_see_notes_not_in_their_department(mockdata, client, session):
+def test_acs_cannot_see_notes_not_in_their_department(client, session):
     with current_app.test_request_context():
         officer = Officer.query.except_(
             Officer.query.filter_by(department_id=AC_DEPT)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -94,7 +94,7 @@ def test_routes_ok(route, client, mockdata):
         "/units/new",
     ],
 )
-def test_route_login_required(route, client, mockdata):
+def test_route_login_required(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.FOUND
 
@@ -232,7 +232,7 @@ def test_admin_add_assignment_validation_error(client, session):
         assert assignments is None
 
 
-def test_ac_can_add_assignment_in_their_dept(mockdata, client, session):
+def test_ac_can_add_assignment_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -264,7 +264,7 @@ def test_ac_can_add_assignment_in_their_dept(mockdata, client, session):
         assert assignment.resign_date == date(2019, 12, 31)
 
 
-def test_ac_cannot_add_non_dept_assignment(mockdata, client, session):
+def test_ac_cannot_add_non_dept_assignment(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -287,7 +287,7 @@ def test_ac_cannot_add_non_dept_assignment(mockdata, client, session):
         assert assignments is None
 
 
-def test_admin_can_edit_assignment(mockdata, client, session):
+def test_admin_can_edit_assignment(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -349,7 +349,7 @@ def test_admin_can_edit_assignment(mockdata, client, session):
 
 
 def test_admin_edit_assignment_validation_error(
-    mockdata, client, session, officer_no_assignments
+    client, session, officer_no_assignments
 ):
     with current_app.test_request_context():
         login_admin(client)
@@ -390,7 +390,7 @@ def test_admin_edit_assignment_validation_error(
         assert assignment.resign_date == date(2019, 12, 31)
 
 
-def test_ac_can_edit_officer_in_their_dept_assignment(mockdata, client, session):
+def test_ac_can_edit_officer_in_their_dept_assignment(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -453,7 +453,7 @@ def test_ac_can_edit_officer_in_their_dept_assignment(mockdata, client, session)
         assert officer.assignments[0].resign_date == date(2019, 11, 30)
 
 
-def test_ac_cannot_edit_assignment_outside_their_dept(mockdata, client, session):
+def test_ac_cannot_edit_assignment_outside_their_dept(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -503,7 +503,7 @@ def test_ac_cannot_edit_assignment_outside_their_dept(mockdata, client, session)
 TestPD = PoliceDepartment("Test Police Department", "TPD")
 
 
-def test_admin_can_add_police_department(mockdata, client, session):
+def test_admin_can_add_police_department(client, session):
     with current_app.test_request_context():
         _, user = login_admin(client)
 
@@ -530,7 +530,7 @@ def test_admin_can_add_police_department(mockdata, client, session):
         assert department.last_updated_by == user.id
 
 
-def test_admin_cannot_add_police_department_without_state(mockdata, client, session):
+def test_admin_cannot_add_police_department_without_state(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -543,7 +543,7 @@ def test_admin_cannot_add_police_department_without_state(mockdata, client, sess
         assert "Invalid value, must be one of: FA, AL, AK, AZ" in errors.get("state")[0]
 
 
-def test_ac_cannot_add_police_department(mockdata, client, session):
+def test_ac_cannot_add_police_department(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -560,7 +560,7 @@ def test_ac_cannot_add_police_department(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_cannot_add_duplicate_police_department(mockdata, client, session):
+def test_admin_cannot_add_duplicate_police_department(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -596,7 +596,7 @@ def test_admin_cannot_add_duplicate_police_department(mockdata, client, session)
 CorrectedPD = PoliceDepartment("Corrected Police Department", "CPD")
 
 
-def test_admin_can_edit_police_department(mockdata, client, session):
+def test_admin_can_edit_police_department(client, session):
     with current_app.test_request_context():
         # Prevent CorrectedPD and MisspelledPD from having the same state
         MisspelledPD = PoliceDepartment(
@@ -707,7 +707,7 @@ def test_admin_can_edit_police_department(mockdata, client, session):
         )
 
 
-def test_admin_cannot_edit_police_department_without_state(mockdata, client, session):
+def test_admin_cannot_edit_police_department_without_state(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -740,7 +740,7 @@ def test_admin_cannot_edit_police_department_without_state(mockdata, client, ses
         assert "Invalid value, must be one of: FA, AL, AK, AZ" in errors.get("state")[0]
 
 
-def test_ac_cannot_edit_police_department(mockdata, client, session, department):
+def test_ac_cannot_edit_police_department(client, session, department):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -759,7 +759,7 @@ def test_ac_cannot_edit_police_department(mockdata, client, session, department)
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_can_edit_rank_order(mockdata, client, session, department):
+def test_admin_can_edit_rank_order(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
         ranks = department.jobs
@@ -793,7 +793,7 @@ def test_admin_can_edit_rank_order(mockdata, client, session, department):
         )
 
 
-def test_admin_cannot_delete_rank_in_use(mockdata, client, session, department):
+def test_admin_cannot_delete_rank_in_use(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -823,7 +823,7 @@ def test_admin_cannot_delete_rank_in_use(mockdata, client, session, department):
         assert len(updated_ranks) == len(original_ranks)
 
 
-def test_admin_can_delete_rank_not_in_use(mockdata, client, session, department):
+def test_admin_can_delete_rank_not_in_use(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
         ranks_update = RANK_CHOICES_1.copy()
@@ -886,9 +886,7 @@ def test_admin_can_delete_rank_not_in_use(mockdata, client, session, department)
         )
 
 
-def test_admin_can_delete_multiple_ranks_not_in_use(
-    mockdata, client, session, department
-):
+def test_admin_can_delete_multiple_ranks_not_in_use(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -947,7 +945,7 @@ def test_admin_can_delete_multiple_ranks_not_in_use(
 
 
 def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_use_rank(
-    mockdata, client, session, department
+    client, session, department
 ):
     with current_app.test_request_context():
         login_admin(client)
@@ -1014,9 +1012,7 @@ def test_admin_cannot_commit_edit_that_deletes_one_rank_in_use_and_one_not_in_us
 ExistingPD = PoliceDepartment("Existing Police Department", "EPD")
 
 
-def test_admin_can_create_department_with_same_name_in_different_state(
-    mockdata, client, session
-):
+def test_admin_can_create_department_with_same_name_in_different_state(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1089,9 +1085,7 @@ def test_admin_can_create_department_with_same_name_in_different_state(
         ) in existing_duplicate_rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_cannot_duplicate_police_department_during_edit(
-    mockdata, client, session
-):
+def test_admin_cannot_duplicate_police_department_during_edit(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1155,7 +1149,7 @@ def test_admin_cannot_duplicate_police_department_during_edit(
         assert new_department.short_name == NewPD.short_name
 
 
-def test_expected_dept_appears_in_submission_dept_selection(mockdata, client, session):
+def test_expected_dept_appears_in_submission_dept_selection(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1164,7 +1158,7 @@ def test_expected_dept_appears_in_submission_dept_selection(mockdata, client, se
         assert SPRINGFIELD_PD.name in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_can_add_new_officer(mockdata, client, session, department, faker):
+def test_admin_can_add_new_officer(client, session, department, faker):
     with current_app.test_request_context():
         _, admin = login_admin(client)
 
@@ -1225,9 +1219,7 @@ def test_admin_can_add_new_officer(mockdata, client, session, department, faker)
         assert officer.descriptions[0].last_updated_by == admin.id
 
 
-def test_admin_can_add_new_officer_with_unit(
-    mockdata, client, session, department, faker
-):
+def test_admin_can_add_new_officer_with_unit(client, session, department, faker):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1265,7 +1257,7 @@ def test_admin_can_add_new_officer_with_unit(
         assert Assignment.query.filter_by(base_officer=officer, unit=unit).one()
 
 
-def test_ac_can_add_new_officer_in_their_dept(mockdata, client, session):
+def test_ac_can_add_new_officer_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         department = session.get(Department, AC_DEPT)
@@ -1307,7 +1299,7 @@ def test_ac_can_add_new_officer_in_their_dept(mockdata, client, session):
             assert officer.gender == gender
 
 
-def test_ac_can_add_new_officer_with_unit_in_their_dept(mockdata, client, session):
+def test_ac_can_add_new_officer_with_unit_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         department = session.get(Department, AC_DEPT)
@@ -1352,7 +1344,7 @@ def test_ac_can_add_new_officer_with_unit_in_their_dept(mockdata, client, sessio
         assert Assignment.query.filter_by(base_officer=officer, unit=unit).one()
 
 
-def test_ac_cannot_add_new_officer_not_in_their_dept(mockdata, client, session):
+def test_ac_cannot_add_new_officer_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -1385,7 +1377,7 @@ def test_ac_cannot_add_new_officer_not_in_their_dept(mockdata, client, session):
         assert officer is None
 
 
-def test_admin_can_edit_existing_officer(mockdata, client, session, department, faker):
+def test_admin_can_edit_existing_officer(client, session, department, faker):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1431,7 +1423,7 @@ def test_admin_can_edit_existing_officer(mockdata, client, session, department, 
         assert link_url1 not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_edit_officer_not_in_their_dept(mockdata, client, session):
+def test_ac_cannot_edit_officer_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -1458,7 +1450,7 @@ def test_ac_cannot_edit_officer_not_in_their_dept(mockdata, client, session):
         assert officer.last_name == old_last_name
 
 
-def test_ac_can_see_officer_not_in_their_dept(mockdata, client, session):
+def test_ac_can_see_officer_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -1476,7 +1468,7 @@ def test_ac_can_see_officer_not_in_their_dept(mockdata, client, session):
         assert str(officer.id) in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_can_edit_officer_in_their_dept(mockdata, client, session):
+def test_ac_can_edit_officer_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         department = session.get(Department, AC_DEPT)
@@ -1533,9 +1525,7 @@ def test_ac_can_edit_officer_in_their_dept(mockdata, client, session):
         assert officer.last_name == new_last_name
 
 
-def test_admin_adds_officer_without_middle_initial(
-    mockdata, client, session, department
-):
+def test_admin_adds_officer_without_middle_initial(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1564,9 +1554,7 @@ def test_admin_adds_officer_without_middle_initial(
         assert officer.gender == "M"
 
 
-def test_admin_adds_officer_with_letter_in_badge_no(
-    mockdata, client, session, department
-):
+def test_admin_adds_officer_with_letter_in_badge_no(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1596,7 +1584,7 @@ def test_admin_adds_officer_with_letter_in_badge_no(
         assert officer.assignments[0].star_no == "T666"
 
 
-def test_admin_can_add_new_unit(mockdata, client, session, department):
+def test_admin_can_add_new_unit(client, session, department):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1613,7 +1601,7 @@ def test_admin_can_add_new_unit(mockdata, client, session, department):
         assert unit.department_id == department.id
 
 
-def test_ac_can_add_new_unit_in_their_dept(mockdata, client, session):
+def test_ac_can_add_new_unit_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -1631,7 +1619,7 @@ def test_ac_can_add_new_unit_in_their_dept(mockdata, client, session):
         assert unit.department_id == department.id
 
 
-def test_ac_cannot_add_new_unit_not_in_their_dept(mockdata, client, session):
+def test_ac_cannot_add_new_unit_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -1647,9 +1635,7 @@ def test_ac_cannot_add_new_unit_not_in_their_dept(mockdata, client, session):
         assert unit is None
 
 
-def test_admin_can_add_new_officer_with_suffix(
-    mockdata, client, session, department, faker
-):
+def test_admin_can_add_new_officer_with_suffix(client, session, department, faker):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1686,9 +1672,7 @@ def test_admin_can_add_new_officer_with_suffix(
         assert officer.suffix == "Jr"
 
 
-def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(
-    mockdata, client, session
-):
+def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(client, session):
     with current_app.test_request_context():
         login_ac(client)
         department = Department.query.except_(
@@ -1704,7 +1688,7 @@ def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_officer_csv(mockdata, client, session, department, faker):
+def test_officer_csv(client, session, department, faker):
     with current_app.test_request_context():
         login_admin(client)
         links = [
@@ -1753,7 +1737,7 @@ def test_officer_csv(mockdata, client, session, department, faker):
         assert form.star_no.data == added_lines[0]["badge number"]
 
 
-def test_assignments_csv(mockdata, client, session, department):
+def test_assignments_csv(client, session, department):
     with current_app.test_request_context():
         _, user = login_admin(client)
         officer = Officer.query.filter_by(department_id=department.id).first()
@@ -1793,7 +1777,7 @@ def test_assignments_csv(mockdata, client, session, department):
         assert new_assignment[0]["job title"] == job.job_title
 
 
-def test_incidents_csv(mockdata, client, session, department, faker):
+def test_incidents_csv(client, session, department, faker):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1842,7 +1826,7 @@ def test_incidents_csv(mockdata, client, session, department, faker):
         assert form.description.data in csv[0]
 
 
-def test_browse_filtering_filters_bad(client, mockdata, session):
+def test_browse_filtering_filters_bad(client, session):
     with current_app.test_request_context():
         race_list = ["BLACK", "WHITE"]
         gender_list = ["M", "F"]
@@ -1895,7 +1879,7 @@ def test_browse_filtering_filters_bad(client, mockdata, session):
                     assert not any(bad_substr in token for token in filter_list)
 
 
-def test_browse_filtering_allows_good(client, mockdata, session, faker):
+def test_browse_filtering_allows_good(client, session, faker):
     with current_app.test_request_context():
         department_id = Department.query.first().id
 
@@ -1976,7 +1960,7 @@ def test_browse_filtering_allows_good(client, mockdata, session, faker):
         assert any("<dd>Male</dd>" in token for token in filter_list)
 
 
-def test_find_officer_redirect(client, mockdata, session):
+def test_find_officer_redirect(client, session):
     with current_app.test_request_context():
         department_id = Department.query.first().id
         rank = "Officer"
@@ -2028,9 +2012,7 @@ def test_find_officer_redirect(client, mockdata, session):
             assert f"{name}={value}" in rv.location
 
 
-def test_admin_can_upload_photos_of_dept_officers(
-    mockdata, client, session, test_jpg_bytes_io
-):
+def test_admin_can_upload_photos_of_dept_officers(client, session, test_jpg_bytes_io):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -2068,9 +2050,7 @@ def test_admin_can_upload_photos_of_dept_officers(
                 assert len(officer.face) == officer_face_count + 1
 
 
-def test_upload_photo_sends_500_on_s3_error(
-    mockdata, client, session, test_png_bytes_io
-):
+def test_upload_photo_sends_500_on_s3_error(client, session, test_png_bytes_io):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -2094,7 +2074,7 @@ def test_upload_photo_sends_500_on_s3_error(
             assert len(officer.face) == officer_face_count
 
 
-def test_upload_photo_sends_415_for_bad_file_type(mockdata, client, session):
+def test_upload_photo_sends_415_for_bad_file_type(client, session):
     with current_app.test_request_context():
         login_admin(client)
         data = {"file": (BytesIO(b"my file contents"), "test_cop1.png")}
@@ -2113,7 +2093,7 @@ def test_upload_photo_sends_415_for_bad_file_type(mockdata, client, session):
         assert b"not allowed" in rv.data
 
 
-def test_user_cannot_upload_officer_photo(mockdata, client, session):
+def test_user_cannot_upload_officer_photo(client, session):
     with current_app.test_request_context():
         login_user(client)
         data = {"file": (BytesIO(b"my file contents"), "test_cop1.png")}
@@ -2128,9 +2108,7 @@ def test_user_cannot_upload_officer_photo(mockdata, client, session):
         assert b"not authorized" in rv.data
 
 
-def test_ac_can_upload_photos_of_dept_officers(
-    mockdata, client, session, test_png_bytes_io
-):
+def test_ac_can_upload_photos_of_dept_officers(client, session, test_png_bytes_io):
     with current_app.test_request_context():
         login_ac(client)
         data = {
@@ -2168,7 +2146,7 @@ def test_ac_can_upload_photos_of_dept_officers(
                 assert len(officer.face) == officer_face_count + 1
 
 
-def test_edit_officers_with_blank_uids(mockdata, client, session):
+def test_edit_officers_with_blank_uids(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -2206,7 +2184,7 @@ def test_edit_officers_with_blank_uids(mockdata, client, session):
         assert officer2.unique_internal_identifier is None
 
 
-def test_admin_can_add_salary(mockdata, client, session):
+def test_admin_can_add_salary(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, AC_DEPT)
@@ -2236,7 +2214,7 @@ def test_admin_can_add_salary(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_add_salary_in_their_dept(mockdata, client, session):
+def test_ac_can_add_salary_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -2261,7 +2239,7 @@ def test_ac_can_add_salary_in_their_dept(mockdata, client, session):
         assert officer is not None
 
 
-def test_ac_cannot_add_non_dept_salary(mockdata, client, session):
+def test_ac_cannot_add_non_dept_salary(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -2281,7 +2259,7 @@ def test_ac_cannot_add_non_dept_salary(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_can_edit_salary(mockdata, client, session):
+def test_admin_can_edit_salary(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, 1)
@@ -2331,7 +2309,7 @@ def test_admin_can_edit_salary(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
+def test_ac_can_edit_salary_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
 
@@ -2377,7 +2355,7 @@ def test_ac_can_edit_salary_in_their_dept(mockdata, client, session):
         assert officer.salaries[0].salary == 150000
 
 
-def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
+def test_ac_cannot_edit_non_dept_salary(client, session):
     with current_app.test_request_context():
         officer = Officer.query.except_(
             Officer.query.filter_by(department_id=AC_DEPT)
@@ -2422,9 +2400,7 @@ def test_ac_cannot_edit_non_dept_salary(mockdata, client, session):
         assert float(officer.salaries[0].salary) == 123456.78
 
 
-def test_get_department_ranks_with_specific_department_id(
-    mockdata, client, session, department
-):
+def test_get_department_ranks_with_specific_department_id(client, session, department):
     with current_app.test_request_context():
         rv = client.get(
             url_for("main.get_dept_ranks", department_id=department.id),
@@ -2437,7 +2413,7 @@ def test_get_department_ranks_with_specific_department_id(
         assert data.count("Commander") == 1
 
 
-def test_get_department_ranks_with_no_department(mockdata, client, session):
+def test_get_department_ranks_with_no_department(client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.get_dept_ranks"), follow_redirects=True)
         data = json.loads(rv.data.decode(ENCODING_UTF_8))
@@ -2447,7 +2423,7 @@ def test_get_department_ranks_with_no_department(mockdata, client, session):
         assert data.count("Commander") == 3  # Once for each test department
 
 
-def test_admin_can_add_link_to_officer_profile(mockdata, client, session):
+def test_admin_can_add_link_to_officer_profile(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = Officer.query.first()
@@ -2477,7 +2453,7 @@ def test_admin_can_add_link_to_officer_profile(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_add_link_to_officer_profile_in_their_dept(mockdata, client, session):
+def test_ac_can_add_link_to_officer_profile_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -2502,9 +2478,7 @@ def test_ac_can_add_link_to_officer_profile_in_their_dept(mockdata, client, sess
         assert officer.unique_internal_identifier in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_add_link_to_officer_profile_not_in_their_dept(
-    mockdata, client, session
-):
+def test_ac_cannot_add_link_to_officer_profile_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -2538,7 +2512,7 @@ def test_ac_cannot_add_link_to_officer_profile_not_in_their_dept(
     ],
 )
 def test_ac_can_add_link_with_content_warning(
-    mockdata, client, session, link_type, expected_text
+    client, session, link_type, expected_text
 ):
     with current_app.test_request_context():
         login_ac(client)
@@ -2576,7 +2550,7 @@ def test_ac_can_add_link_with_content_warning(
         assert expected_text in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_can_edit_link_on_officer_profile(mockdata, client, session):
+def test_admin_can_edit_link_on_officer_profile(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, 1)
@@ -2608,7 +2582,7 @@ def test_admin_can_edit_link_on_officer_profile(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_edit_link_on_officer_profile_in_their_dept(mockdata, client, session):
+def test_ac_can_edit_link_on_officer_profile_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         # Officer from department with id AC_DEPT and no links
@@ -2664,9 +2638,7 @@ def test_ac_can_edit_link_on_officer_profile_in_their_dept(mockdata, client, ses
         assert officer.unique_internal_identifier in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_edit_link_on_officer_profile_not_in_their_dept(
-    mockdata, client, session
-):
+def test_ac_cannot_edit_link_on_officer_profile_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_admin(client)
         # Officer from another department (not id AC_DEPT) and no links
@@ -2722,7 +2694,7 @@ def test_ac_cannot_edit_link_on_officer_profile_not_in_their_dept(
         assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_can_delete_link_from_officer_profile(mockdata, client, session):
+def test_admin_can_delete_link_from_officer_profile(client, session):
     with current_app.test_request_context():
         login_admin(client)
         # Officer from department with id AC_DEPT and some links
@@ -2749,9 +2721,7 @@ def test_admin_can_delete_link_from_officer_profile(mockdata, client, session):
         assert has_database_cache_entry(*cache_params) is False
 
 
-def test_ac_can_delete_link_from_officer_profile_in_their_dept(
-    mockdata, client, session
-):
+def test_ac_can_delete_link_from_officer_profile_in_their_dept(client, session):
     with current_app.test_request_context():
         login_ac(client)
         # Officer from department with id AC_DEPT and no links
@@ -2796,9 +2766,7 @@ def test_ac_can_delete_link_from_officer_profile_in_their_dept(
         assert officer.unique_internal_identifier in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_delete_link_from_officer_profile_not_in_their_dept(
-    mockdata, client, session
-):
+def test_ac_cannot_delete_link_from_officer_profile_not_in_their_dept(client, session):
     with current_app.test_request_context():
         login_admin(client)
         # Officer from another department (not id AC_DEPT) and no links

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -106,12 +106,12 @@ def test_route_login_required(route, client, mockdata):
         "/officers/3/assignments/new",
     ],
 )
-def test_route_post_only(route, client, mockdata):
+def test_route_post_only(route, client):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-def test_user_can_access_officer_profile(mockdata, client, session):
+def test_user_can_access_officer_profile(client, session):
     with current_app.test_request_context():
         rv = client.get(
             url_for("main.officer_profile", officer_id=3), follow_redirects=True
@@ -119,7 +119,7 @@ def test_user_can_access_officer_profile(mockdata, client, session):
         assert "Officer Detail" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_user_can_access_officer_list(mockdata, client, session):
+def test_user_can_access_officer_list(client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.list_officer", department_id=2))
 
@@ -136,7 +136,7 @@ def test_user_can_access_officer_list(mockdata, client, session):
     ],
 )
 def test_officer_appropriately_shows_placeholder(
-    filter_func, has_placeholder, mockdata, client, session
+    filter_func, has_placeholder, client, session
 ):
     with current_app.test_request_context():
         officer = Officer.query.filter(filter_func(Officer.face.any())).first()
@@ -152,7 +152,7 @@ def test_officer_appropriately_shows_placeholder(
         assert (placeholder in rv.data.decode(ENCODING_UTF_8)) == has_placeholder
 
 
-def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):
+def test_ac_can_access_admin_on_dept_officer_profile(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.filter_by(department_id=AC_DEPT).first()
@@ -164,7 +164,7 @@ def test_ac_can_access_admin_on_dept_officer_profile(mockdata, client, session):
         assert "Admin only" in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_access_admin_on_non_dept_officer_profile(mockdata, client, session):
+def test_ac_cannot_access_admin_on_non_dept_officer_profile(client, session):
     with current_app.test_request_context():
         login_ac(client)
         officer = Officer.query.except_(
@@ -178,7 +178,7 @@ def test_ac_cannot_access_admin_on_non_dept_officer_profile(mockdata, client, se
         assert "Admin only" not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_admin_can_add_assignment(mockdata, client, session):
+def test_admin_can_add_assignment(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -207,7 +207,7 @@ def test_admin_can_add_assignment(mockdata, client, session):
         assert assignment.resign_date == date(2019, 12, 31)
 
 
-def test_admin_add_assignment_validation_error(mockdata, client, session):
+def test_admin_add_assignment_validation_error(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, 3)

--- a/OpenOversight/tests/routes/test_officer_and_department.py
+++ b/OpenOversight/tests/routes/test_officer_and_department.py
@@ -112,13 +112,13 @@ def test_route_post_only(route, client):
     assert rv.status_code == HTTPStatus.METHOD_NOT_ALLOWED
 
 
-def test_invalid_id_officer_profile(mockdata, client, session):
+def test_invalid_id_officer_profile(client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.officer_profile", officer_id=400000))
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_can_access_officer_profile(mockdata, client, session):
+def test_user_can_access_officer_profile(client, session):
     with current_app.test_request_context():
         rv = client.get(
             url_for("main.officer_profile", officer_id=3), follow_redirects=True
@@ -132,7 +132,7 @@ def test_invalid_officer_id_officer_list(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_can_access_officer_list(mockdata, client, session):
+def test_user_can_access_officer_list(client, session):
     with current_app.test_request_context():
         rv = client.get(url_for("main.list_officer", department_id=2))
 
@@ -191,7 +191,7 @@ def test_ac_cannot_access_admin_on_non_dept_officer_profile(client, session):
         assert "Admin only" not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_invalid_officer_id_add_assignment(mockdata, client, session):
+def test_invalid_officer_id_add_assignment(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -201,7 +201,7 @@ def test_invalid_officer_id_add_assignment(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_add_assignment(mockdata, client, session):
+def test_admin_can_add_assignment(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -320,7 +320,7 @@ def test_invalid_officer_id_edit_assignment(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_edit_assignment(mockdata, client, session):
+def test_admin_can_edit_assignment(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -1714,9 +1714,7 @@ def test_invalid_officer_id_upload_photos(client, session):
         assert "This officer does not exist." in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(
-    mockdata, client, session
-):
+def test_ac_cannot_directly_upload_photos_of_of_non_dept_officers(client, session):
     with current_app.test_request_context():
         login_ac(client)
         department = Department.query.except_(
@@ -2200,7 +2198,7 @@ def test_invalid_officer_id_edit_officer(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_edit_officers_with_blank_uids(mockdata, client, session):
+def test_edit_officers_with_blank_uids(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -2248,7 +2246,7 @@ def test_invalid_officer_id_add_salary(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_add_salary(mockdata, client, session):
+def test_admin_can_add_salary(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, AC_DEPT)
@@ -2333,7 +2331,7 @@ def test_invalid_officer_id_edit_salary(client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_admin_can_edit_salary(mockdata, client, session):
+def test_admin_can_edit_salary(client, session):
     with current_app.test_request_context():
         login_admin(client)
         officer = session.get(Officer, 1)

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -28,7 +28,7 @@ def test_routes_ok(route, client, mockdata):
     assert rv.status_code == HTTPStatus.OK
 
 
-def test_user_can_access_profile(mockdata, client, session):
+def test_user_can_access_profile(client, session):
     with current_app.test_request_context():
         login_user(client)
 
@@ -43,7 +43,7 @@ def test_user_can_access_profile(mockdata, client, session):
         assert "Edit User" not in rv.data.decode(ENCODING_UTF_8)
 
 
-def test_user_can_access_profile_differently_cased(mockdata, client, session):
+def test_user_can_access_profile_differently_cased(client, session):
     with current_app.test_request_context():
         login_user(client)
 

--- a/OpenOversight/tests/routes/test_user.py
+++ b/OpenOversight/tests/routes/test_user.py
@@ -8,7 +8,7 @@ from OpenOversight.tests.constants import AC_USER_EMAIL, GENERAL_USER_EMAIL
 from OpenOversight.tests.routes.route_helpers import login_ac, login_admin, login_user
 
 
-def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
+def test_user_cannot_see_profile_if_not_logged_in(client, session):
     with current_app.test_request_context():
         user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
         rv = client.get(f"/user/{user.username}")
@@ -17,7 +17,7 @@ def test_user_cannot_see_profile_if_not_logged_in(mockdata, client, session):
         assert rv.status_code == HTTPStatus.FOUND
 
 
-def test_user_profile_for_invalid_regex_username(mockdata, client, session):
+def test_user_profile_for_invalid_regex_username(client, session):
     with current_app.test_request_context():
         login_user(client)
         rv = client.get("/user/this_name_is_mad]]bogus")
@@ -26,7 +26,7 @@ def test_user_profile_for_invalid_regex_username(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_profile_for_invalid_username(mockdata, client, session):
+def test_user_profile_for_invalid_username(client, session):
     with current_app.test_request_context():
         login_user(client)
         rv = client.get("/user/this_name_is_mad_bogus")
@@ -35,7 +35,7 @@ def test_user_profile_for_invalid_username(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_profile_does_not_use_id(mockdata, client, session):
+def test_user_profile_does_not_use_id(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         rv = client.get(f"/user/{user.id}")
@@ -44,7 +44,7 @@ def test_user_profile_does_not_use_id(mockdata, client, session):
         assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_user_can_see_own_profile(mockdata, client, session):
+def test_user_can_see_own_profile(client, session):
     with current_app.test_request_context():
         _, user = login_user(client)
         rv = client.get(f"/user/{user.username}")
@@ -53,7 +53,7 @@ def test_user_can_see_own_profile(mockdata, client, session):
         assert bytes(f"Profile: {user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_user_can_see_other_users_profile(mockdata, client, session):
+def test_user_can_see_other_users_profile(client, session):
     with current_app.test_request_context():
         login_user(client)
         other_user = User.query.filter_by(email=AC_USER_EMAIL).first()
@@ -63,7 +63,7 @@ def test_user_can_see_other_users_profile(mockdata, client, session):
         assert bytes(f"Profile: {other_user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_ac_user_can_see_other_users_profile(mockdata, client, session):
+def test_ac_user_can_see_other_users_profile(client, session):
     with current_app.test_request_context():
         login_ac(client)
         other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()
@@ -73,7 +73,7 @@ def test_ac_user_can_see_other_users_profile(mockdata, client, session):
         assert bytes(f"Profile: {other_user.username}", ENCODING_UTF_8) in rv.data
 
 
-def test_admin_user_can_see_other_users_profile(mockdata, client, session):
+def test_admin_user_can_see_other_users_profile(client, session):
     with current_app.test_request_context():
         login_admin(client)
         other_user = User.query.filter_by(email=GENERAL_USER_EMAIL).first()

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -24,7 +24,7 @@ routes_methods = [
 
 # All login_required views should redirect if there is no user logged in
 @pytest.mark.parametrize("route,methods", routes_methods)
-def test_user_api_login_required(route, methods, client, mockdata):
+def test_user_api_login_required(route, methods, client):
     if HTTPMethod.GET in methods:
         rv = client.get(route)
         assert rv.status_code == HTTPStatus.FORBIDDEN
@@ -34,7 +34,7 @@ def test_user_api_login_required(route, methods, client, mockdata):
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)
-def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
+def test_user_cannot_access_user_api(route, methods, client, session):
     with current_app.test_request_context():
         login_user(client)
         if HTTPMethod.GET in methods:
@@ -46,7 +46,7 @@ def test_user_cannot_access_user_api(route, methods, mockdata, client, session):
 
 
 @pytest.mark.parametrize("route,methods", routes_methods)
-def test_ac_cannot_access_user_api(route, methods, mockdata, client, session):
+def test_ac_cannot_access_user_api(route, methods, client, session):
     with current_app.test_request_context():
         login_ac(client)
         if HTTPMethod.GET in methods:
@@ -57,7 +57,7 @@ def test_ac_cannot_access_user_api(route, methods, mockdata, client, session):
             assert rv.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_admin_can_update_users_to_ac(mockdata, client, session):
+def test_admin_can_update_users_to_ac(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -77,7 +77,7 @@ def test_admin_can_update_users_to_ac(mockdata, client, session):
         assert user.is_area_coordinator is True
 
 
-def test_admin_cannot_update_to_ac_without_department(mockdata, client, session):
+def test_admin_cannot_update_to_ac_without_department(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -95,7 +95,7 @@ def test_admin_cannot_update_to_ac_without_department(mockdata, client, session)
         assert user.is_area_coordinator is False
 
 
-def test_admin_can_update_users_to_admin(mockdata, client, session):
+def test_admin_can_update_users_to_admin(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -115,7 +115,7 @@ def test_admin_can_update_users_to_admin(mockdata, client, session):
         assert user.is_administrator is True
 
 
-def test_admin_can_delete_user(mockdata, client, session):
+def test_admin_can_delete_user(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -137,7 +137,7 @@ def test_admin_can_delete_user(mockdata, client, session):
         assert not session.get(User, user.id)
 
 
-def test_admin_cannot_delete_other_admin(mockdata, client, session):
+def test_admin_cannot_delete_other_admin(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -153,7 +153,7 @@ def test_admin_cannot_delete_other_admin(mockdata, client, session):
         assert session.get(User, user.id) is not None
 
 
-def test_admin_can_disable_user(mockdata, client, session):
+def test_admin_can_disable_user(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -179,7 +179,7 @@ def test_admin_can_disable_user(mockdata, client, session):
         assert user.is_disabled
 
 
-def test_admin_cannot_disable_self(mockdata, client, session):
+def test_admin_cannot_disable_self(client, session):
     with current_app.test_request_context():
         _, user = login_admin(client)
 
@@ -202,7 +202,7 @@ def test_admin_cannot_disable_self(mockdata, client, session):
         assert not user.is_disabled
 
 
-def test_admin_can_enable_user(mockdata, client, session):
+def test_admin_can_enable_user(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -230,7 +230,7 @@ def test_admin_can_enable_user(mockdata, client, session):
         assert not user.is_disabled
 
 
-def test_admin_can_resend_user_confirmation_email(mockdata, client, session):
+def test_admin_can_resend_user_confirmation_email(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -252,7 +252,7 @@ def test_admin_can_resend_user_confirmation_email(mockdata, client, session):
         )
 
 
-def test_register_user_approval_required(mockdata, client, session):
+def test_register_user_approval_required(client, session):
     current_app.config["APPROVE_REGISTRATIONS"] = True
     with current_app.test_request_context():
         diceware_password = "operative hamster persevere verbalize curling"
@@ -285,7 +285,7 @@ def test_register_user_approval_required(mockdata, client, session):
         assert b"administrator has not approved your account yet" in rv.data
 
 
-def test_admin_can_approve_user(mockdata, client, session):
+def test_admin_can_approve_user(client, session):
     with current_app.test_request_context():
         login_admin(client)
 
@@ -333,7 +333,6 @@ def test_admin_approval_sends_confirmation_email(
     currently_confirmed,
     should_send_email,
     approve_registration_config,
-    mockdata,
     client,
     session,
 ):

--- a/OpenOversight/tests/test_database_cache.py
+++ b/OpenOversight/tests/test_database_cache.py
@@ -34,7 +34,7 @@ from OpenOversight.app.utils.db import unit_choices
 from OpenOversight.tests.routes.route_helpers import login_admin, process_form_data
 
 
-def test_get_database_cache_entry(mockdata, faker):
+def test_get_database_cache_entry(faker):
     """Test getting a cache entry."""
     test_key = faker.uuid4()
     test_officer = Officer(id=faker.random_number(digits=3))
@@ -47,7 +47,7 @@ def test_get_database_cache_entry(mockdata, faker):
     )
 
 
-def test_model_key(mockdata, faker):
+def test_model_key(faker):
     """Test the model key generation with multiple Model inheriting classes."""
     test_key = faker.uuid4()
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -81,7 +81,7 @@ def scroll_to_element(browser, element):
     return element
 
 
-def test_user_can_load_homepage_and_get_to_form(mockdata, browser, server_port):
+def test_user_can_load_homepage_and_get_to_form(browser, server_port):
     browser.get(f"http://localhost:{server_port}")
     wait_for_element_to_be_visible(browser, By.ID, "cpd")
 
@@ -95,7 +95,7 @@ def test_user_can_load_homepage_and_get_to_form(mockdata, browser, server_port):
     assert "Find an Officer" in page_text
 
 
-def test_user_can_get_to_complaint(mockdata, browser, server_port):
+def test_user_can_get_to_complaint(browser, server_port):
     browser.get(
         f"http://localhost:{server_port}/complaints?officer_star=6265&"
         "officer_first_name=IVANA&officer_last_name=SNOTBALL&officer_middle_initial="
@@ -110,7 +110,7 @@ def test_user_can_get_to_complaint(mockdata, browser, server_port):
     assert "File a Complaint" in title_text
 
 
-def test_officer_browse_pagination(mockdata, browser, server_port):
+def test_officer_browse_pagination(browser, server_port):
     total = Officer.query.filter_by(department_id=AC_DEPT).count()
 
     # first page of results
@@ -152,9 +152,7 @@ def test_officer_browse_pagination(mockdata, browser, server_port):
     assert "require_photo" not in previous_link
 
 
-def test_find_officer_can_see_uii_question_for_depts_with_uiis(
-    mockdata, browser, server_port
-):
+def test_find_officer_can_see_uii_question_for_depts_with_uiis(browser, server_port):
     browser.get(f"http://localhost:{server_port}/find")
     wait_for_element(browser, By.TAG_NAME, "body")
 
@@ -170,7 +168,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
-    mockdata, browser, server_port
+    browser, server_port
 ):
     browser.get(f"http://localhost:{server_port}/find")
     wait_for_element(browser, By.TAG_NAME, "body")
@@ -188,7 +186,7 @@ def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
 
 
 def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
-    mockdata, browser, server_port
+    browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -204,7 +202,7 @@ def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
 
 
 def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
-    mockdata, browser, server_port
+    browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -224,7 +222,7 @@ def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
 
 
 def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_cutoff(
-    mockdata, browser, server_port
+    browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -235,7 +233,7 @@ def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_
     assert not result.is_displayed()
 
 
-def test_click_to_read_more_displays_full_description(mockdata, browser, server_port):
+def test_click_to_read_more_displays_full_description(browser, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
 
@@ -256,7 +254,7 @@ def test_click_to_read_more_displays_full_description(mockdata, browser, server_
     assert description_text == original_description
 
 
-def test_click_to_read_more_hides_the_read_more_button(mockdata, browser, server_port):
+def test_click_to_read_more_hides_the_read_more_button(browser, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
 
@@ -273,7 +271,7 @@ def test_click_to_read_more_hides_the_read_more_button(mockdata, browser, server
     assert not buttonRow.is_displayed()
 
 
-def test_officer_form_has_units_alpha_sorted(mockdata, browser, server_port, session):
+def test_officer_form_has_units_alpha_sorted(browser, server_port, session):
     login_admin(browser, server_port)
 
     # get the units from the DB in the sort we expect
@@ -298,7 +296,7 @@ def test_officer_form_has_units_alpha_sorted(mockdata, browser, server_port, ses
 
 
 def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
-    mockdata, browser, server_port, session
+    browser, server_port, session
 ):
     # Set NULL race and gender for officer 1
     session.execute(
@@ -325,7 +323,7 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
 
 
 @pytest.mark.skip("Enable once real file upload in tests is supported.")
-def test_image_classification_and_tagging(mockdata, browser, server_port):
+def test_image_classification_and_tagging(browser, server_port):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
     star_no = 1312
@@ -426,7 +424,7 @@ def test_image_classification_and_tagging(mockdata, browser, server_port):
 
 
 @pytest.mark.skip("Enable once real file upload in tests is supported.")
-def test_anonymous_user_can_upload_image(mockdata, browser, server_port):
+def test_anonymous_user_can_upload_image(browser, server_port):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
 

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -81,7 +81,7 @@ def scroll_to_element(browser, element):
     return element
 
 
-def test_user_can_load_homepage_and_get_to_form(browser, server_port):
+def test_user_can_load_homepage_and_get_to_form(mockdata, browser, server_port):
     browser.get(f"http://localhost:{server_port}")
     wait_for_element_to_be_visible(browser, By.ID, "cpd")
 
@@ -110,7 +110,7 @@ def test_user_can_get_to_complaint(browser, server_port):
     assert "File a Complaint" in title_text
 
 
-def test_officer_browse_pagination(browser, server_port):
+def test_officer_browse_pagination(mockdata, browser, server_port):
     total = Officer.query.filter_by(department_id=AC_DEPT).count()
 
     # first page of results
@@ -152,7 +152,9 @@ def test_officer_browse_pagination(browser, server_port):
     assert "require_photo" not in previous_link
 
 
-def test_find_officer_can_see_uii_question_for_depts_with_uiis(browser, server_port):
+def test_find_officer_can_see_uii_question_for_depts_with_uiis(
+    mockdata, browser, server_port
+):
     browser.get(f"http://localhost:{server_port}/find")
     wait_for_element(browser, By.TAG_NAME, "body")
 
@@ -168,7 +170,7 @@ def test_find_officer_can_see_uii_question_for_depts_with_uiis(browser, server_p
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
-    browser, server_port
+    mockdata, browser, server_port
 ):
     browser.get(f"http://localhost:{server_port}/find")
     wait_for_element(browser, By.TAG_NAME, "body")
@@ -186,7 +188,7 @@ def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
 
 
 def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
-    browser, server_port
+    mockdata, browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -202,7 +204,7 @@ def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
 
 
 def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
-    browser, server_port
+    mockdata, browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -222,7 +224,7 @@ def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
 
 
 def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_cutoff(
-    browser, server_port
+    mockdata, browser, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
@@ -233,7 +235,7 @@ def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_
     assert not result.is_displayed()
 
 
-def test_click_to_read_more_displays_full_description(browser, server_port):
+def test_click_to_read_more_displays_full_description(mockdata, browser, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
 
@@ -254,7 +256,7 @@ def test_click_to_read_more_displays_full_description(browser, server_port):
     assert description_text == original_description
 
 
-def test_click_to_read_more_hides_the_read_more_button(browser, server_port):
+def test_click_to_read_more_hides_the_read_more_button(mockdata, browser, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
     browser.get(f"http://localhost:{server_port}/officers/1")
 

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -165,7 +165,7 @@ def test_compute_hash(mockdata):
     assert hash_result == expected_hash
 
 
-def test_s3_upload_png(mockdata, test_png_bytes_io):
+def test_s3_upload_png(test_png_bytes_io):
     mocked_connection = Mock()
     mocked_resource = Mock()
     with patch("boto3.client", Mock(return_value=mocked_connection)):
@@ -177,7 +177,7 @@ def test_s3_upload_png(mockdata, test_png_bytes_io):
     )
 
 
-def test_s3_upload_jpeg(mockdata, test_jpg_bytes_io):
+def test_s3_upload_jpeg(test_jpg_bytes_io):
     mocked_connection = Mock()
     mocked_resource = Mock()
     with patch("boto3.client", Mock(return_value=mocked_connection)):
@@ -263,14 +263,12 @@ def test_save_image_to_s3_and_db_saves_filename_in_correct_format(
             assert len(filename_parts) == 2
 
 
-def test_save_image_to_s3_and_db_invalid_image(mockdata, client):
+def test_save_image_to_s3_and_db_invalid_image(client):
     with pytest.raises(ValueError):
         save_image_to_s3_and_db(BytesIO(b"invalid-image"), 1, 1)
 
 
-def test_save_image_to_s3_and_db_unrecognized_format(
-    mockdata, test_tiff_bytes_io, client
-):
+def test_save_image_to_s3_and_db_unrecognized_format(test_tiff_bytes_io, client):
     with pytest.raises(ValueError):
         save_image_to_s3_and_db(test_tiff_bytes_io, 1, 1)
 


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/1125

## Description of Changes
Removed the `mockdata` parameter from test functions that don't require it.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
