### PR TITLE
Add donate link to footer

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -149,8 +149,10 @@
               A product of Lucy Parsons Labs in Chicago, IL.
               <br>
               <a href="https://lucyparsonslabs.com/" target="_blank">Lucy Parsons Labs</a>
+                <br>
+              <a href="https://lucyparsonslabs.com/donate" target="_blank">Donate</a>
               <br>
-              <a href="{{ url_for("main.all_data") }}" target="_blank">Download department data</a>
+              <a href="{{ url_for("main.all_data") }}" target="_blank">Download Department Data</a>
             </p>
           </div>
           <div class="col-sm-4">

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -149,7 +149,7 @@
               A product of Lucy Parsons Labs in Chicago, IL.
               <br>
               <a href="https://lucyparsonslabs.com/" target="_blank">Lucy Parsons Labs</a>
-                <br>
+              <br>
               <a href="https://lucyparsonslabs.com/donate" target="_blank">Donate</a>
               <br>
               <a href="{{ url_for("main.all_data") }}" target="_blank">Download Department Data</a>

--- a/OpenOversight/tests/routes/test_other.py
+++ b/OpenOversight/tests/routes/test_other.py
@@ -27,6 +27,12 @@ def test_routes_ok(route, client, mockdata):
     rv = client.get(route)
     assert rv.status_code == HTTPStatus.OK
 
+    # Assert donate link is in all base pages
+    assert (
+        '<a href="https://lucyparsonslabs.com/donate" target="_blank">Donate</a>'
+        in rv.data.decode()
+    )
+
 
 def test_user_can_access_profile(client, session):
     with current_app.test_request_context():


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/215

## Description of Changes
Added a `Donate` link to the footer so that it is available on all pages throughout the application instead of just the home page. I also updated the casing of `Download department data` so that it matches the rest of the casing on the footer.

## Screenshots (if appropriate)
Before:
<img width="1470" alt="Screenshot 2024-10-03 at 4 25 31 PM" src="https://github.com/user-attachments/assets/62f9b72c-f72d-437b-86ce-60a350f16101">

After:
<img width="1470" alt="Screenshot 2024-10-03 at 4 26 08 PM" src="https://github.com/user-attachments/assets/92ffee96-1594-4adc-97be-d965ee87c3d0">

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
