### PR TITLE
Use Flask-Migrate in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ create_db: start
 	done
 	@echo "Postgres is up"
 	## Creating database
-	docker compose run --rm web alembic --config=./OpenOversight/migrations/alembic.ini stamp head
+	docker compose run --rm web flask db stamp head
 
 .PHONY: dev
 dev: create_empty_secret build start create_db populate


### PR DESCRIPTION
## Description of Changes
If we are using Flask-Migrate commands everywhere else, we shouldn't make an exception for the `Makefile`.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
- [x] Verify `make create_db` works correctly.

```console
(env) michaelp@MacBook-Air-18 OpenOversight % make create_db
docker compose build
WARN[0000] The "AWS_DEFAULT_REGION" variable is not set. Defaulting to a blank string.
WARN[0000] The "AWS_SECRET_ACCESS_KEY" variable is not set. Defaulting to a blank string.
WARN[0000] The "AWS_ACCESS_KEY_ID" variable is not set. Defaulting to a blank string.
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string.
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string.
[+] Building 0.6s (25/25) FINISHED                                                                                                                                                         docker:desktop-linux
 ...
Postgres is up
## Creating database
docker compose run --rm web flask db stamp head
...
INFO  [sqlalchemy.engine.Engine] COMMIT
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
(env) michaelp@MacBook-Air-18 OpenOversight %
```
