### PR TITLE
Fix the `/find` department sort

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -40,7 +40,7 @@ from OpenOversight.app.utils.choices import (
     STATE_CHOICES,
     SUFFIX_CHOICES,
 )
-from OpenOversight.app.utils.db import dept_choices, unit_choices, unsorted_dept_choices
+from OpenOversight.app.utils.db import dept_choices, unit_choices
 from OpenOversight.app.widgets import BootstrapListWidget, FormFieldWidget
 
 
@@ -102,7 +102,7 @@ class FindOfficerForm(Form):
     dept = QuerySelectField(
         "dept",
         validators=[DataRequired()],
-        query_factory=unsorted_dept_choices,
+        query_factory=dept_choices,
         get_label="display_name",
     )
     unit = StringField("unit", default="Not Sure", validators=[Optional()])

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -181,8 +181,6 @@ def browse():
 def get_officer():
     form = FindOfficerForm()
 
-    departments_dict = [dept_choice.to_custom_dict() for dept_choice in dept_choices()]
-
     if getattr(current_user, "dept_pref_rel", None):
         set_dynamic_default(form.dept, current_user.dept_pref_rel)
 
@@ -213,7 +211,7 @@ def get_officer():
     return render_template(
         "input_find_officer.html",
         form=form,
-        depts_dict=departments_dict,
+        depts_dict=[dept_choice.to_custom_dict() for dept_choice in dept_choices()],
         jsloads=["js/find_officer.js"],
     )
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -98,8 +98,8 @@ from OpenOversight.app.utils.db import (
     add_department_query,
     add_unit_query,
     compute_leaderboard_stats,
+    dept_choices,
     unit_choices,
-    unsorted_dept_choices,
 )
 from OpenOversight.app.utils.forms import (
     add_new_assignment,
@@ -181,11 +181,7 @@ def browse():
 def get_officer():
     form = FindOfficerForm()
 
-    # TODO: Figure out why this test is failing when the departments are sorted using
-    #  the dept_choices function.
-    departments_dict = [
-        dept_choice.to_custom_dict() for dept_choice in unsorted_dept_choices()
-    ]
+    departments_dict = [dept_choice.to_custom_dict() for dept_choice in dept_choices()]
 
     if getattr(current_user, "dept_pref_rel", None):
         set_dynamic_default(form.dept, current_user.dept_pref_rel)

--- a/OpenOversight/app/utils/db.py
+++ b/OpenOversight/app/utils/db.py
@@ -61,10 +61,6 @@ def dept_choices():
     )
 
 
-def unsorted_dept_choices():
-    return db.session.query(Department).all()
-
-
 def get_officer(department_id, star_no, first_name, last_name):
     """
     Return the first officer with the given name and badge combo in the department, if one exists.


### PR DESCRIPTION
## Fixes issue
Addresses TO-DO in code.

## Description of Changes
The `/find` route was using an unsorted list of departments unlike the rest of the application.

Before:
<img width="1334" alt="Screenshot 2024-11-06 at 10 13 13 PM" src="https://github.com/user-attachments/assets/8c6b832a-109e-465a-a6ec-c102524eb43b">

After:
<img width="1324" alt="Screenshot 2024-11-06 at 10 13 36 PM" src="https://github.com/user-attachments/assets/1f639518-a750-498e-8a26-6f5784ad052b">

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
