### PR TITLE
Update CPD complaint link

### DIFF
--- a/OpenOversight/app/templates/complaint.html
+++ b/OpenOversight/app/templates/complaint.html
@@ -22,7 +22,7 @@
             Warning! <small>The following link will open an external site
           in a new browser tab:</small>
         </h3>
-        <a href="https://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:2709570244836141"
+        <a href="https://www.chicagocopa.org/complaints/"
            target="_blank"
            class="btn btn-info btn-lrg">File Complaint Online</a>
       </div>


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/issues/748

## Description of Changes
The link to make a complaint at CPD was no longer working.
- Old link: [link](https://ipraportal.iprachicago.org/pls/htmldb/f?p=1503:12:2709570244836141)
    - Does not work.
- New link: [link](https://www.chicagocopa.org/complaints/)

## Screenshots (if appropriate)
Before:
<img width="922" alt="Screenshot 2024-11-22 at 10 51 30 PM" src="https://github.com/user-attachments/assets/74839f98-018c-4c23-a52f-0f9e9cd7ddd5">

After:
<img width="987" alt="Screenshot 2024-11-22 at 10 21 17 PM" src="https://github.com/user-attachments/assets/8b98be46-8f79-474b-a0dc-6cb92fb6968e">

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
