### PR TITLE
Address Dependabot alerts

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,6 @@ pytest==7.4.0
 pytest-cov==4.1.0
 pytest-pep8==1.0.6
 pytest-xdist==3.3.1
-selenium==4.26.0
 sphinx==7.0.1
 sphinx-autobuild==2021.3.14
 xvfbwrapper==0.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Bootstrap-Flask==2.4.0
 boto3==1.28.1
 botocore==1.31.1
 cachetools==5.3.1
-certifi~=2023.7.22
+certifi==2024.07.04
 cffi~=1.15.1
 click==8.1.4
 cryptography~=43.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi~=1.15.1
 click==8.1.4
 cryptography~=43.0.1
 Deprecated~=1.2.14
-dnspython~=2.3.0
+dnspython==2.6.1
 docutils~=0.20.1
 dominate~=2.8.0
 email-validator==2.0.0.post2

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pytest~=7.4.0
 python-dateutil==2.8.2
 PyYAML~=6.0
 recommonmark==0.7.1
-requests~=2.31.0
+requests==2.32.0
 rich~=13.4.2
 s3transfer~=0.6.1
 selenium==4.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Faker==18.13.0
 Flask==2.3.2
 Flask-Compress==1.13
 Flask-Limiter==3.3.1
-Flask-Login==0.6.2
+Flask-Login==0.6.3
 Flask-Mail==0.9.1
 Flask-Migrate==4.0.4
 Flask-Sitemap==0.4.0
@@ -56,6 +56,7 @@ recommonmark==0.7.1
 requests~=2.31.0
 rich~=13.4.2
 s3transfer~=0.6.1
+selenium==4.26.0
 six~=1.16.0
 sphinx==7.1.2
 SQLAlchemy==1.4.52

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ urllib3==1.26.20
 us==3.1.1
 visitor~=0.1.3
 webencodings~=0.5.1
-Werkzeug~=2.3.6
+Werkzeug==3.0.6
 wrapt~=1.15.0
 wtforms==3.0.1
 WTForms-SQLAlchemy==0.3.0


### PR DESCRIPTION
## Fixes issue
- https://github.com/lucyparsons/OpenOversight/security/dependabot/84
- https://github.com/lucyparsons/OpenOversight/security/dependabot/85
- https://github.com/lucyparsons/OpenOversight/security/dependabot/75
- https://github.com/lucyparsons/OpenOversight/security/dependabot/76
- https://github.com/lucyparsons/OpenOversight/security/dependabot/72
- https://github.com/lucyparsons/OpenOversight/security/dependabot/81

## Description of Changes
Updated the packages that were causing the creation of Dependabot alerts.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
