### PR TITLE
Remove `Flask-Sitemap` package

### DIFF
--- a/OpenOversight/app/__init__.py
+++ b/OpenOversight/app/__init__.py
@@ -10,7 +10,6 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_migrate import Migrate
-from flask_sitemap import Sitemap
 from flask_wtf.csrf import CSRFProtect
 
 from OpenOversight.app.email_client import EmailClient
@@ -33,7 +32,6 @@ limiter = Limiter(
     key_func=get_remote_address, default_limits=["100 per minute", "5 per second"]
 )
 
-sitemap = Sitemap()
 csrf = CSRFProtect()
 
 
@@ -49,7 +47,6 @@ def create_app(config_name="default"):
         EmailClient()
     limiter.init_app(app)
     login_manager.init_app(app)
-    sitemap.init_app(app)
     compress.init_app(app)
 
     from OpenOversight.app.main import main as main_blueprint

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -12,7 +12,6 @@ from flask import (
 )
 from flask_login import current_user, login_required, login_user, logout_user
 
-from OpenOversight.app import sitemap
 from OpenOversight.app.auth import auth
 from OpenOversight.app.auth.forms import (
     ChangeDefaultDepartmentForm,
@@ -41,18 +40,6 @@ from OpenOversight.app.utils.general import validate_redirect_url
 
 
 js_loads = ["js/zxcvbn.js", "js/password.js"]
-sitemap_endpoints = []
-
-
-def sitemap_include(view):
-    sitemap_endpoints.append(view.__name__)
-    return view
-
-
-@sitemap.register_generator
-def static_routes():
-    for endpoint in sitemap_endpoints:
-        yield "auth." + endpoint, {}
 
 
 @auth.before_app_request
@@ -84,7 +71,6 @@ def unconfirmed():
         return render_template("auth/unconfirmed.html")
 
 
-@sitemap_include
 @auth.route("/login", methods=[HTTPMethod.GET, HTTPMethod.POST])
 def login():
     form = LoginForm()
@@ -112,7 +98,6 @@ def logout():
     return redirect(url_for("main.index"))
 
 
-@sitemap_include
 @auth.route("/register", methods=[HTTPMethod.GET, HTTPMethod.POST])
 def register():
     form = RegistrationForm()

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 from sqlalchemy.orm.exc import NoResultFound
 
-from OpenOversight.app import limiter, sitemap
+from OpenOversight.app import limiter
 from OpenOversight.app.auth.forms import LoginForm
 from OpenOversight.app.main import main
 from OpenOversight.app.main.downloads import (
@@ -127,19 +127,6 @@ from OpenOversight.app.utils.general import (
 # Ensure the file is read/write by the creator only
 SAVED_UMASK = os.umask(0o077)
 
-sitemap_endpoints = []
-
-
-def sitemap_include(view):
-    sitemap_endpoints.append(view.__name__)
-    return view
-
-
-@sitemap.register_generator
-def static_routes():
-    for endpoint in sitemap_endpoints:
-        yield "main." + endpoint, {}
-
 
 def redirect_url(default="main.index"):
     return (
@@ -149,7 +136,6 @@ def redirect_url(default="main.index"):
     )
 
 
-@sitemap_include
 @main.route("/")
 @main.route("/index")
 def index():
@@ -167,7 +153,6 @@ def set_session_timezone():
     return Response("User timezone saved", status=HTTPStatus.OK)
 
 
-@sitemap_include
 @main.route("/browse", methods=[HTTPMethod.GET])
 def browse():
     departments = Department.query.filter(Department.officers.any()).order_by(
@@ -176,7 +161,6 @@ def browse():
     return render_template("browse.html", departments=departments)
 
 
-@sitemap_include
 @main.route("/find", methods=[HTTPMethod.GET, HTTPMethod.POST])
 def get_officer():
     form = FindOfficerForm()
@@ -224,7 +208,6 @@ def redirect_get_started_labeling():
     )
 
 
-@sitemap_include
 @main.route("/labels", methods=[HTTPMethod.GET, HTTPMethod.POST])
 def get_started_labeling():
     form = LoginForm()
@@ -277,7 +260,6 @@ def sort_images(department_id: int):
     )
 
 
-@sitemap_include
 @main.route("/tutorial")
 def get_tutorial():
     return render_template("tutorial.html")
@@ -353,12 +335,6 @@ def officer_profile(officer_id: int):
         assignments=assignments,
         form=form,
     )
-
-
-@sitemap.register_generator
-def sitemap_officers():
-    for officer in Officer.query.all():
-        yield "main.officer_profile", {"officer_id": officer.id}
 
 
 @main.route("/officer/<int:officer_id>/assignment/new", methods=[HTTPMethod.POST])
@@ -1535,7 +1511,6 @@ def submit_complaint():
     )
 
 
-@sitemap_include
 @main.route("/submit", methods=[HTTPMethod.GET, HTTPMethod.POST])
 @limiter.limit("5/minute")
 def submit_data():
@@ -1822,7 +1797,6 @@ def download_dept_descriptions_csv(department_id: int):
     )
 
 
-@sitemap_include
 @main.route("/download/all", methods=[HTTPMethod.GET])
 def all_data():
     departments = Department.query.filter(Department.officers.any())
@@ -1930,13 +1904,11 @@ def upload(department_id: int, officer_id: Optional[int] = None):
         )
 
 
-@sitemap_include
 @main.route("/about")
 def about_oo():
     return render_template("about.html")
 
 
-@sitemap_include
 @main.route("/privacy")
 def privacy_oo():
     return render_template("privacy.html")
@@ -2127,12 +2099,6 @@ main.add_url_rule(
     view_func=incident_view,
     methods=[HTTPMethod.GET, HTTPMethod.POST],
 )
-
-
-@sitemap.register_generator
-def sitemap_incidents():
-    for incident in Incident.query.all():
-        yield "main.incident_api", {"obj_id": incident.id}
 
 
 class TextApi(ModelView):

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,4 +1,3 @@
-import os
 import re
 import sys
 from datetime import datetime
@@ -122,10 +121,6 @@ from OpenOversight.app.utils.general import (
     serve_image,
     validate_redirect_url,
 )
-
-
-# Ensure the file is read/write by the creator only
-SAVED_UMASK = os.umask(0o077)
 
 
 def redirect_url(default="main.index"):

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -1,6 +1,3 @@
-import os
-
-
 # Cache Key Constants
 KEY_DEPT_ALL_ASSIGNMENTS = "all_department_assignments"
 KEY_DEPT_ALL_INCIDENTS = "all_department_incidents"
@@ -44,7 +41,6 @@ OO_TIME_FORMAT = "%I:%M %p"
 ENCODING_UTF_8 = "utf-8"
 FILE_TYPE_HTML = "html"
 FILE_TYPE_PLAIN = "plain"
-SAVED_UMASK = os.umask(0o077)  # Ensure the file is read/write by the creator only
 
 # File Name Constants
 SERVICE_ACCOUNT_FILE = "service_account_key.json"

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,9 +25,6 @@ ignore_missing_imports = True
 [mypy-flask_migrate.*]
 ignore_missing_imports = True
 
-[mypy-flask_sitemap.*]
-ignore_missing_imports = True
-
 [mypy-flask_sqlalchemy.*]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ Flask-Limiter==3.3.1
 Flask-Login==0.6.3
 Flask-Mail==0.9.1
 Flask-Migrate==4.0.4
-Flask-Sitemap==0.4.0
 Flask-SQLAlchemy==3.0.5
 Flask-WTF==1.1.2
 google-api-python-client==2.92.0


### PR DESCRIPTION
## Description of Changes
AFAIK, we do not seem to be using Sitemap within the application to any meaningful extent. There is no mention of it in the documentation, and it seems to only be loosely used throughout the application. If we are looking to flesh out the API further, I think it's worth removing it and potentially adding it back in a more explicit manner so that it doesn't seem like it's just legacy code.

Documentation: [link](https://flask-sitemap.readthedocs.io/en/latest/).

## Screenshots (if appropriate)
<img width="935" alt="Screenshot 2024-12-18 at 5 34 22 PM" src="https://github.com/user-attachments/assets/ef9e9c5f-2269-4ddf-92a1-d55bfc1b0b48" />

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
