### PR TITLE
Standardize model `__repr__` functions

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1,4 +1,3 @@
-import os
 import re
 import sys
 from datetime import datetime
@@ -123,9 +122,6 @@ from OpenOversight.app.utils.general import (
     validate_redirect_url,
 )
 
-
-# Ensure the file is read/write by the creator only
-SAVED_UMASK = os.umask(0o077)
 
 sitemap_endpoints = []
 

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -406,7 +406,7 @@ class Assignment(BaseModel, TrackUpdates):
     resign_date = db.Column(db.Date, index=True, unique=False, nullable=True)
 
     def __repr__(self):
-        return f"<Assignment: ID {self.officer_id} : {self.star_no}>"
+        return f"<Assignment ID: {self.officer_id} : {self.star_no}>"
 
     @property
     def start_date_or_min(self):
@@ -656,12 +656,12 @@ class Link(BaseModel, TrackUpdates):
     author = db.Column(db.String(255), nullable=True)
     has_content_warning = db.Column(db.Boolean, nullable=False, default=False)
 
-    def __repr__(self):
-        return f"<Link ID: {self.id} : {self.title}>"
-
     @validates("url")
     def validate_url(self, key, url):
         return url_validator(url)
+
+    def __repr__(self):
+        return f"<Link ID: {self.id} : {self.title}>"
 
 
 class Incident(BaseModel, TrackUpdates):

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -212,6 +212,9 @@ class Note(BaseModel, TrackUpdates):
     officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
     officer = db.relationship("Officer", back_populates="notes")
 
+    def __repr__(self):
+        return f"<Note ID: {self.id} : {self.text_contents}>"
+
 
 class Description(BaseModel, TrackUpdates):
     __tablename__ = "descriptions"
@@ -220,6 +223,9 @@ class Description(BaseModel, TrackUpdates):
     id = db.Column(db.Integer, primary_key=True)
     text_contents = db.Column(db.Text())
     officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
+
+    def __repr__(self):
+        return f"<Description ID: {self.id} : {self.text_contents}>"
 
 
 class Officer(BaseModel, TrackUpdates):

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -198,7 +198,7 @@ class Job(BaseModel, TrackUpdates):
     )
 
     def __repr__(self):
-        return f"<Job ID {self.id}: {self.job_title}>"
+        return f"<Job ID: {self.id} : {self.job_title}>"
 
     def __str__(self):
         return self.job_title
@@ -288,10 +288,10 @@ class Officer(BaseModel, TrackUpdates):
     def __repr__(self):
         if self.unique_internal_identifier:
             return (
-                f"<Officer ID {self.id}: {self.full_name()} "
+                f"<Officer ID: {self.id} : {self.full_name()} "
                 f"({self.unique_internal_identifier})>"
             )
-        return f"<Officer ID {self.id}: {self.full_name()}>"
+        return f"<Officer ID: {self.id}: {self.full_name()}>"
 
     def full_name(self):
         if self.middle_initial:

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -136,7 +136,7 @@ class Department(BaseModel, TrackUpdates):
     __table_args__ = (UniqueConstraint("name", "state", name="departments_name_state"),)
 
     def __repr__(self):
-        return f"<Department ID {self.id} : {self.name} {self.state}>"
+        return f"<Department ID: {self.id} : {self.name} : {self.state}>"
 
     def to_custom_dict(self):
         return {
@@ -365,7 +365,7 @@ class Salary(BaseModel, TrackUpdates):
     is_fiscal_year = db.Column(db.Boolean, index=False, unique=False, nullable=False)
 
     def __repr__(self):
-        return f"<Salary: ID {self.officer_id} : {self.salary}>"
+        return f"<Salary ID: {self.officer_id} : {self.salary}>"
 
     @property
     def total_pay(self) -> float:
@@ -512,7 +512,7 @@ class Image(BaseModel, TrackUpdates):
     )
 
     def __repr__(self):
-        return f"<Image ID {self.id}: {self.filepath}>"
+        return f"<Image ID: {self.id} : {self.filepath}>"
 
 
 incident_links = db.Table(
@@ -656,6 +656,9 @@ class Link(BaseModel, TrackUpdates):
     author = db.Column(db.String(255), nullable=True)
     has_content_warning = db.Column(db.Boolean, nullable=False, default=False)
 
+    def __repr__(self):
+        return f"<Link ID: {self.id} : {self.title}>"
+
     @validates("url")
     def validate_url(self, key, url):
         return url_validator(url)
@@ -703,6 +706,9 @@ class Incident(BaseModel, TrackUpdates):
     department = db.relationship(
         "Department", backref=db.backref("incidents", cascade_backrefs=False), lazy=True
     )
+
+    def __repr__(self):
+        return f"<Incident ID: {self.id} : {self.report_number}>"
 
 
 class User(UserMixin, BaseModel):

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -291,7 +291,7 @@ class Officer(BaseModel, TrackUpdates):
                 f"<Officer ID: {self.id} : {self.full_name()} "
                 f"({self.unique_internal_identifier})>"
             )
-        return f"<Officer ID: {self.id}: {self.full_name()}>"
+        return f"<Officer ID: {self.id} : {self.full_name()}>"
 
     def full_name(self):
         if self.middle_initial:

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -650,6 +650,9 @@ class LicensePlate(BaseModel, TrackUpdates):
     def validate_state(self, key, state):
         return state_validator(state)
 
+    def __repr__(self):
+        return f"<LicensePlate ID: {self.id} : {self.state} : {self.number}>"
+
 
 class Link(BaseModel, TrackUpdates):
     __tablename__ = "links"

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -136,7 +136,7 @@ class Department(BaseModel, TrackUpdates):
     __table_args__ = (UniqueConstraint("name", "state", name="departments_name_state"),)
 
     def __repr__(self):
-        return f"<Department ID {self.id}: {self.name} {self.state}>"
+        return f"<Department ID {self.id} : {self.name} {self.state}>"
 
     def to_custom_dict(self):
         return {
@@ -279,6 +279,14 @@ class Officer(BaseModel, TrackUpdates):
         CheckConstraint("gender in ('M', 'F', 'Other')", name="gender_options"),
     )
 
+    def __repr__(self):
+        if self.unique_internal_identifier:
+            return (
+                f"<Officer ID {self.id}: {self.full_name()} "
+                f"({self.unique_internal_identifier})>"
+            )
+        return f"<Officer ID {self.id}: {self.full_name()}>"
+
     def full_name(self):
         if self.middle_initial:
             middle_initial = (
@@ -339,14 +347,6 @@ class Officer(BaseModel, TrackUpdates):
             return "Yes" if most_recent.resign_date is None else "No"
         return "Uncertain"
 
-    def __repr__(self):
-        if self.unique_internal_identifier:
-            return (
-                f"<Officer ID {self.id}: {self.full_name()} "
-                f"({self.unique_internal_identifier})>"
-            )
-        return f"<Officer ID {self.id}: {self.full_name()}>"
-
 
 class Salary(BaseModel, TrackUpdates):
     __tablename__ = "salaries"
@@ -365,7 +365,7 @@ class Salary(BaseModel, TrackUpdates):
     is_fiscal_year = db.Column(db.Boolean, index=False, unique=False, nullable=False)
 
     def __repr__(self):
-        return f"<Salary: ID {self.officer_id} : {self.salary}"
+        return f"<Salary: ID {self.officer_id} : {self.salary}>"
 
     @property
     def total_pay(self) -> float:
@@ -433,7 +433,7 @@ class Unit(BaseModel, TrackUpdates):
     )
 
     def __repr__(self):
-        return f"Unit: {self.description}"
+        return f"<Unit ID: {self.id} : {self.description}>"
 
 
 class Face(BaseModel, TrackUpdates):
@@ -485,7 +485,7 @@ class Face(BaseModel, TrackUpdates):
     __table_args__ = (UniqueConstraint("officer_id", "img_id", name="unique_faces"),)
 
     def __repr__(self):
-        return f"<Tag ID {self.id}: {self.officer_id} - {self.img_id}>"
+        return f"<Tag ID: {self.id} : {self.officer_id} : {self.img_id}>"
 
 
 class Image(BaseModel, TrackUpdates):

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -44,7 +44,6 @@ OO_TIME_FORMAT = "%I:%M %p"
 ENCODING_UTF_8 = "utf-8"
 FILE_TYPE_HTML = "html"
 FILE_TYPE_PLAIN = "plain"
-SAVED_UMASK = os.umask(0o077)  # Ensure the file is read/write by the creator only
 
 # File Name Constants
 SERVICE_ACCOUNT_FILE = "service_account_key.json"

--- a/OpenOversight/app/utils/constants.py
+++ b/OpenOversight/app/utils/constants.py
@@ -1,6 +1,3 @@
-import os
-
-
 # Cache Key Constants
 KEY_DEPT_ALL_ASSIGNMENTS = "all_department_assignments"
 KEY_DEPT_ALL_INCIDENTS = "all_department_incidents"

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -109,7 +109,7 @@ def test_officer_repr(session):
     ).first()
 
     assert (
-        repr(officer_no_uii) == f"<Officer I:  {officer_no_uii.id} : "
+        repr(officer_no_uii) == f"<Officer ID: {officer_no_uii.id} : "
         f"{officer_no_uii.first_name} {officer_no_uii.middle_initial}. "
         f"{officer_no_uii.last_name} {officer_no_uii.suffix}>"
     )

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from OpenOversight.app.models.database import (
     Assignment,
     Department,
+    Description,
     Face,
     Image,
     Incident,
@@ -17,6 +18,7 @@ from OpenOversight.app.models.database import (
     LicensePlate,
     Link,
     Location,
+    Note,
     Officer,
     Salary,
     Unit,
@@ -179,6 +181,19 @@ def test_salary_repr(mockdata):
 def test_link_repr(mockdata):
     link = Link.query.first()
     assert repr(link) == f"<Link ID: {link.id} : {link.title}>"
+
+
+def test_note_repr(mockdata):
+    note = Note.query.first()
+    assert repr(note) == f"<Note ID: {note.id} : {note.text_contents}>"
+
+
+def test_description_repr(mockdata):
+    description = Description.query.first()
+    assert (
+        repr(description)
+        == f"<Description ID: {description.id} : {description.text_contents}>"
+    )
 
 
 def test_password_not_printed(mockdata):

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -95,7 +95,7 @@ def test_officer_repr(session):
     ).first()
 
     assert (
-        repr(officer_uii) == f"<Officer ID {officer_uii.id}: "
+        repr(officer_uii) == f"<Officer ID: {officer_uii.id} : "
         f"{officer_uii.first_name} {officer_uii.middle_initial}. {officer_uii.last_name} "
         f"({officer_uii.unique_internal_identifier})>"
     )
@@ -109,7 +109,7 @@ def test_officer_repr(session):
     ).first()
 
     assert (
-        repr(officer_no_uii) == f"<Officer ID {officer_no_uii.id}: "
+        repr(officer_no_uii) == f"<Officer I:  {officer_no_uii.id} : "
         f"{officer_no_uii.first_name} {officer_no_uii.middle_initial}. "
         f"{officer_no_uii.last_name} {officer_no_uii.suffix}>"
     )
@@ -120,7 +120,7 @@ def test_officer_repr(session):
 
     assert (
         repr(officer_no_mi)
-        == f"<Officer ID {officer_no_mi.id}: {officer_no_mi.first_name} "
+        == f"<Officer ID: {officer_no_mi.id} : {officer_no_mi.first_name} "
         f"{officer_no_mi.last_name} {officer_no_mi.suffix} "
         f"({officer_no_mi.unique_internal_identifier})>"
     )
@@ -150,7 +150,7 @@ def test_incident_repr(mockdata):
 
 def test_job_repr(mockdata):
     job = Job.query.first()
-    assert repr(job) == f"<Job ID {job.id}: {job.job_title}>"
+    assert repr(job) == f"<Job ID: {job.id} : {job.job_title}>"
 
 
 def test_image_repr(mockdata):

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -196,6 +196,14 @@ def test_description_repr(mockdata):
     )
 
 
+def test_license_plate_repr(mockdata):
+    license_plate = LicensePlate.query.first()
+    assert (
+        repr(license_plate)
+        == f"<LicensePlate ID: {license_plate.id} : {license_plate.state} : {license_plate.number}>"
+    )
+
+
 def test_password_not_printed(mockdata):
     """Validate that password fields cannot be directly accessed."""
     user = User(password="bacon")

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -137,7 +137,7 @@ def test_assignment_repr(mockdata):
     assignment = Assignment.query.first()
     assert (
         repr(assignment)
-        == f"<Assignment: ID {assignment.base_officer.id} : {assignment.star_no}>"
+        == f"<Assignment ID: {assignment.base_officer.id} : {assignment.star_no}>"
     )
 
 

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -30,7 +30,7 @@ def test_department_repr(mockdata):
     department = Department.query.first()
     assert (
         repr(department)
-        == f"<Department ID {department.id}: {department.name} {department.state}>"
+        == f"<Department ID: {department.id} : {department.name} : {department.state}>"
     )
 
 
@@ -141,6 +141,11 @@ def test_assignment_repr(mockdata):
     )
 
 
+def test_incident_repr(mockdata):
+    incident = Incident.query.first()
+    assert repr(incident) == f"<Incident ID: {incident.id} : {incident.report_number}>"
+
+
 def test_job_repr(mockdata):
     job = Job.query.first()
     assert repr(job) == f"<Job ID {job.id}: {job.job_title}>"
@@ -148,17 +153,17 @@ def test_job_repr(mockdata):
 
 def test_image_repr(mockdata):
     image = Image.query.first()
-    assert repr(image) == f"<Image ID {image.id}: {image.filepath}>"
+    assert repr(image) == f"<Image ID: {image.id} : {image.filepath}>"
 
 
 def test_face_repr(mockdata):
     face = Face.query.first()
-    assert repr(face) == f"<Tag ID {face.id}: {face.officer_id} - {face.img_id}>"
+    assert repr(face) == f"<Tag ID: {face.id} : {face.officer_id} : {face.img_id}>"
 
 
 def test_unit_repr(mockdata):
     unit = Unit.query.first()
-    assert repr(unit) == f"Unit: {unit.description}"
+    assert repr(unit) == f"<Unit ID: {unit.id} : {unit.description}>"
 
 
 def test_user_repr(mockdata):
@@ -168,7 +173,12 @@ def test_user_repr(mockdata):
 
 def test_salary_repr(mockdata):
     salary = Salary.query.first()
-    assert repr(salary) == f"<Salary: ID {salary.officer_id} : {salary.salary}"
+    assert repr(salary) == f"<Salary ID: {salary.officer_id} : {salary.salary}>"
+
+
+def test_link_repr(mockdata):
+    link = Link.query.first()
+    assert repr(link) == f"<Link ID: {link.id} : {link.title}>"
 
 
 def test_password_not_printed(mockdata):

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -212,7 +212,7 @@ def test_user_cannot_submit_invalid_file_extension(mockdata):
 
 def test_unit_choices(mockdata):
     unit_choices_result = [str(x) for x in unit_choices()]
-    assert "Unit: Bureau of Organized Crime" in unit_choices_result
+    assert "<Unit ID: 4 : Bureau of Organized Crime>" in unit_choices_result
 
 
 @upload_s3_patch


### PR DESCRIPTION
## Description of Changes
Addressed inconsistencies with the model `__repr__` functions.

Mostly making this because this PR got a bit out of control: https://github.com/lucyparsons/OpenOversight/pull/1138

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
