### PR TITLE
Update SQLAlchemy

### DIFF
--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -10,9 +10,29 @@ from cachetools import cached
 from flask import current_app
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import CheckConstraint, UniqueConstraint, func
-from sqlalchemy.orm import DeclarativeMeta, declarative_mixin, declared_attr, validates
-from sqlalchemy.sql import func as sql_func
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    backref,
+    declarative_mixin,
+    declared_attr,
+    mapped_column,
+    relationship,
+    validates,
+)
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from OpenOversight.app.models.database_cache import (
@@ -34,51 +54,54 @@ from OpenOversight.app.validators import state_validator, url_validator
 
 db = SQLAlchemy()
 jwt = JsonWebToken(SIGNATURE_ALGORITHM)
-BaseModel: DeclarativeMeta = db.Model
+
+
+class BaseModel(MappedAsDataclass, DeclarativeBase):
+    """subclasses will be converted to dataclasses"""
 
 
 officer_links = db.Table(
     "officer_links",
-    db.Column(
+    Column(
         "officer_id",
-        db.Integer,
-        db.ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
+        Integer,
+        ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    Column(
         "link_id",
-        db.Integer,
-        db.ForeignKey("links.id", name="officer_links_link_id_fkey"),
+        Integer,
+        ForeignKey("links.id", name="officer_links_link_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    Column(
         "created_at",
-        db.DateTime(timezone=True),
+        DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     ),
 )
 
 officer_incidents = db.Table(
     "officer_incidents",
-    db.Column(
+    Column(
         "officer_id",
-        db.Integer,
-        db.ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
+        Integer,
+        ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    Column(
         "incident_id",
-        db.Integer,
-        db.ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
+        Integer,
+        ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    Column(
         "created_at",
-        db.DateTime(timezone=True),
+        DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     ),
 )
@@ -93,52 +116,61 @@ class TrackUpdates:
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     )
     last_updated_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
         unique=False,
-        onupdate=datetime.utcnow,
     )
 
     @declared_attr
     def created_by(cls):
         return db.Column(
-            db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
+            db.Integer,
+            ForeignKey("users.id", ondelete="SET NULL"),
+            unique=False,
         )
 
     @declared_attr
     def last_updated_by(cls):
         return db.Column(
-            db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
+            db.Integer,
+            ForeignKey("users.id", ondelete="SET NULL"),
+            unique=False,
         )
 
     @declared_attr
     def creator(cls):
-        return db.relationship("User", foreign_keys=[cls.created_by])
+        return relationship(
+            "User", foreign_keys=[cls.created_by], backref="created_objects"
+        )
+
+    @declared_attr
+    def last_updater(cls):
+        return relationship(
+            "User", foreign_keys=[cls.last_updated_by], backref="updated_objects"
+        )
 
 
 class Department(BaseModel, TrackUpdates):
     __tablename__ = "departments"
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(255), index=False, unique=False, nullable=False)
-    short_name = db.Column(db.String(100), unique=False, nullable=False)
-    state = db.Column(db.String(2), server_default="", nullable=False)
 
-    # See https://github.com/lucyparsons/OpenOversight/issues/462
-    unique_internal_identifier_label = db.Column(
-        db.String(100), unique=False, nullable=True
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    short_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    state: Mapped[str] = mapped_column(String(2), server_default="", nullable=False)
+
+    unique_internal_identifier_label: Mapped[str] = mapped_column(
+        String(100), nullable=True
     )
 
     __table_args__ = (UniqueConstraint("name", "state", name="departments_name_state"),)
 
-    def __repr__(self):
-        return f"<Department ID: {self.id} : {self.name} : {self.state}>"
-
-    def to_custom_dict(self):
+    def to_custom_dict(self) -> dict:
         return {
             "id": self.id,
             "name": self.name,
@@ -148,28 +180,32 @@ class Department(BaseModel, TrackUpdates):
         }
 
     @property
-    def display_name(self):
+    def display_name(self) -> str:
         return self.name if not self.state else f"[{self.state}] {self.name}"
 
     @cached(cache=DB_CACHE, key=model_cache_key(KEY_DEPT_TOTAL_ASSIGNMENTS))
-    def total_documented_assignments(self):
+    def total_documented_assignments(self) -> int:
         return (
-            db.session.query(Assignment.id)
+            self.db_session.query(Assignment.id)
             .join(Officer, Assignment.officer_id == Officer.id)
             .filter(Officer.department_id == self.id)
             .count()
         )
 
     @cached(cache=DB_CACHE, key=model_cache_key(KEY_DEPT_TOTAL_INCIDENTS))
-    def total_documented_incidents(self):
+    def total_documented_incidents(self) -> int:
         return (
-            db.session.query(Incident).filter(Incident.department_id == self.id).count()
+            self.db_session.query(Incident)
+            .filter(Incident.department_id == self.id)
+            .count()
         )
 
     @cached(cache=DB_CACHE, key=model_cache_key(KEY_DEPT_TOTAL_OFFICERS))
-    def total_documented_officers(self):
+    def total_documented_officers(self) -> int:
         return (
-            db.session.query(Officer).filter(Officer.department_id == self.id).count()
+            self.db_session.query(Officer)
+            .filter(Officer.department_id == self.id)
+            .count()
         )
 
     def remove_database_cache_entries(self, update_types: List[str]) -> None:
@@ -180,15 +216,16 @@ class Department(BaseModel, TrackUpdates):
 class Job(BaseModel, TrackUpdates):
     __tablename__ = "jobs"
 
-    id = db.Column(db.Integer, primary_key=True)
-    job_title = db.Column(db.String(255), index=True, unique=False, nullable=False)
-    is_sworn_officer = db.Column(db.Boolean, index=True, default=True)
-    order = db.Column(db.Integer, index=True, unique=False, nullable=False)
-    department_id = db.Column(
-        db.Integer, db.ForeignKey("departments.id", name="jobs_department_id_fkey")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    job_title: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
+    is_sworn_officer: Mapped[bool] = mapped_column(Boolean, index=True, default=True)
+    order: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
+    department_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("departments.id", name="jobs_department_id_fkey")
     )
-    department = db.relationship(
-        "Department", backref=db.backref("jobs", cascade_backrefs=False)
+    department: Mapped["Department"] = relationship(
+        "Department",
+        backref=backref("jobs", cascade_backrefs=False),
     )
 
     __table_args__ = (
@@ -197,23 +234,16 @@ class Job(BaseModel, TrackUpdates):
         ),
     )
 
-    def __repr__(self):
-        return f"<Job ID: {self.id} : {self.job_title}>"
-
-    def __str__(self):
-        return self.job_title
-
 
 class Note(BaseModel, TrackUpdates):
     __tablename__ = "notes"
 
-    id = db.Column(db.Integer, primary_key=True)
-    text_contents = db.Column(db.Text())
-    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
-    officer = db.relationship("Officer", back_populates="notes")
-
-    def __repr__(self):
-        return f"<Note ID: {self.id} : {self.text_contents}>"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    text_contents: Mapped[str] = mapped_column(Text, nullable=True)
+    officer_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("officers.id", ondelete="CASCADE")
+    )
+    officer: Mapped["Officer"] = relationship("Officer", back_populates="notes")
 
 
 class Description(BaseModel, TrackUpdates):
@@ -539,7 +569,7 @@ incident_links = db.Table(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     ),
 )
@@ -564,7 +594,7 @@ incident_license_plates = db.Table(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     ),
 )
@@ -587,7 +617,7 @@ incident_officers = db.Table(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     ),
 )
@@ -722,6 +752,7 @@ class Incident(BaseModel, TrackUpdates):
 
 class User(UserMixin, BaseModel):
     __tablename__ = "users"
+
     id = db.Column(db.Integer, primary_key=True)
 
     # A universally unique identifier (UUID) that can be
@@ -796,7 +827,7 @@ class User(UserMixin, BaseModel):
     created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
-        server_default=sql_func.now(),
+        server_default=func.now(),
         unique=False,
     )
 

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -11,15 +11,7 @@ from flask import current_app
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import CheckConstraint, UniqueConstraint, func
-from sqlalchemy.orm import (
-    DeclarativeBase,
-    Mapped,
-    MappedAsDataclass,
-    declarative_mixin,
-    declared_attr,
-    mapped_column,
-    validates,
-)
+from sqlalchemy.orm import DeclarativeMeta, declarative_mixin, declared_attr, validates
 from sqlalchemy.sql import func as sql_func
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -42,27 +34,24 @@ from OpenOversight.app.validators import state_validator, url_validator
 
 db = SQLAlchemy()
 jwt = JsonWebToken(SIGNATURE_ALGORITHM)
-
-
-class BaseModel(MappedAsDataclass, DeclarativeBase):
-    """subclasses will be converted to dataclasses"""
+BaseModel: DeclarativeMeta = db.Model
 
 
 officer_links = db.Table(
     "officer_links",
-    mapped_column(
+    db.Column(
         "officer_id",
         db.Integer,
         db.ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "link_id",
         db.Integer,
         db.ForeignKey("links.id", name="officer_links_link_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -73,19 +62,19 @@ officer_links = db.Table(
 
 officer_incidents = db.Table(
     "officer_incidents",
-    mapped_column(
+    db.Column(
         "officer_id",
         db.Integer,
         db.ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -101,13 +90,13 @@ class TrackUpdates:
     the object.
     """
 
-    created_at: Mapped[datetime] = mapped_column(
+    created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
         unique=False,
     )
-    last_updated_at = mapped_column(
+    last_updated_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
@@ -117,13 +106,13 @@ class TrackUpdates:
 
     @declared_attr
     def created_by(cls):
-        return mapped_column(
+        return db.Column(
             db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
         )
 
     @declared_attr
     def last_updated_by(cls):
-        return mapped_column(
+        return db.Column(
             db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
         )
 
@@ -134,14 +123,13 @@ class TrackUpdates:
 
 class Department(BaseModel, TrackUpdates):
     __tablename__ = "departments"
-
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    name = mapped_column(db.String(255), index=False, unique=False, nullable=False)
-    short_name = mapped_column(db.String(100), unique=False, nullable=False)
-    state = mapped_column(db.String(2), server_default="", nullable=False)
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), index=False, unique=False, nullable=False)
+    short_name = db.Column(db.String(100), unique=False, nullable=False)
+    state = db.Column(db.String(2), server_default="", nullable=False)
 
     # See https://github.com/lucyparsons/OpenOversight/issues/462
-    unique_internal_identifier_label = mapped_column(
+    unique_internal_identifier_label = db.Column(
         db.String(100), unique=False, nullable=True
     )
 
@@ -192,11 +180,11 @@ class Department(BaseModel, TrackUpdates):
 class Job(BaseModel, TrackUpdates):
     __tablename__ = "jobs"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    job_title = mapped_column(db.String(255), index=True, unique=False, nullable=False)
-    is_sworn_officer = mapped_column(db.Boolean, index=True, default=True)
-    order = mapped_column(db.Integer, index=True, unique=False, nullable=False)
-    department_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    job_title = db.Column(db.String(255), index=True, unique=False, nullable=False)
+    is_sworn_officer = db.Column(db.Boolean, index=True, default=True)
+    order = db.Column(db.Integer, index=True, unique=False, nullable=False)
+    department_id = db.Column(
         db.Integer, db.ForeignKey("departments.id", name="jobs_department_id_fkey")
     )
     department = db.relationship(
@@ -219,11 +207,9 @@ class Job(BaseModel, TrackUpdates):
 class Note(BaseModel, TrackUpdates):
     __tablename__ = "notes"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    text_contents = mapped_column(db.Text())
-    officer_id: Mapped[int] = mapped_column(
-        db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE")
-    )
+    id = db.Column(db.Integer, primary_key=True)
+    text_contents = db.Column(db.Text())
+    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
     officer = db.relationship("Officer", back_populates="notes")
 
     def __repr__(self):
@@ -234,11 +220,9 @@ class Description(BaseModel, TrackUpdates):
     __tablename__ = "descriptions"
 
     officer = db.relationship("Officer", back_populates="descriptions")
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    text_contents = mapped_column(db.Text())
-    officer_id: Mapped[int] = mapped_column(
-        db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE")
-    )
+    id = db.Column(db.Integer, primary_key=True)
+    text_contents = db.Column(db.Text())
+    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
 
     def __repr__(self):
         return f"<Description ID: {self.id} : {self.text_contents}>"
@@ -247,28 +231,28 @@ class Description(BaseModel, TrackUpdates):
 class Officer(BaseModel, TrackUpdates):
     __tablename__ = "officers"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    last_name = mapped_column(db.String(120), index=True, unique=False)
-    first_name = mapped_column(db.String(120), index=True, unique=False)
-    middle_initial = mapped_column(db.String(120), unique=False, nullable=True)
-    suffix = mapped_column(db.String(120), index=True, unique=False)
-    race = mapped_column(db.String(120), index=True, unique=False)
-    gender = mapped_column(db.String(5), index=True, unique=False, nullable=True)
-    employment_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
-    birth_year = mapped_column(db.Integer, index=True, unique=False, nullable=True)
+    id = db.Column(db.Integer, primary_key=True)
+    last_name = db.Column(db.String(120), index=True, unique=False)
+    first_name = db.Column(db.String(120), index=True, unique=False)
+    middle_initial = db.Column(db.String(120), unique=False, nullable=True)
+    suffix = db.Column(db.String(120), index=True, unique=False)
+    race = db.Column(db.String(120), index=True, unique=False)
+    gender = db.Column(db.String(5), index=True, unique=False, nullable=True)
+    employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
+    birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
     assignments = db.relationship(
         "Assignment", back_populates="base_officer", cascade_backrefs=False
     )
     face = db.relationship(
         "Face", backref=db.backref("officer", cascade_backrefs=False)
     )
-    department_id: Mapped[int] = mapped_column(
+    department_id = db.Column(
         db.Integer, db.ForeignKey("departments.id", name="officers_department_id_fkey")
     )
     department = db.relationship(
         "Department", backref=db.backref("officers", cascade_backrefs=False)
     )
-    unique_internal_identifier = mapped_column(
+    unique_internal_identifier = db.Column(
         db.String(50), index=True, unique=True, nullable=True
     )
 
@@ -373,20 +357,18 @@ class Officer(BaseModel, TrackUpdates):
 class Salary(BaseModel, TrackUpdates):
     __tablename__ = "salaries"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    officer_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    officer_id = db.Column(
         db.Integer,
         db.ForeignKey(
             "officers.id", name="salaries_officer_id_fkey", ondelete="CASCADE"
         ),
     )
     officer = db.relationship("Officer", back_populates="salaries")
-    salary = mapped_column(db.Float, index=True, unique=False, nullable=False)
-    overtime_pay = mapped_column(db.Float, index=True, unique=False, nullable=True)
-    year = mapped_column(db.Integer, index=True, unique=False, nullable=False)
-    is_fiscal_year = mapped_column(
-        db.Boolean, index=False, unique=False, nullable=False
-    )
+    salary = db.Column(db.Float, index=True, unique=False, nullable=False)
+    overtime_pay = db.Column(db.Float, index=True, unique=False, nullable=True)
+    year = db.Column(db.Integer, index=True, unique=False, nullable=False)
+    is_fiscal_year = db.Column(db.Boolean, index=False, unique=False, nullable=False)
 
     def __repr__(self):
         return f"<Salary ID: {self.officer_id} : {self.salary}>"
@@ -405,29 +387,29 @@ class Salary(BaseModel, TrackUpdates):
 class Assignment(BaseModel, TrackUpdates):
     __tablename__ = "assignments"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    officer_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    officer_id = db.Column(
         db.Integer,
         db.ForeignKey(
             "officers.id", name="assignments_officer_id_fkey", ondelete="CASCADE"
         ),
     )
     base_officer = db.relationship("Officer", back_populates="assignments")
-    star_no = mapped_column(db.String(120), index=True, unique=False, nullable=True)
-    job_id: Mapped[int] = mapped_column(
+    star_no = db.Column(db.String(120), index=True, unique=False, nullable=True)
+    job_id = db.Column(
         db.Integer,
         db.ForeignKey("jobs.id", name="assignments_job_id_fkey"),
         nullable=False,
     )
     job = db.relationship("Job")
-    unit_id: Mapped[int] = mapped_column(
+    unit_id = db.Column(
         db.Integer,
         db.ForeignKey("unit_types.id", name="assignments_unit_id_fkey"),
         nullable=True,
     )
     unit = db.relationship("Unit")
-    start_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
-    resign_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
+    start_date = db.Column(db.Date, index=True, unique=False, nullable=True)
+    resign_date = db.Column(db.Date, index=True, unique=False, nullable=True)
 
     def __repr__(self):
         return f"<Assignment ID: {self.officer_id} : {self.star_no}>"
@@ -444,9 +426,9 @@ class Assignment(BaseModel, TrackUpdates):
 class Unit(BaseModel, TrackUpdates):
     __tablename__ = "unit_types"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    description = mapped_column(db.String(120), index=True, unique=False)
-    department_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(db.String(120), index=True, unique=False)
+    department_id = db.Column(
         db.Integer,
         db.ForeignKey("departments.id", name="unit_types_department_id_fkey"),
     )
@@ -463,11 +445,11 @@ class Unit(BaseModel, TrackUpdates):
 class Face(BaseModel, TrackUpdates):
     __tablename__ = "faces"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    officer_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    officer_id = db.Column(
         db.Integer, db.ForeignKey("officers.id", name="faces_officer_id_fkey")
     )
-    img_id: Mapped[int] = mapped_column(
+    img_id = db.Column(
         db.Integer,
         db.ForeignKey(
             "raw_images.id",
@@ -477,7 +459,7 @@ class Face(BaseModel, TrackUpdates):
             use_alter=True,
         ),
     )
-    original_image_id: Mapped[int] = mapped_column(
+    original_image_id = db.Column(
         db.Integer,
         db.ForeignKey(
             "raw_images.id",
@@ -487,10 +469,10 @@ class Face(BaseModel, TrackUpdates):
             name="fk_face_original_image_id",
         ),
     )
-    face_position_x = mapped_column(db.Integer, unique=False)
-    face_position_y = mapped_column(db.Integer, unique=False)
-    face_width = mapped_column(db.Integer, unique=False)
-    face_height = mapped_column(db.Integer, unique=False)
+    face_position_x = db.Column(db.Integer, unique=False)
+    face_position_y = db.Column(db.Integer, unique=False)
+    face_width = db.Column(db.Integer, unique=False)
+    face_height = db.Column(db.Integer, unique=False)
     image = db.relationship(
         "Image",
         backref=db.backref("faces", cascade_backrefs=False),
@@ -502,7 +484,7 @@ class Face(BaseModel, TrackUpdates):
         foreign_keys=[original_image_id],
         lazy=True,
     )
-    featured = mapped_column(
+    featured = db.Column(
         db.Boolean, nullable=False, default=False, server_default="false"
     )
 
@@ -515,19 +497,19 @@ class Face(BaseModel, TrackUpdates):
 class Image(BaseModel, TrackUpdates):
     __tablename__ = "raw_images"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    filepath = mapped_column(db.String(255), unique=False)
-    hash_img = mapped_column(db.String(120), unique=False, nullable=True)
+    id = db.Column(db.Integer, primary_key=True)
+    filepath = db.Column(db.String(255), unique=False)
+    hash_img = db.Column(db.String(120), unique=False, nullable=True)
 
     # We might know when the image was taken e.g. through EXIF data
-    taken_at = mapped_column(
+    taken_at = db.Column(
         db.DateTime(timezone=True), index=True, unique=False, nullable=True
     )
-    contains_cops = mapped_column(db.Boolean, nullable=True)
+    contains_cops = db.Column(db.Boolean, nullable=True)
 
-    is_tagged = mapped_column(db.Boolean, default=False, unique=False, nullable=True)
+    is_tagged = db.Column(db.Boolean, default=False, unique=False, nullable=True)
 
-    department_id: Mapped[int] = mapped_column(
+    department_id = db.Column(
         db.Integer,
         db.ForeignKey("departments.id", name="raw_images_department_id_fkey"),
     )
@@ -541,19 +523,19 @@ class Image(BaseModel, TrackUpdates):
 
 incident_links = db.Table(
     "incident_links",
-    mapped_column(
+    db.Column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_links_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "link_id",
         db.Integer,
         db.ForeignKey("links.id", name="incident_links_link_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -564,13 +546,13 @@ incident_links = db.Table(
 
 incident_license_plates = db.Table(
     "incident_license_plates",
-    mapped_column(
+    db.Column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_license_plates_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "license_plate_id",
         db.Integer,
         db.ForeignKey(
@@ -578,7 +560,7 @@ incident_license_plates = db.Table(
         ),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -589,19 +571,19 @@ incident_license_plates = db.Table(
 
 incident_officers = db.Table(
     "incident_officers",
-    mapped_column(
+    db.Column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_officers_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "officers_id",
         db.Integer,
         db.ForeignKey("officers.id", name="incident_officers_officers_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    db.Column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -614,13 +596,13 @@ incident_officers = db.Table(
 class Location(BaseModel, TrackUpdates):
     __tablename__ = "locations"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    street_name = mapped_column(db.String(100), index=True)
-    cross_street1 = mapped_column(db.String(100), unique=False)
-    cross_street2 = mapped_column(db.String(100), unique=False)
-    city = mapped_column(db.String(100), unique=False, index=True)
-    state = mapped_column(db.String(2), unique=False, index=True)
-    zip_code = mapped_column(db.String(5), unique=False, index=True)
+    id = db.Column(db.Integer, primary_key=True)
+    street_name = db.Column(db.String(100), index=True)
+    cross_street1 = db.Column(db.String(100), unique=False)
+    cross_street2 = db.Column(db.String(100), unique=False)
+    city = db.Column(db.String(100), unique=False, index=True)
+    state = db.Column(db.String(2), unique=False, index=True)
+    zip_code = db.Column(db.String(5), unique=False, index=True)
 
     @validates("zip_code")
     def validate_zip_code(self, key, zip_code):
@@ -657,12 +639,12 @@ class Location(BaseModel, TrackUpdates):
 class LicensePlate(BaseModel, TrackUpdates):
     __tablename__ = "license_plates"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    number = mapped_column(db.String(8), nullable=False, index=True)
-    state = mapped_column(db.String(2), index=True)
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.String(8), nullable=False, index=True)
+    state = db.Column(db.String(2), index=True)
 
     # for use if car is federal, diplomat, or other non-state
-    # non_state_identifier = mapped_column(db.String(20), index=True)
+    # non_state_identifier = db.Column(db.String(20), index=True)
 
     @validates("state")
     def validate_state(self, key, state):
@@ -675,13 +657,13 @@ class LicensePlate(BaseModel, TrackUpdates):
 class Link(BaseModel, TrackUpdates):
     __tablename__ = "links"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    title = mapped_column(db.String(100), index=True)
-    url = mapped_column(db.Text(), nullable=False)
-    link_type = mapped_column(db.String(100), index=True)
-    description = mapped_column(db.Text(), nullable=True)
-    author = mapped_column(db.String(255), nullable=True)
-    has_content_warning = mapped_column(db.Boolean, nullable=False, default=False)
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(100), index=True)
+    url = db.Column(db.Text(), nullable=False)
+    link_type = db.Column(db.String(100), index=True)
+    description = db.Column(db.Text(), nullable=True)
+    author = db.Column(db.String(255), nullable=True)
+    has_content_warning = db.Column(db.Boolean, nullable=False, default=False)
 
     @validates("url")
     def validate_url(self, key, url):
@@ -694,12 +676,12 @@ class Link(BaseModel, TrackUpdates):
 class Incident(BaseModel, TrackUpdates):
     __tablename__ = "incidents"
 
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
-    date = mapped_column(db.Date, unique=False, index=True)
-    time = mapped_column(db.Time, unique=False, index=True)
-    report_number = mapped_column(db.String(50), index=True)
-    description = mapped_column(db.Text(), nullable=True)
-    address_id: Mapped[int] = mapped_column(
+    id = db.Column(db.Integer, primary_key=True)
+    date = db.Column(db.Date, unique=False, index=True)
+    time = db.Column(db.Time, unique=False, index=True)
+    report_number = db.Column(db.String(50), index=True)
+    description = db.Column(db.Text(), nullable=True)
+    address_id = db.Column(
         db.Integer, db.ForeignKey("locations.id", name="incidents_address_id_fkey")
     )
     address = db.relationship(
@@ -727,7 +709,7 @@ class Incident(BaseModel, TrackUpdates):
             order_by="Incident.date.desc(), Incident.time.desc()",
         ),
     )
-    department_id: Mapped[int] = mapped_column(
+    department_id = db.Column(
         db.Integer, db.ForeignKey("departments.id", name="incidents_department_id_fkey")
     )
     department = db.relationship(
@@ -740,36 +722,35 @@ class Incident(BaseModel, TrackUpdates):
 
 class User(UserMixin, BaseModel):
     __tablename__ = "users"
-
-    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
 
     # A universally unique identifier (UUID) that can be
     # used in place of the user's primary key for things like user
     # lookup queries.
-    _uuid: Mapped[str] = mapped_column(
+    _uuid = db.Column(
         db.String(36),
         unique=True,
         nullable=False,
         index=True,
         default=lambda: str(uuid.uuid4()),
     )
-    email = mapped_column(db.String(64), unique=True, index=True)
-    username = mapped_column(db.String(64), unique=True, index=True)
-    password_hash = mapped_column(db.String(128))
-    confirmed_at = mapped_column(db.DateTime(timezone=True))
-    confirmed_by = mapped_column(
+    email = db.Column(db.String(64), unique=True, index=True)
+    username = db.Column(db.String(64), unique=True, index=True)
+    password_hash = db.Column(db.String(128))
+    confirmed_at = db.Column(db.DateTime(timezone=True))
+    confirmed_by = db.Column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_confirmed_by_fkey"),
         unique=False,
     )
-    approved_at = mapped_column(db.DateTime(timezone=True))
-    approved_by = mapped_column(
+    approved_at = db.Column(db.DateTime(timezone=True))
+    approved_by = db.Column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_approved_by_fkey"),
         unique=False,
     )
-    is_area_coordinator = mapped_column(db.Boolean, default=False)
-    ac_department_id: Mapped[int] = mapped_column(
+    is_area_coordinator = db.Column(db.Boolean, default=False)
+    ac_department_id = db.Column(
         db.Integer, db.ForeignKey("departments.id", name="users_ac_department_id_fkey")
     )
     ac_department = db.relationship(
@@ -777,15 +758,15 @@ class User(UserMixin, BaseModel):
         backref=db.backref("coordinators", cascade_backrefs=False),
         foreign_keys=[ac_department_id],
     )
-    is_administrator = mapped_column(db.Boolean, default=False)
-    disabled_at = mapped_column(db.DateTime(timezone=True))
-    disabled_by = mapped_column(
+    is_administrator = db.Column(db.Boolean, default=False)
+    disabled_at = db.Column(db.DateTime(timezone=True))
+    disabled_by = db.Column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_disabled_by_fkey"),
         unique=False,
     )
 
-    dept_pref = mapped_column(
+    dept_pref = db.Column(
         db.Integer, db.ForeignKey("departments.id", name="users_dept_pref_fkey")
     )
     dept_pref_rel = db.relationship("Department", foreign_keys=[dept_pref])
@@ -812,7 +793,7 @@ class User(UserMixin, BaseModel):
         "Face", back_populates=KEY_DB_CREATOR, foreign_keys="Face.created_by"
     )
 
-    created_at = mapped_column(
+    created_at = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
@@ -948,7 +929,7 @@ class User(UserMixin, BaseModel):
         return True
 
     def regenerate_uuid(self):
-        self._uuid: Mapped[str] = str(uuid.uuid4())
+        self._uuid = str(uuid.uuid4())
 
     def get_id(self):
         """Get the Flask-Login user identifier, NOT THE DATABASE ID."""

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -63,53 +63,6 @@ class BaseModel(MappedAsDataclass, DeclarativeBase):
     """subclasses will be converted to dataclasses"""
 
 
-officer_links = db.Table(
-    "officer_links",
-    Column(
-        "officer_id",
-        Integer,
-        ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
-        primary_key=True,
-    ),
-    Column(
-        "link_id",
-        Integer,
-        ForeignKey("links.id", name="officer_links_link_id_fkey"),
-        primary_key=True,
-    ),
-    Column(
-        "created_at",
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        unique=False,
-    ),
-)
-
-officer_incidents = db.Table(
-    "officer_incidents",
-    Column(
-        "officer_id",
-        Integer,
-        ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
-        primary_key=True,
-    ),
-    Column(
-        "incident_id",
-        Integer,
-        ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
-        primary_key=True,
-    ),
-    Column(
-        "created_at",
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        unique=False,
-    ),
-)
-
-
 @declarative_mixin
 class TrackUpdates:
     """Add columns to track the date of and user who created and last modified
@@ -276,6 +229,30 @@ class Description(BaseModel, TrackUpdates):
         Integer, ForeignKey("officers.id", ondelete="CASCADE")
     )
     officer: Mapped["Officer"] = relationship("Officer", back_populates="descriptions")
+
+
+officer_links = db.Table(
+    "officer_links",
+    db.Column(
+        "officer_id",
+        Integer,
+        ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
+        primary_key=True,
+    ),
+    db.Column(
+        "link_id",
+        Integer,
+        ForeignKey("links.id", name="officer_links_link_id_fkey"),
+        primary_key=True,
+    ),
+    db.Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        unique=False,
+    ),
+)
 
 
 class Officer(BaseModel, TrackUpdates):
@@ -550,6 +527,29 @@ class Image(BaseModel, TrackUpdates):
     )
 
 
+officer_incidents = db.Table(
+    "officer_incidents",
+    Column(
+        "officer_id",
+        Integer,
+        ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
+        primary_key=True,
+    ),
+    Column(
+        "incident_id",
+        Integer,
+        ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
+        primary_key=True,
+    ),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        unique=False,
+    ),
+)
+
 incident_links = db.Table(
     "incident_links",
     Column(
@@ -789,7 +789,7 @@ class User(UserMixin, BaseModel):
         unique=True,
         nullable=False,
         index=True,
-        default=lambda: str(uuid.uuid4()),
+        insert_default=lambda: str(uuid.uuid4()),
     )
     is_area_coordinator: Mapped[bool] = mapped_column(Boolean, default=False)
     is_administrator: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -14,11 +14,14 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Column,
+    Date,
     DateTime,
+    Float,
     ForeignKey,
     Integer,
     String,
     Text,
+    Time,
     UniqueConstraint,
     func,
 )
@@ -249,239 +252,217 @@ class Note(BaseModel, TrackUpdates):
 class Description(BaseModel, TrackUpdates):
     __tablename__ = "descriptions"
 
-    officer = db.relationship("Officer", back_populates="descriptions")
-    id = db.Column(db.Integer, primary_key=True)
-    text_contents = db.Column(db.Text())
-    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
-
-    def __repr__(self):
-        return f"<Description ID: {self.id} : {self.text_contents}>"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    text_contents: Mapped[str] = mapped_column(Text, nullable=True)
+    officer_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("officers.id", ondelete="CASCADE")
+    )
+    officer: Mapped["Officer"] = relationship("Officer", back_populates="descriptions")
 
 
 class Officer(BaseModel, TrackUpdates):
     __tablename__ = "officers"
 
-    id = db.Column(db.Integer, primary_key=True)
-    last_name = db.Column(db.String(120), index=True, unique=False)
-    first_name = db.Column(db.String(120), index=True, unique=False)
-    middle_initial = db.Column(db.String(120), unique=False, nullable=True)
-    suffix = db.Column(db.String(120), index=True, unique=False)
-    race = db.Column(db.String(120), index=True, unique=False)
-    gender = db.Column(db.String(5), index=True, unique=False, nullable=True)
-    employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
-    birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
-    assignments = db.relationship(
-        "Assignment", back_populates="base_officer", cascade_backrefs=False
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    last_name: Mapped[str] = mapped_column(String(120), index=True)
+    first_name: Mapped[str] = mapped_column(String(120), index=True)
+    middle_initial: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    suffix: Mapped[Optional[str]] = mapped_column(
+        String(120), index=True, nullable=True
     )
-    face = db.relationship(
-        "Face", backref=db.backref("officer", cascade_backrefs=False)
+    race: Mapped[Optional[str]] = mapped_column(String(120), index=True, nullable=True)
+    gender: Mapped[Optional[str]] = mapped_column(String(5), index=True, nullable=True)
+    employment_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    birth_year: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    department_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("departments.id", name="officers_department_id_fkey")
     )
-    department_id = db.Column(
-        db.Integer, db.ForeignKey("departments.id", name="officers_department_id_fkey")
+    department: Mapped["Department"] = relationship(
+        "Department", backref="officers", cascade_backrefs=False
     )
-    department = db.relationship(
-        "Department", backref=db.backref("officers", cascade_backrefs=False)
-    )
-    unique_internal_identifier = db.Column(
-        db.String(50), index=True, unique=True, nullable=True
+    unique_internal_identifier: Mapped[Optional[str]] = mapped_column(
+        String(50), index=True, unique=True, nullable=True
     )
 
-    links = db.relationship(
-        "Link",
-        secondary=officer_links,
-        backref=db.backref("officers", lazy=True, cascade_backrefs=False),
-        lazy=True,
+    # Relationships
+    assignments: Mapped[list["Assignment"]] = relationship(
+        "Assignment", back_populates="base_officer"
     )
-    notes = db.relationship(
-        "Note",
-        back_populates="officer",
-        cascade_backrefs=False,
-        order_by="Note.created_at",
+    face: Mapped[list["Face"]] = relationship(
+        "Face", backref="officer", cascade_backrefs=False
     )
-    descriptions = db.relationship(
-        "Description",
-        back_populates="officer",
-        cascade_backrefs=False,
-        order_by="Description.created_at",
+    links: Mapped[list["Link"]] = relationship(
+        "Link", secondary=officer_links, backref="officers", lazy=True
     )
-    salaries = db.relationship(
-        "Salary",
-        back_populates="officer",
-        cascade_backrefs=False,
-        order_by="Salary.year.desc()",
+    notes: Mapped[list["Note"]] = relationship(
+        "Note", back_populates="officer", order_by="Note.created_at"
+    )
+    descriptions: Mapped[list["Description"]] = relationship(
+        "Description", back_populates="officer", order_by="Description.created_at"
+    )
+    salaries: Mapped[list["Salary"]] = relationship(
+        "Salary", back_populates="officer", order_by="Salary.year.desc()"
     )
 
     __table_args__ = (
         CheckConstraint("gender in ('M', 'F', 'Other')", name="gender_options"),
     )
 
-    def __repr__(self):
-        if self.unique_internal_identifier:
-            return (
-                f"<Officer ID: {self.id} : {self.full_name()} "
-                f"({self.unique_internal_identifier})>"
-            )
-        return f"<Officer ID: {self.id} : {self.full_name()}>"
-
-    def full_name(self):
+    def full_name(self) -> str:
         if self.middle_initial:
             middle_initial = (
                 self.middle_initial + "."
                 if len(self.middle_initial) == 1
                 else self.middle_initial
             )
-            if self.suffix:
-                return (
-                    f"{self.first_name} {middle_initial} {self.last_name} {self.suffix}"
-                )
-            else:
-                return f"{self.first_name} {middle_initial} {self.last_name}"
-        if self.suffix:
-            return f"{self.first_name} {self.last_name} {self.suffix}"
-        return f"{self.first_name} {self.last_name}"
+            return (
+                f"{self.first_name} {middle_initial} {self.last_name} {self.suffix}"
+                if self.suffix
+                else f"{self.first_name} {middle_initial} {self.last_name}"
+            )
+        return (
+            f"{self.first_name} {self.last_name} {self.suffix}"
+            if self.suffix
+            else f"{self.first_name} {self.last_name}"
+        )
 
-    def race_label(self):
-        if self.race is None:
-            return "Data Missing"
-
+    def race_label(self) -> str:
         for race, label in RACE_CHOICES:
             if self.race == race:
                 return label
+        return "Data Missing"
 
-    def gender_label(self):
-        if self.gender is None:
-            return "Data Missing"
-
+    def gender_label(self) -> str:
         for gender, label in GENDER_CHOICES:
             if self.gender == gender:
                 return label
+        return "Data Missing"
 
-    def job_title(self):
-        if self.assignments:
-            return max(
+    def job_title(self) -> Optional[str]:
+        return (
+            max(
                 self.assignments, key=operator.attrgetter("start_date_or_min")
             ).job.job_title
+            if self.assignments
+            else None
+        )
 
-    def unit_description(self):
-        if self.assignments:
-            unit = max(
+    def unit_description(self) -> Optional[str]:
+        return (
+            max(
                 self.assignments, key=operator.attrgetter("start_date_or_min")
-            ).unit
-            return unit.description if unit else None
+            ).unit.description
+            if self.assignments
+            else None
+        )
 
-    def badge_number(self):
-        if self.assignments:
-            return max(
-                self.assignments, key=operator.attrgetter("start_date_or_min")
-            ).star_no
+    def badge_number(self) -> Optional[str]:
+        return (
+            max(self.assignments, key=operator.attrgetter("start_date_or_min")).star_no
+            if self.assignments
+            else None
+        )
 
-    def currently_on_force(self):
-        if self.assignments:
-            most_recent = max(
-                self.assignments, key=operator.attrgetter("start_date_or_min")
-            )
-            return "Yes" if most_recent.resign_date is None else "No"
-        return "Uncertain"
+    def currently_on_force(self) -> str:
+        most_recent = (
+            max(self.assignments, key=operator.attrgetter("start_date_or_min"))
+            if self.assignments
+            else None
+        )
+        return (
+            "Yes"
+            if most_recent and most_recent.resign_date is None
+            else "No"
+            if most_recent
+            else "Uncertain"
+        )
 
 
 class Salary(BaseModel, TrackUpdates):
     __tablename__ = "salaries"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
-            "officers.id", name="salaries_officer_id_fkey", ondelete="CASCADE"
-        ),
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("officers.id", name="salaries_officer_id_fkey", ondelete="CASCADE"),
     )
-    officer = db.relationship("Officer", back_populates="salaries")
-    salary = db.Column(db.Float, index=True, unique=False, nullable=False)
-    overtime_pay = db.Column(db.Float, index=True, unique=False, nullable=True)
-    year = db.Column(db.Integer, index=True, unique=False, nullable=False)
-    is_fiscal_year = db.Column(db.Boolean, index=False, unique=False, nullable=False)
-
-    def __repr__(self):
-        return f"<Salary ID: {self.officer_id} : {self.salary}>"
+    officer: Mapped["Officer"] = relationship("Officer", back_populates="salaries")
+    salary: Mapped[float] = mapped_column(Float, nullable=False)
+    overtime_pay: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    year: Mapped[int] = mapped_column(Integer, nullable=False)
+    is_fiscal_year: Mapped[bool] = mapped_column(Boolean, nullable=False)
 
     @property
     def total_pay(self) -> float:
-        return self.salary + self.overtime_pay
+        return self.salary + (self.overtime_pay or 0)
 
     @property
     def year_repr(self) -> str:
-        if self.is_fiscal_year:
-            return f"FY{self.year}"
-        return str(self.year)
+        return f"FY{self.year}" if self.is_fiscal_year else str(self.year)
 
 
 class Assignment(BaseModel, TrackUpdates):
     __tablename__ = "assignments"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey(
             "officers.id", name="assignments_officer_id_fkey", ondelete="CASCADE"
         ),
     )
-    base_officer = db.relationship("Officer", back_populates="assignments")
-    star_no = db.Column(db.String(120), index=True, unique=False, nullable=True)
-    job_id = db.Column(
-        db.Integer,
-        db.ForeignKey("jobs.id", name="assignments_job_id_fkey"),
-        nullable=False,
+    base_officer: Mapped["Officer"] = relationship(
+        "Officer", back_populates="assignments"
     )
-    job = db.relationship("Job")
-    unit_id = db.Column(
-        db.Integer,
-        db.ForeignKey("unit_types.id", name="assignments_unit_id_fkey"),
+    star_no: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    job_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("jobs.id", name="assignments_job_id_fkey"), nullable=False
+    )
+    job: Mapped["Job"] = relationship("Job")
+    unit_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("unit_types.id", name="assignments_unit_id_fkey"),
         nullable=True,
     )
-    unit = db.relationship("Unit")
-    start_date = db.Column(db.Date, index=True, unique=False, nullable=True)
-    resign_date = db.Column(db.Date, index=True, unique=False, nullable=True)
-
-    def __repr__(self):
-        return f"<Assignment ID: {self.officer_id} : {self.star_no}>"
+    unit: Mapped["Unit"] = relationship("Unit")
+    start_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    resign_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
 
     @property
-    def start_date_or_min(self):
+    def start_date_or_min(self) -> date:
         return self.start_date or date.min
 
     @property
-    def start_date_or_max(self):
+    def start_date_or_max(self) -> date:
         return self.start_date or date.max
 
 
 class Unit(BaseModel, TrackUpdates):
     __tablename__ = "unit_types"
 
-    id = db.Column(db.Integer, primary_key=True)
-    description = db.Column(db.String(120), index=True, unique=False)
-    department_id = db.Column(
-        db.Integer,
-        db.ForeignKey("departments.id", name="unit_types_department_id_fkey"),
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    description: Mapped[str] = mapped_column(String(120), index=True, nullable=True)
+    department_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("departments.id", name="unit_types_department_id_fkey")
     )
-    department = db.relationship(
+    department: Mapped["Department"] = relationship(
         "Department",
-        backref=db.backref("unit_types", cascade_backrefs=False),
+        backref="unit_types",
+        cascade_backrefs=False,
         order_by="Unit.description.asc()",
     )
-
-    def __repr__(self):
-        return f"<Unit ID: {self.id} : {self.description}>"
 
 
 class Face(BaseModel, TrackUpdates):
     __tablename__ = "faces"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
-        db.Integer, db.ForeignKey("officers.id", name="faces_officer_id_fkey")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("officers.id", name="faces_officer_id_fkey")
     )
-    img_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
+    img_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey(
             "raw_images.id",
             ondelete="CASCADE",
             onupdate="CASCADE",
@@ -489,9 +470,9 @@ class Face(BaseModel, TrackUpdates):
             use_alter=True,
         ),
     )
-    original_image_id = db.Column(
-        db.Integer,
-        db.ForeignKey(
+    original_image_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey(
             "raw_images.id",
             ondelete="SET NULL",
             onupdate="CASCADE",
@@ -499,126 +480,113 @@ class Face(BaseModel, TrackUpdates):
             name="fk_face_original_image_id",
         ),
     )
-    face_position_x = db.Column(db.Integer, unique=False)
-    face_position_y = db.Column(db.Integer, unique=False)
-    face_width = db.Column(db.Integer, unique=False)
-    face_height = db.Column(db.Integer, unique=False)
-    image = db.relationship(
+    face_position_x: Mapped[int] = mapped_column(Integer, unique=False)
+    face_position_y: Mapped[int] = mapped_column(Integer, unique=False)
+    face_width: Mapped[int] = mapped_column(Integer, unique=False)
+    face_height: Mapped[int] = mapped_column(Integer, unique=False)
+    featured: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
+    image: Mapped["Image"] = relationship(
         "Image",
-        backref=db.backref("faces", cascade_backrefs=False),
+        backref="faces",
+        cascade_backrefs=False,
         foreign_keys=[img_id],
     )
-    original_image = db.relationship(
+    original_image: Mapped["Image"] = relationship(
         "Image",
-        backref=db.backref("tags", cascade_backrefs=False),
+        backref="tags",
+        cascade_backrefs=False,
         foreign_keys=[original_image_id],
         lazy=True,
     )
-    featured = db.Column(
-        db.Boolean, nullable=False, default=False, server_default="false"
-    )
 
     __table_args__ = (UniqueConstraint("officer_id", "img_id", name="unique_faces"),)
-
-    def __repr__(self):
-        return f"<Tag ID: {self.id} : {self.officer_id} : {self.img_id}>"
 
 
 class Image(BaseModel, TrackUpdates):
     __tablename__ = "raw_images"
 
-    id = db.Column(db.Integer, primary_key=True)
-    filepath = db.Column(db.String(255), unique=False)
-    hash_img = db.Column(db.String(120), unique=False, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    filepath: Mapped[str] = mapped_column(String(255), unique=False)
+    hash_img: Mapped[str] = mapped_column(String(120), unique=False, nullable=True)
 
     # We might know when the image was taken e.g. through EXIF data
-    taken_at = db.Column(
-        db.DateTime(timezone=True), index=True, unique=False, nullable=True
+    taken_at: Mapped[str] = mapped_column(
+        DateTime(timezone=True), index=True, unique=False, nullable=True
     )
-    contains_cops = db.Column(db.Boolean, nullable=True)
+    contains_cops: Mapped[bool] = mapped_column(Boolean, nullable=True)
 
-    is_tagged = db.Column(db.Boolean, default=False, unique=False, nullable=True)
-
-    department_id = db.Column(
-        db.Integer,
-        db.ForeignKey("departments.id", name="raw_images_department_id_fkey"),
-    )
-    department = db.relationship(
-        "Department", backref=db.backref("raw_images", cascade_backrefs=False)
+    is_tagged: Mapped[bool] = mapped_column(
+        Boolean, default=False, unique=False, nullable=True
     )
 
-    def __repr__(self):
-        return f"<Image ID: {self.id} : {self.filepath}>"
+    department_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("departments.id", name="raw_images_department_id_fkey"),
+    )
+    department: Mapped["Department"] = relationship(
+        "Department", backref="raw_images", cascade_backrefs=False
+    )
 
 
 incident_links = db.Table(
     "incident_links",
-    db.Column(
+    mapped_column(
         "incident_id",
-        db.Integer,
-        db.ForeignKey("incidents.id", name="incident_links_incident_id_fkey"),
+        Integer,
+        ForeignKey("incidents.id", name="incident_links_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "link_id",
-        db.Integer,
-        db.ForeignKey("links.id", name="incident_links_link_id_fkey"),
+        Integer,
+        ForeignKey("links.id", name="incident_links_link_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
-        "created_at",
-        db.DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        unique=False,
+    mapped_column(
+        "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
 
 incident_license_plates = db.Table(
     "incident_license_plates",
-    db.Column(
+    mapped_column(
         "incident_id",
-        db.Integer,
-        db.ForeignKey("incidents.id", name="incident_license_plates_incident_id_fkey"),
+        Integer,
+        ForeignKey("incidents.id", name="incident_license_plates_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "license_plate_id",
-        db.Integer,
-        db.ForeignKey(
+        Integer,
+        ForeignKey(
             "license_plates.id", name="incident_license_plates_license_plate_id_fkey"
         ),
         primary_key=True,
     ),
-    db.Column(
-        "created_at",
-        db.DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        unique=False,
+    mapped_column(
+        "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
 
 incident_officers = db.Table(
     "incident_officers",
-    db.Column(
+    mapped_column(
         "incident_id",
-        db.Integer,
-        db.ForeignKey("incidents.id", name="incident_officers_incident_id_fkey"),
+        Integer,
+        ForeignKey("incidents.id", name="incident_officers_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "officers_id",
-        db.Integer,
-        db.ForeignKey("officers.id", name="incident_officers_officers_id_fkey"),
+        Integer,
+        ForeignKey("officers.id", name="incident_officers_officers_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
-        "created_at",
-        db.DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        unique=False,
+    mapped_column(
+        "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
 
@@ -626,13 +594,13 @@ incident_officers = db.Table(
 class Location(BaseModel, TrackUpdates):
     __tablename__ = "locations"
 
-    id = db.Column(db.Integer, primary_key=True)
-    street_name = db.Column(db.String(100), index=True)
-    cross_street1 = db.Column(db.String(100), unique=False)
-    cross_street2 = db.Column(db.String(100), unique=False)
-    city = db.Column(db.String(100), unique=False, index=True)
-    state = db.Column(db.String(2), unique=False, index=True)
-    zip_code = db.Column(db.String(5), unique=False, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    street_name: Mapped[str] = mapped_column(String(100), index=True)
+    cross_street1: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    cross_street2: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    city: Mapped[str] = mapped_column(String(100), index=True)
+    state: Mapped[str] = mapped_column(String(2), index=True)
+    zip_code: Mapped[str | None] = mapped_column(String(5), nullable=True, index=True)
 
     @validates("zip_code")
     def validate_zip_code(self, key, zip_code):
@@ -640,7 +608,7 @@ class Location(BaseModel, TrackUpdates):
             zip_re = r"^\d{5}$"
             if not re.match(zip_re, zip_code):
                 raise ValueError("Not a valid zip code")
-            return zip_code
+        return zip_code
 
     @validates("state")
     def validate_state(self, key, state):
@@ -655,12 +623,12 @@ class Location(BaseModel, TrackUpdates):
         elif self.street_name and self.cross_street2:
             return (
                 f"Intersection of {self.street_name} and {self.cross_street2}, "
-                + f"{self.city} {self.state}"
+                f"{self.city} {self.state}"
             )
         elif self.street_name and self.cross_street1:
             return (
                 f"Intersection of {self.street_name} and {self.cross_street1}, "
-                + f"{self.city} {self.state}"
+                f"{self.city} {self.state}"
             )
         else:
             return f"{self.city} {self.state}"
@@ -669,69 +637,69 @@ class Location(BaseModel, TrackUpdates):
 class LicensePlate(BaseModel, TrackUpdates):
     __tablename__ = "license_plates"
 
-    id = db.Column(db.Integer, primary_key=True)
-    number = db.Column(db.String(8), nullable=False, index=True)
-    state = db.Column(db.String(2), index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    number: Mapped[str] = mapped_column(String(8), nullable=False, index=True)
+    state: Mapped[str | None] = mapped_column(String(2), index=True)
 
     # for use if car is federal, diplomat, or other non-state
-    # non_state_identifier = db.Column(db.String(20), index=True)
+    # non_state_identifier: Mapped[str | None] = mapped_column(String(20), nullable=True, index=True)
 
     @validates("state")
     def validate_state(self, key, state):
         return state_validator(state)
 
-    def __repr__(self):
-        return f"<LicensePlate ID: {self.id} : {self.state} : {self.number}>"
-
 
 class Link(BaseModel, TrackUpdates):
     __tablename__ = "links"
 
-    id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(100), index=True)
-    url = db.Column(db.Text(), nullable=False)
-    link_type = db.Column(db.String(100), index=True)
-    description = db.Column(db.Text(), nullable=True)
-    author = db.Column(db.String(255), nullable=True)
-    has_content_warning = db.Column(db.Boolean, nullable=False, default=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str | None] = mapped_column(String(100), index=True)
+    url: Mapped[str] = mapped_column(Text(), nullable=False)
+    link_type: Mapped[str | None] = mapped_column(String(100), index=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    author: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    has_content_warning: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
 
     @validates("url")
     def validate_url(self, key, url):
         return url_validator(url)
 
-    def __repr__(self):
-        return f"<Link ID: {self.id} : {self.title}>"
-
 
 class Incident(BaseModel, TrackUpdates):
     __tablename__ = "incidents"
 
-    id = db.Column(db.Integer, primary_key=True)
-    date = db.Column(db.Date, unique=False, index=True)
-    time = db.Column(db.Time, unique=False, index=True)
-    report_number = db.Column(db.String(50), index=True)
-    description = db.Column(db.Text(), nullable=True)
-    address_id = db.Column(
-        db.Integer, db.ForeignKey("locations.id", name="incidents_address_id_fkey")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    date: Mapped[date | None] = mapped_column(Date, index=True)
+    time: Mapped[time | None] = mapped_column(Time, index=True)
+    report_number: Mapped[str | None] = mapped_column(String(50), index=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+
+    address_id: Mapped[int | None] = mapped_column(
+        Integer, db.ForeignKey("locations.id", name="incidents_address_id_fkey")
     )
-    address = db.relationship(
+    address: Mapped["Location"] = relationship(
         "Location", backref=db.backref("incidents", cascade_backrefs=False)
     )
-    license_plates = db.relationship(
+
+    license_plates: Mapped[list["LicensePlate"]] = relationship(
         "LicensePlate",
         secondary=incident_license_plates,
         lazy="subquery",
         backref=db.backref("incidents", cascade_backrefs=False, lazy=True),
     )
-    links = db.relationship(
+
+    links: Mapped[list["Link"]] = relationship(
         "Link",
         secondary=incident_links,
         lazy="subquery",
         backref=db.backref("incidents", cascade_backrefs=False, lazy=True),
     )
-    officers = db.relationship(
+
+    officers: Mapped[list["Officer"]] = relationship(
         "Officer",
-        secondary=officer_incidents,
+        secondary=incident_officers,
         lazy="subquery",
         backref=db.backref(
             "incidents",
@@ -739,93 +707,87 @@ class Incident(BaseModel, TrackUpdates):
             order_by="Incident.date.desc(), Incident.time.desc()",
         ),
     )
-    department_id = db.Column(
-        db.Integer, db.ForeignKey("departments.id", name="incidents_department_id_fkey")
+
+    department_id: Mapped[int | None] = mapped_column(
+        Integer, db.ForeignKey("departments.id", name="incidents_department_id_fkey")
     )
-    department = db.relationship(
+    department: Mapped["Department"] = relationship(
         "Department", backref=db.backref("incidents", cascade_backrefs=False), lazy=True
     )
-
-    def __repr__(self):
-        return f"<Incident ID: {self.id} : {self.report_number}>"
 
 
 class User(UserMixin, BaseModel):
     __tablename__ = "users"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
 
-    # A universally unique identifier (UUID) that can be
-    # used in place of the user's primary key for things like user
-    # lookup queries.
-    _uuid = db.Column(
-        db.String(36),
+    _uuid: Mapped[str] = mapped_column(
+        String(36),
         unique=True,
         nullable=False,
         index=True,
         default=lambda: str(uuid.uuid4()),
     )
-    email = db.Column(db.String(64), unique=True, index=True)
-    username = db.Column(db.String(64), unique=True, index=True)
-    password_hash = db.Column(db.String(128))
-    confirmed_at = db.Column(db.DateTime(timezone=True))
-    confirmed_by = db.Column(
-        db.Integer,
-        db.ForeignKey("users.id", ondelete="SET NULL", name="users_confirmed_by_fkey"),
-        unique=False,
+    email: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
+    username: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
+    password_hash: Mapped[str | None] = mapped_column(String(128))
+    confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    confirmed_by: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="users_confirmed_by_fkey"),
     )
-    approved_at = db.Column(db.DateTime(timezone=True))
-    approved_by = db.Column(
-        db.Integer,
-        db.ForeignKey("users.id", ondelete="SET NULL", name="users_approved_by_fkey"),
-        unique=False,
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    approved_by: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="users_approved_by_fkey"),
     )
-    is_area_coordinator = db.Column(db.Boolean, default=False)
-    ac_department_id = db.Column(
-        db.Integer, db.ForeignKey("departments.id", name="users_ac_department_id_fkey")
+    is_area_coordinator: Mapped[bool] = mapped_column(Boolean, default=False)
+    ac_department_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("departments.id", name="users_ac_department_id_fkey")
     )
-    ac_department = db.relationship(
+    ac_department: Mapped["Department"] = relationship(
         "Department",
         backref=db.backref("coordinators", cascade_backrefs=False),
         foreign_keys=[ac_department_id],
     )
-    is_administrator = db.Column(db.Boolean, default=False)
-    disabled_at = db.Column(db.DateTime(timezone=True))
-    disabled_by = db.Column(
-        db.Integer,
-        db.ForeignKey("users.id", ondelete="SET NULL", name="users_disabled_by_fkey"),
-        unique=False,
+    is_administrator: Mapped[bool] = mapped_column(Boolean, default=False)
+    disabled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    disabled_by: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL", name="users_disabled_by_fkey"),
     )
 
-    dept_pref = db.Column(
-        db.Integer, db.ForeignKey("departments.id", name="users_dept_pref_fkey")
+    dept_pref: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("departments.id", name="users_dept_pref_fkey")
     )
-    dept_pref_rel = db.relationship("Department", foreign_keys=[dept_pref])
+    dept_pref_rel: Mapped["Department"] = relationship(
+        "Department", foreign_keys=[dept_pref]
+    )
 
     # creator backlinks
-    classifications = db.relationship(
+    classifications: Mapped[list["Image"]] = relationship(
         "Image", back_populates=KEY_DB_CREATOR, foreign_keys="Image.created_by"
     )
-    descriptions = db.relationship(
+    descriptions: Mapped[list["Description"]] = relationship(
         "Description",
         back_populates=KEY_DB_CREATOR,
         foreign_keys="Description.created_by",
     )
-    incidents_created = db.relationship(
+    incidents_created: Mapped[list["Incident"]] = relationship(
         "Incident", back_populates=KEY_DB_CREATOR, foreign_keys="Incident.created_by"
     )
-    links = db.relationship(
+    links: Mapped[list["Link"]] = relationship(
         "Link", back_populates=KEY_DB_CREATOR, foreign_keys="Link.created_by"
     )
-    notes = db.relationship(
+    notes: Mapped[list["Note"]] = relationship(
         "Note", back_populates=KEY_DB_CREATOR, foreign_keys="Note.created_by"
     )
-    tags = db.relationship(
+    tags: Mapped[list["Face"]] = relationship(
         "Face", back_populates=KEY_DB_CREATOR, foreign_keys="Face.created_by"
     )
 
-    created_at = db.Column(
-        db.DateTime(timezone=True),
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),
         unique=False,
@@ -846,13 +808,13 @@ class User(UserMixin, BaseModel):
         ),
     )
 
-    def is_admin_or_coordinator(self, department: Optional[Department]) -> bool:
+    def is_admin_or_coordinator(self, department: Optional["Department"]) -> bool:
         return self.is_administrator or (
             department is not None
             and (self.is_area_coordinator and self.ac_department_id == department.id)
         )
 
-    def _jwt_encode(self, payload, expiration):
+    def _jwt_encode(self, payload, expiration: int) -> str:
         secret = current_app.config["SECRET_KEY"]
         header = {"alg": SIGNATURE_ALGORITHM}
 
@@ -872,37 +834,35 @@ class User(UserMixin, BaseModel):
     def password(self):
         raise AttributeError("password is not a readable attribute")
 
-    # mypy has difficulty with mixins, specifically the ones where we define a function
-    # twice.
     @password.setter  # type: ignore
-    def password(self, password):  # type: ignore
+    def password(self, password: str) -> None:  # type: ignore
         self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
         self.regenerate_uuid()
 
     @property
-    def uuid(self):
+    def uuid(self) -> str:
         return self._uuid
 
     @staticmethod
-    def _case_insensitive_equality(field, value):
+    def _case_insensitive_equality(field, value: str):
         return User.query.filter(func.lower(field) == func.lower(value))
 
     @staticmethod
-    def by_email(email):
+    def by_email(email: str):
         return User._case_insensitive_equality(User.email, email)
 
     @staticmethod
-    def by_username(username):
+    def by_username(username: str):
         return User._case_insensitive_equality(User.username, username)
 
-    def verify_password(self, password):
+    def verify_password(self, password: str) -> bool:
         return check_password_hash(self.password_hash, password)
 
     def generate_confirmation_token(self, expiration=3600):
         payload = {"confirm": self.uuid}
         return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
-    def confirm(self, token, confirming_user_id: int):
+    def confirm(self, token: str, confirming_user_id: int) -> bool:
         try:
             data = self._jwt_decode(token)
         except JoseError as e:
@@ -925,7 +885,7 @@ class User(UserMixin, BaseModel):
         payload = {"reset": self.uuid}
         return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
-    def reset_password(self, token, new_password):
+    def reset_password(self, token: str, new_password: str) -> bool:
         try:
             data = self._jwt_decode(token)
         except JoseError:
@@ -941,7 +901,7 @@ class User(UserMixin, BaseModel):
         payload = {"change_email": self.uuid, "new_email": new_email}
         return self._jwt_encode(payload, expiration).decode(ENCODING_UTF_8)
 
-    def change_email(self, token):
+    def change_email(self, token: str) -> bool:
         try:
             data = self._jwt_decode(token)
         except JoseError:
@@ -959,19 +919,19 @@ class User(UserMixin, BaseModel):
         db.session.commit()
         return True
 
-    def regenerate_uuid(self):
+    def regenerate_uuid(self) -> None:
         self._uuid = str(uuid.uuid4())
 
-    def get_id(self):
+    def get_id(self) -> str:
         """Get the Flask-Login user identifier, NOT THE DATABASE ID."""
         return str(self.uuid)
 
     @property
-    def is_active(self):
+    def is_active(self) -> bool:
         """Override UserMixin.is_active to prevent disabled users from logging in."""
         return not self.disabled_at
 
-    def approve_user(self, approving_user_id: int):
+    def approve_user(self, approving_user_id: int) -> bool:
         """Handle approving logic."""
         if self.approved_at or self.approved_by:
             return False
@@ -982,7 +942,7 @@ class User(UserMixin, BaseModel):
         db.session.commit()
         return True
 
-    def confirm_user(self, confirming_user_id: int):
+    def confirm_user(self, confirming_user_id: int) -> bool:
         """Handle confirming logic."""
         if self.confirmed_at or self.confirmed_by:
             return False
@@ -993,7 +953,7 @@ class User(UserMixin, BaseModel):
         db.session.commit()
         return True
 
-    def disable_user(self, disabling_user_id: int):
+    def disable_user(self, disabling_user_id: int) -> bool:
         """Handle disabling logic."""
         if self.disabled_at or self.disabled_by:
             return False
@@ -1003,6 +963,3 @@ class User(UserMixin, BaseModel):
         db.session.add(self)
         db.session.commit()
         return True
-
-    def __repr__(self):
-        return f"<User {self.username!r}>"

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -223,7 +223,7 @@ class Job(BaseModel, TrackUpdates):
     job_title: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
     is_sworn_officer: Mapped[bool] = mapped_column(Boolean, index=True, default=True)
     order: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
-    department_id: Mapped[Optional[int]] = mapped_column(
+    department_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("departments.id", name="jobs_department_id_fkey")
     )
     department: Mapped["Department"] = relationship(

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -216,6 +216,24 @@ class Department(BaseModel, TrackUpdates):
         remove_database_cache_entries(self, update_types)
 
 
+class Link(BaseModel, TrackUpdates):
+    __tablename__ = "links"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str | None] = mapped_column(String(100), index=True)
+    url: Mapped[str] = mapped_column(Text(), nullable=False)
+    link_type: Mapped[str | None] = mapped_column(String(100), index=True)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    author: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    has_content_warning: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+
+    @validates("url")
+    def validate_url(self, key, url):
+        return url_validator(url)
+
+
 class Job(BaseModel, TrackUpdates):
     __tablename__ = "jobs"
 
@@ -650,24 +668,6 @@ class LicensePlate(BaseModel, TrackUpdates):
         return state_validator(state)
 
 
-class Link(BaseModel, TrackUpdates):
-    __tablename__ = "links"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    title: Mapped[str | None] = mapped_column(String(100), index=True)
-    url: Mapped[str] = mapped_column(Text(), nullable=False)
-    link_type: Mapped[str | None] = mapped_column(String(100), index=True)
-    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
-    author: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    has_content_warning: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-
-    @validates("url")
-    def validate_url(self, key, url):
-        return url_validator(url)
-
-
 class Incident(BaseModel, TrackUpdates):
     __tablename__ = "incidents"
 
@@ -727,14 +727,6 @@ class User(UserMixin, BaseModel):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-
-    _uuid: Mapped[str] = mapped_column(
-        String(36),
-        unique=True,
-        nullable=False,
-        index=True,
-        default=lambda: str(uuid.uuid4()),
-    )
     email: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
     username: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
     password_hash: Mapped[str | None] = mapped_column(String(128))
@@ -748,7 +740,7 @@ class User(UserMixin, BaseModel):
         Integer,
         ForeignKey("users.id", ondelete="SET NULL", name="users_approved_by_fkey"),
     )
-    is_area_coordinator: Mapped[bool] = mapped_column(Boolean, default=False)
+
     ac_department_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("departments.id", name="users_ac_department_id_fkey")
     )
@@ -757,7 +749,6 @@ class User(UserMixin, BaseModel):
         backref=db.backref("coordinators", cascade_backrefs=False),
         foreign_keys=[ac_department_id],
     )
-    is_administrator: Mapped[bool] = mapped_column(Boolean, default=False)
     disabled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     disabled_by: Mapped[Optional[int]] = mapped_column(
         Integer,
@@ -793,10 +784,19 @@ class User(UserMixin, BaseModel):
         "Face", back_populates=KEY_DB_CREATOR, foreign_keys="Face.created_by"
     )
 
+    _uuid: Mapped[str] = mapped_column(
+        String(36),
+        unique=True,
+        nullable=False,
+        index=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    is_area_coordinator: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_administrator: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        default=func.now(),
         nullable=False,
-        server_default=func.now(),
         unique=False,
     )
 

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -877,8 +877,8 @@ class User(UserMixin, BaseModel):
             return False
         self.confirmed_at = datetime.now(timezone.utc)
         self.confirmed_by = confirming_user_id
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True
 
     def generate_reset_token(self, expiration=3600):
@@ -893,8 +893,8 @@ class User(UserMixin, BaseModel):
         if data.get("reset") != self.uuid:
             return False
         self.password = new_password
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True
 
     def generate_email_change_token(self, new_email, expiration=3600):
@@ -915,8 +915,8 @@ class User(UserMixin, BaseModel):
             return False
         self.email = new_email
         self.regenerate_uuid()
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True
 
     def regenerate_uuid(self) -> None:
@@ -938,8 +938,8 @@ class User(UserMixin, BaseModel):
 
         self.approved_at = datetime.now(timezone.utc)
         self.approved_by = approving_user_id
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True
 
     def confirm_user(self, confirming_user_id: int) -> bool:
@@ -949,8 +949,8 @@ class User(UserMixin, BaseModel):
 
         self.confirmed_at = datetime.now(timezone.utc)
         self.confirmed_by = confirming_user_id
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True
 
     def disable_user(self, disabling_user_id: int) -> bool:
@@ -960,6 +960,6 @@ class User(UserMixin, BaseModel):
 
         self.disabled_at = datetime.now(timezone.utc)
         self.disabled_by = disabling_user_id
-        db.session.add(self)
-        db.session.commit()
+        self.db_session.add(self)
+        self.db_session.commit()
         return True

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -11,7 +11,15 @@ from flask import current_app
 from flask_login import UserMixin
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import CheckConstraint, UniqueConstraint, func
-from sqlalchemy.orm import DeclarativeMeta, declarative_mixin, declared_attr, validates
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    MappedAsDataclass,
+    declarative_mixin,
+    declared_attr,
+    mapped_column,
+    validates,
+)
 from sqlalchemy.sql import func as sql_func
 from werkzeug.security import check_password_hash, generate_password_hash
 
@@ -34,24 +42,27 @@ from OpenOversight.app.validators import state_validator, url_validator
 
 db = SQLAlchemy()
 jwt = JsonWebToken(SIGNATURE_ALGORITHM)
-BaseModel: DeclarativeMeta = db.Model
+
+
+class BaseModel(MappedAsDataclass, DeclarativeBase):
+    """subclasses will be converted to dataclasses"""
 
 
 officer_links = db.Table(
     "officer_links",
-    db.Column(
+    mapped_column(
         "officer_id",
         db.Integer,
         db.ForeignKey("officers.id", name="officer_links_officer_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "link_id",
         db.Integer,
         db.ForeignKey("links.id", name="officer_links_link_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -62,19 +73,19 @@ officer_links = db.Table(
 
 officer_incidents = db.Table(
     "officer_incidents",
-    db.Column(
+    mapped_column(
         "officer_id",
         db.Integer,
         db.ForeignKey("officers.id", name="officer_incidents_officer_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="officer_incidents_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -90,13 +101,13 @@ class TrackUpdates:
     the object.
     """
 
-    created_at = db.Column(
+    created_at: Mapped[datetime] = mapped_column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
         unique=False,
     )
-    last_updated_at = db.Column(
+    last_updated_at = mapped_column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
@@ -106,13 +117,13 @@ class TrackUpdates:
 
     @declared_attr
     def created_by(cls):
-        return db.Column(
+        return mapped_column(
             db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
         )
 
     @declared_attr
     def last_updated_by(cls):
-        return db.Column(
+        return mapped_column(
             db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), unique=False
         )
 
@@ -123,13 +134,14 @@ class TrackUpdates:
 
 class Department(BaseModel, TrackUpdates):
     __tablename__ = "departments"
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(255), index=False, unique=False, nullable=False)
-    short_name = db.Column(db.String(100), unique=False, nullable=False)
-    state = db.Column(db.String(2), server_default="", nullable=False)
+
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    name = mapped_column(db.String(255), index=False, unique=False, nullable=False)
+    short_name = mapped_column(db.String(100), unique=False, nullable=False)
+    state = mapped_column(db.String(2), server_default="", nullable=False)
 
     # See https://github.com/lucyparsons/OpenOversight/issues/462
-    unique_internal_identifier_label = db.Column(
+    unique_internal_identifier_label = mapped_column(
         db.String(100), unique=False, nullable=True
     )
 
@@ -180,11 +192,11 @@ class Department(BaseModel, TrackUpdates):
 class Job(BaseModel, TrackUpdates):
     __tablename__ = "jobs"
 
-    id = db.Column(db.Integer, primary_key=True)
-    job_title = db.Column(db.String(255), index=True, unique=False, nullable=False)
-    is_sworn_officer = db.Column(db.Boolean, index=True, default=True)
-    order = db.Column(db.Integer, index=True, unique=False, nullable=False)
-    department_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    job_title = mapped_column(db.String(255), index=True, unique=False, nullable=False)
+    is_sworn_officer = mapped_column(db.Boolean, index=True, default=True)
+    order = mapped_column(db.Integer, index=True, unique=False, nullable=False)
+    department_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("departments.id", name="jobs_department_id_fkey")
     )
     department = db.relationship(
@@ -207,9 +219,11 @@ class Job(BaseModel, TrackUpdates):
 class Note(BaseModel, TrackUpdates):
     __tablename__ = "notes"
 
-    id = db.Column(db.Integer, primary_key=True)
-    text_contents = db.Column(db.Text())
-    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    text_contents = mapped_column(db.Text())
+    officer_id: Mapped[int] = mapped_column(
+        db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE")
+    )
     officer = db.relationship("Officer", back_populates="notes")
 
     def __repr__(self):
@@ -220,9 +234,11 @@ class Description(BaseModel, TrackUpdates):
     __tablename__ = "descriptions"
 
     officer = db.relationship("Officer", back_populates="descriptions")
-    id = db.Column(db.Integer, primary_key=True)
-    text_contents = db.Column(db.Text())
-    officer_id = db.Column(db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE"))
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    text_contents = mapped_column(db.Text())
+    officer_id: Mapped[int] = mapped_column(
+        db.Integer, db.ForeignKey("officers.id", ondelete="CASCADE")
+    )
 
     def __repr__(self):
         return f"<Description ID: {self.id} : {self.text_contents}>"
@@ -231,28 +247,28 @@ class Description(BaseModel, TrackUpdates):
 class Officer(BaseModel, TrackUpdates):
     __tablename__ = "officers"
 
-    id = db.Column(db.Integer, primary_key=True)
-    last_name = db.Column(db.String(120), index=True, unique=False)
-    first_name = db.Column(db.String(120), index=True, unique=False)
-    middle_initial = db.Column(db.String(120), unique=False, nullable=True)
-    suffix = db.Column(db.String(120), index=True, unique=False)
-    race = db.Column(db.String(120), index=True, unique=False)
-    gender = db.Column(db.String(5), index=True, unique=False, nullable=True)
-    employment_date = db.Column(db.Date, index=True, unique=False, nullable=True)
-    birth_year = db.Column(db.Integer, index=True, unique=False, nullable=True)
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    last_name = mapped_column(db.String(120), index=True, unique=False)
+    first_name = mapped_column(db.String(120), index=True, unique=False)
+    middle_initial = mapped_column(db.String(120), unique=False, nullable=True)
+    suffix = mapped_column(db.String(120), index=True, unique=False)
+    race = mapped_column(db.String(120), index=True, unique=False)
+    gender = mapped_column(db.String(5), index=True, unique=False, nullable=True)
+    employment_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
+    birth_year = mapped_column(db.Integer, index=True, unique=False, nullable=True)
     assignments = db.relationship(
         "Assignment", back_populates="base_officer", cascade_backrefs=False
     )
     face = db.relationship(
         "Face", backref=db.backref("officer", cascade_backrefs=False)
     )
-    department_id = db.Column(
+    department_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("departments.id", name="officers_department_id_fkey")
     )
     department = db.relationship(
         "Department", backref=db.backref("officers", cascade_backrefs=False)
     )
-    unique_internal_identifier = db.Column(
+    unique_internal_identifier = mapped_column(
         db.String(50), index=True, unique=True, nullable=True
     )
 
@@ -357,18 +373,20 @@ class Officer(BaseModel, TrackUpdates):
 class Salary(BaseModel, TrackUpdates):
     __tablename__ = "salaries"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey(
             "officers.id", name="salaries_officer_id_fkey", ondelete="CASCADE"
         ),
     )
     officer = db.relationship("Officer", back_populates="salaries")
-    salary = db.Column(db.Float, index=True, unique=False, nullable=False)
-    overtime_pay = db.Column(db.Float, index=True, unique=False, nullable=True)
-    year = db.Column(db.Integer, index=True, unique=False, nullable=False)
-    is_fiscal_year = db.Column(db.Boolean, index=False, unique=False, nullable=False)
+    salary = mapped_column(db.Float, index=True, unique=False, nullable=False)
+    overtime_pay = mapped_column(db.Float, index=True, unique=False, nullable=True)
+    year = mapped_column(db.Integer, index=True, unique=False, nullable=False)
+    is_fiscal_year = mapped_column(
+        db.Boolean, index=False, unique=False, nullable=False
+    )
 
     def __repr__(self):
         return f"<Salary ID: {self.officer_id} : {self.salary}>"
@@ -387,29 +405,29 @@ class Salary(BaseModel, TrackUpdates):
 class Assignment(BaseModel, TrackUpdates):
     __tablename__ = "assignments"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey(
             "officers.id", name="assignments_officer_id_fkey", ondelete="CASCADE"
         ),
     )
     base_officer = db.relationship("Officer", back_populates="assignments")
-    star_no = db.Column(db.String(120), index=True, unique=False, nullable=True)
-    job_id = db.Column(
+    star_no = mapped_column(db.String(120), index=True, unique=False, nullable=True)
+    job_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey("jobs.id", name="assignments_job_id_fkey"),
         nullable=False,
     )
     job = db.relationship("Job")
-    unit_id = db.Column(
+    unit_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey("unit_types.id", name="assignments_unit_id_fkey"),
         nullable=True,
     )
     unit = db.relationship("Unit")
-    start_date = db.Column(db.Date, index=True, unique=False, nullable=True)
-    resign_date = db.Column(db.Date, index=True, unique=False, nullable=True)
+    start_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
+    resign_date = mapped_column(db.Date, index=True, unique=False, nullable=True)
 
     def __repr__(self):
         return f"<Assignment ID: {self.officer_id} : {self.star_no}>"
@@ -426,9 +444,9 @@ class Assignment(BaseModel, TrackUpdates):
 class Unit(BaseModel, TrackUpdates):
     __tablename__ = "unit_types"
 
-    id = db.Column(db.Integer, primary_key=True)
-    description = db.Column(db.String(120), index=True, unique=False)
-    department_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    description = mapped_column(db.String(120), index=True, unique=False)
+    department_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey("departments.id", name="unit_types_department_id_fkey"),
     )
@@ -445,11 +463,11 @@ class Unit(BaseModel, TrackUpdates):
 class Face(BaseModel, TrackUpdates):
     __tablename__ = "faces"
 
-    id = db.Column(db.Integer, primary_key=True)
-    officer_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    officer_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("officers.id", name="faces_officer_id_fkey")
     )
-    img_id = db.Column(
+    img_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey(
             "raw_images.id",
@@ -459,7 +477,7 @@ class Face(BaseModel, TrackUpdates):
             use_alter=True,
         ),
     )
-    original_image_id = db.Column(
+    original_image_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey(
             "raw_images.id",
@@ -469,10 +487,10 @@ class Face(BaseModel, TrackUpdates):
             name="fk_face_original_image_id",
         ),
     )
-    face_position_x = db.Column(db.Integer, unique=False)
-    face_position_y = db.Column(db.Integer, unique=False)
-    face_width = db.Column(db.Integer, unique=False)
-    face_height = db.Column(db.Integer, unique=False)
+    face_position_x = mapped_column(db.Integer, unique=False)
+    face_position_y = mapped_column(db.Integer, unique=False)
+    face_width = mapped_column(db.Integer, unique=False)
+    face_height = mapped_column(db.Integer, unique=False)
     image = db.relationship(
         "Image",
         backref=db.backref("faces", cascade_backrefs=False),
@@ -484,7 +502,7 @@ class Face(BaseModel, TrackUpdates):
         foreign_keys=[original_image_id],
         lazy=True,
     )
-    featured = db.Column(
+    featured = mapped_column(
         db.Boolean, nullable=False, default=False, server_default="false"
     )
 
@@ -497,19 +515,19 @@ class Face(BaseModel, TrackUpdates):
 class Image(BaseModel, TrackUpdates):
     __tablename__ = "raw_images"
 
-    id = db.Column(db.Integer, primary_key=True)
-    filepath = db.Column(db.String(255), unique=False)
-    hash_img = db.Column(db.String(120), unique=False, nullable=True)
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    filepath = mapped_column(db.String(255), unique=False)
+    hash_img = mapped_column(db.String(120), unique=False, nullable=True)
 
     # We might know when the image was taken e.g. through EXIF data
-    taken_at = db.Column(
+    taken_at = mapped_column(
         db.DateTime(timezone=True), index=True, unique=False, nullable=True
     )
-    contains_cops = db.Column(db.Boolean, nullable=True)
+    contains_cops = mapped_column(db.Boolean, nullable=True)
 
-    is_tagged = db.Column(db.Boolean, default=False, unique=False, nullable=True)
+    is_tagged = mapped_column(db.Boolean, default=False, unique=False, nullable=True)
 
-    department_id = db.Column(
+    department_id: Mapped[int] = mapped_column(
         db.Integer,
         db.ForeignKey("departments.id", name="raw_images_department_id_fkey"),
     )
@@ -523,19 +541,19 @@ class Image(BaseModel, TrackUpdates):
 
 incident_links = db.Table(
     "incident_links",
-    db.Column(
+    mapped_column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_links_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "link_id",
         db.Integer,
         db.ForeignKey("links.id", name="incident_links_link_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -546,13 +564,13 @@ incident_links = db.Table(
 
 incident_license_plates = db.Table(
     "incident_license_plates",
-    db.Column(
+    mapped_column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_license_plates_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "license_plate_id",
         db.Integer,
         db.ForeignKey(
@@ -560,7 +578,7 @@ incident_license_plates = db.Table(
         ),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -571,19 +589,19 @@ incident_license_plates = db.Table(
 
 incident_officers = db.Table(
     "incident_officers",
-    db.Column(
+    mapped_column(
         "incident_id",
         db.Integer,
         db.ForeignKey("incidents.id", name="incident_officers_incident_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "officers_id",
         db.Integer,
         db.ForeignKey("officers.id", name="incident_officers_officers_id_fkey"),
         primary_key=True,
     ),
-    db.Column(
+    mapped_column(
         "created_at",
         db.DateTime(timezone=True),
         nullable=False,
@@ -596,13 +614,13 @@ incident_officers = db.Table(
 class Location(BaseModel, TrackUpdates):
     __tablename__ = "locations"
 
-    id = db.Column(db.Integer, primary_key=True)
-    street_name = db.Column(db.String(100), index=True)
-    cross_street1 = db.Column(db.String(100), unique=False)
-    cross_street2 = db.Column(db.String(100), unique=False)
-    city = db.Column(db.String(100), unique=False, index=True)
-    state = db.Column(db.String(2), unique=False, index=True)
-    zip_code = db.Column(db.String(5), unique=False, index=True)
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    street_name = mapped_column(db.String(100), index=True)
+    cross_street1 = mapped_column(db.String(100), unique=False)
+    cross_street2 = mapped_column(db.String(100), unique=False)
+    city = mapped_column(db.String(100), unique=False, index=True)
+    state = mapped_column(db.String(2), unique=False, index=True)
+    zip_code = mapped_column(db.String(5), unique=False, index=True)
 
     @validates("zip_code")
     def validate_zip_code(self, key, zip_code):
@@ -639,12 +657,12 @@ class Location(BaseModel, TrackUpdates):
 class LicensePlate(BaseModel, TrackUpdates):
     __tablename__ = "license_plates"
 
-    id = db.Column(db.Integer, primary_key=True)
-    number = db.Column(db.String(8), nullable=False, index=True)
-    state = db.Column(db.String(2), index=True)
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    number = mapped_column(db.String(8), nullable=False, index=True)
+    state = mapped_column(db.String(2), index=True)
 
     # for use if car is federal, diplomat, or other non-state
-    # non_state_identifier = db.Column(db.String(20), index=True)
+    # non_state_identifier = mapped_column(db.String(20), index=True)
 
     @validates("state")
     def validate_state(self, key, state):
@@ -657,13 +675,13 @@ class LicensePlate(BaseModel, TrackUpdates):
 class Link(BaseModel, TrackUpdates):
     __tablename__ = "links"
 
-    id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(100), index=True)
-    url = db.Column(db.Text(), nullable=False)
-    link_type = db.Column(db.String(100), index=True)
-    description = db.Column(db.Text(), nullable=True)
-    author = db.Column(db.String(255), nullable=True)
-    has_content_warning = db.Column(db.Boolean, nullable=False, default=False)
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    title = mapped_column(db.String(100), index=True)
+    url = mapped_column(db.Text(), nullable=False)
+    link_type = mapped_column(db.String(100), index=True)
+    description = mapped_column(db.Text(), nullable=True)
+    author = mapped_column(db.String(255), nullable=True)
+    has_content_warning = mapped_column(db.Boolean, nullable=False, default=False)
 
     @validates("url")
     def validate_url(self, key, url):
@@ -676,12 +694,12 @@ class Link(BaseModel, TrackUpdates):
 class Incident(BaseModel, TrackUpdates):
     __tablename__ = "incidents"
 
-    id = db.Column(db.Integer, primary_key=True)
-    date = db.Column(db.Date, unique=False, index=True)
-    time = db.Column(db.Time, unique=False, index=True)
-    report_number = db.Column(db.String(50), index=True)
-    description = db.Column(db.Text(), nullable=True)
-    address_id = db.Column(
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
+    date = mapped_column(db.Date, unique=False, index=True)
+    time = mapped_column(db.Time, unique=False, index=True)
+    report_number = mapped_column(db.String(50), index=True)
+    description = mapped_column(db.Text(), nullable=True)
+    address_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("locations.id", name="incidents_address_id_fkey")
     )
     address = db.relationship(
@@ -709,7 +727,7 @@ class Incident(BaseModel, TrackUpdates):
             order_by="Incident.date.desc(), Incident.time.desc()",
         ),
     )
-    department_id = db.Column(
+    department_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("departments.id", name="incidents_department_id_fkey")
     )
     department = db.relationship(
@@ -722,35 +740,36 @@ class Incident(BaseModel, TrackUpdates):
 
 class User(UserMixin, BaseModel):
     __tablename__ = "users"
-    id = db.Column(db.Integer, primary_key=True)
+
+    id: Mapped[int] = mapped_column(db.Integer, primary_key=True)
 
     # A universally unique identifier (UUID) that can be
     # used in place of the user's primary key for things like user
     # lookup queries.
-    _uuid = db.Column(
+    _uuid: Mapped[str] = mapped_column(
         db.String(36),
         unique=True,
         nullable=False,
         index=True,
         default=lambda: str(uuid.uuid4()),
     )
-    email = db.Column(db.String(64), unique=True, index=True)
-    username = db.Column(db.String(64), unique=True, index=True)
-    password_hash = db.Column(db.String(128))
-    confirmed_at = db.Column(db.DateTime(timezone=True))
-    confirmed_by = db.Column(
+    email = mapped_column(db.String(64), unique=True, index=True)
+    username = mapped_column(db.String(64), unique=True, index=True)
+    password_hash = mapped_column(db.String(128))
+    confirmed_at = mapped_column(db.DateTime(timezone=True))
+    confirmed_by = mapped_column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_confirmed_by_fkey"),
         unique=False,
     )
-    approved_at = db.Column(db.DateTime(timezone=True))
-    approved_by = db.Column(
+    approved_at = mapped_column(db.DateTime(timezone=True))
+    approved_by = mapped_column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_approved_by_fkey"),
         unique=False,
     )
-    is_area_coordinator = db.Column(db.Boolean, default=False)
-    ac_department_id = db.Column(
+    is_area_coordinator = mapped_column(db.Boolean, default=False)
+    ac_department_id: Mapped[int] = mapped_column(
         db.Integer, db.ForeignKey("departments.id", name="users_ac_department_id_fkey")
     )
     ac_department = db.relationship(
@@ -758,15 +777,15 @@ class User(UserMixin, BaseModel):
         backref=db.backref("coordinators", cascade_backrefs=False),
         foreign_keys=[ac_department_id],
     )
-    is_administrator = db.Column(db.Boolean, default=False)
-    disabled_at = db.Column(db.DateTime(timezone=True))
-    disabled_by = db.Column(
+    is_administrator = mapped_column(db.Boolean, default=False)
+    disabled_at = mapped_column(db.DateTime(timezone=True))
+    disabled_by = mapped_column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL", name="users_disabled_by_fkey"),
         unique=False,
     )
 
-    dept_pref = db.Column(
+    dept_pref = mapped_column(
         db.Integer, db.ForeignKey("departments.id", name="users_dept_pref_fkey")
     )
     dept_pref_rel = db.relationship("Department", foreign_keys=[dept_pref])
@@ -793,7 +812,7 @@ class User(UserMixin, BaseModel):
         "Face", back_populates=KEY_DB_CREATOR, foreign_keys="Face.created_by"
     )
 
-    created_at = db.Column(
+    created_at = mapped_column(
         db.DateTime(timezone=True),
         nullable=False,
         server_default=sql_func.now(),
@@ -929,7 +948,7 @@ class User(UserMixin, BaseModel):
         return True
 
     def regenerate_uuid(self):
-        self._uuid = str(uuid.uuid4())
+        self._uuid: Mapped[str] = str(uuid.uuid4())
 
     def get_id(self):
         """Get the Flask-Login user identifier, NOT THE DATABASE ID."""

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -1,8 +1,8 @@
 import operator
 import re
-import time
+import time as time_obj
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
 from typing import List, Optional
 
 from authlib.jose import JoseError, JsonWebToken
@@ -221,7 +221,6 @@ class Job(BaseModel, TrackUpdates):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     job_title: Mapped[str] = mapped_column(String(255), index=True, nullable=False)
-    is_sworn_officer: Mapped[bool] = mapped_column(Boolean, index=True, default=True)
     order: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
     department_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("departments.id", name="jobs_department_id_fkey")
@@ -230,6 +229,7 @@ class Job(BaseModel, TrackUpdates):
         "Department",
         backref=backref("jobs", cascade_backrefs=False),
     )
+    is_sworn_officer: Mapped[bool] = mapped_column(Boolean, index=True, default=True)
 
     __table_args__ = (
         UniqueConstraint(
@@ -484,22 +484,23 @@ class Face(BaseModel, TrackUpdates):
     face_position_y: Mapped[int] = mapped_column(Integer, unique=False)
     face_width: Mapped[int] = mapped_column(Integer, unique=False)
     face_height: Mapped[int] = mapped_column(Integer, unique=False)
-    featured: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default="false"
-    )
 
-    image: Mapped["Image"] = relationship(
-        "Image",
-        backref="faces",
-        cascade_backrefs=False,
-        foreign_keys=[img_id],
-    )
     original_image: Mapped["Image"] = relationship(
         "Image",
         backref="tags",
         cascade_backrefs=False,
         foreign_keys=[original_image_id],
         lazy=True,
+    )
+    image: Mapped["Image"] = relationship(
+        "Image",
+        backref="faces",
+        cascade_backrefs=False,
+        foreign_keys=[img_id],
+    )
+
+    featured: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
     )
 
     __table_args__ = (UniqueConstraint("officer_id", "img_id", name="unique_faces"),)
@@ -518,10 +519,6 @@ class Image(BaseModel, TrackUpdates):
     )
     contains_cops: Mapped[bool] = mapped_column(Boolean, nullable=True)
 
-    is_tagged: Mapped[bool] = mapped_column(
-        Boolean, default=False, unique=False, nullable=True
-    )
-
     department_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("departments.id", name="raw_images_department_id_fkey"),
@@ -530,35 +527,39 @@ class Image(BaseModel, TrackUpdates):
         "Department", backref="raw_images", cascade_backrefs=False
     )
 
+    is_tagged: Mapped[bool] = mapped_column(
+        Boolean, default=False, unique=False, nullable=True
+    )
+
 
 incident_links = db.Table(
     "incident_links",
-    mapped_column(
+    Column(
         "incident_id",
         Integer,
         ForeignKey("incidents.id", name="incident_links_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "link_id",
         Integer,
         ForeignKey("links.id", name="incident_links_link_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
 
 incident_license_plates = db.Table(
     "incident_license_plates",
-    mapped_column(
+    Column(
         "incident_id",
         Integer,
         ForeignKey("incidents.id", name="incident_license_plates_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "license_plate_id",
         Integer,
         ForeignKey(
@@ -566,26 +567,26 @@ incident_license_plates = db.Table(
         ),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
 
 incident_officers = db.Table(
     "incident_officers",
-    mapped_column(
+    Column(
         "incident_id",
         Integer,
         ForeignKey("incidents.id", name="incident_officers_incident_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "officers_id",
         Integer,
         ForeignKey("officers.id", name="incident_officers_officers_id_fkey"),
         primary_key=True,
     ),
-    mapped_column(
+    Column(
         "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
     ),
 )
@@ -671,13 +672,17 @@ class Incident(BaseModel, TrackUpdates):
     __tablename__ = "incidents"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    date: Mapped[date | None] = mapped_column(Date, index=True)
-    time: Mapped[time | None] = mapped_column(Time, index=True)
-    report_number: Mapped[str | None] = mapped_column(String(50), index=True)
-    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    date: Mapped[Optional[date]] = mapped_column(Date, index=True, nullable=True)
+    time: Mapped[Optional[time]] = mapped_column(Time, index=True, nullable=True)
+    report_number: Mapped[Optional[str]] = mapped_column(
+        String(50), index=True, nullable=True
+    )
+    description: Mapped[Optional[str]] = mapped_column(Text(), nullable=True)
 
-    address_id: Mapped[int | None] = mapped_column(
-        Integer, db.ForeignKey("locations.id", name="incidents_address_id_fkey")
+    address_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("locations.id", name="incidents_address_id_fkey"),
+        nullable=True,
     )
     address: Mapped["Location"] = relationship(
         "Location", backref=db.backref("incidents", cascade_backrefs=False)
@@ -708,8 +713,10 @@ class Incident(BaseModel, TrackUpdates):
         ),
     )
 
-    department_id: Mapped[int | None] = mapped_column(
-        Integer, db.ForeignKey("departments.id", name="incidents_department_id_fkey")
+    department_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("departments.id", name="incidents_department_id_fkey"),
+        nullable=True,
     )
     department: Mapped["Department"] = relationship(
         "Department", backref=db.backref("incidents", cascade_backrefs=False), lazy=True
@@ -818,7 +825,7 @@ class User(UserMixin, BaseModel):
         secret = current_app.config["SECRET_KEY"]
         header = {"alg": SIGNATURE_ALGORITHM}
 
-        now = int(time.time())
+        now = int(time_obj.time())
         payload["iat"] = now
         payload["exp"] = now + expiration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ s3transfer~=0.6.1
 selenium==4.26.0
 six~=1.16.0
 sphinx==7.1.2
-SQLAlchemy==2.0.36
+SQLAlchemy==1.4.52
 tornado~=6.4
 trio==0.22.1
 urllib3==1.26.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ s3transfer~=0.6.1
 selenium==4.26.0
 six~=1.16.0
 sphinx==7.1.2
-SQLAlchemy==1.4.52
+SQLAlchemy==2.0.36
 tornado~=6.4
 trio==0.22.1
 urllib3==1.26.20


### PR DESCRIPTION
## Description of Changes
Updating SQLAlchemy to version `2.x.y` so that we can make use of the `MappedAsDataclass` class and remove all of our custom `__repr__` functions so that we're more up to specifications with standard Python. 

## Documentation
SQLAlchemy: https://docs.sqlalchemy.org/en/20/orm/dataclasses.html
PR suggestion: https://github.com/lucyparsons/OpenOversight/pull/1140#pullrequestreview-2525077080

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
