### PR TITLE
Omit DB migrations folder from Coveralls report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
-[run]
+[report]
 omit =
     OpenOversight/migrations/versions/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    OpenOversight/migrations/versions/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
-[report]
-omit =
-    OpenOversight/migrations/versions/*
+[run]
+omit = OpenOversight/migrations/versions/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = OpenOversight/migrations/versions/*

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,5 +1,8 @@
 name: Test Coverage
 on:
+  pull_request:
+    branches:
+      - develop
   push:
     branches:
       - develop

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight/app --cov=OpenOversight/tests --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight/app --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight --cov-exclude=OpenOversight/migrations/versions/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight/app --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight  --cov-config=.coveragerc --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight --omit=OpenOversight/migrations/versions/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight --omit=OpenOversight/migrations/versions/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight/app --cov=OpenOversight/tests --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight/app --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight/app/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight/app/ --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight  --cov-config=.coveragerc --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight --cov-exclude=OpenOversight/migrations/versions/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight/app/* --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov=OpenOversight/app/ --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start


### PR DESCRIPTION
## Description of Changes
We currently consider the `migrations/versions` folder in the Coveralls report, but we don't to any meaningful testing on it so it tanks our numbers and is not representative or useful with regard to our testing strategy. To make our numbers more accurately reflective of our intentions, I omitted the `migrations/versions` from the coverage report.

**Documentation:** [link](https://coverage.readthedocs.io/en/latest/source.html#source)

## Screenshots (if appropriate)


## Tests and Linting
- [ ] This branch is up-to-date with the `develop` branch.
- [ ] Ran `make create_db_diagram` command.
- [ ] `pytest` passes on my local development environment.
- [ ] `pre-commit` passes on my local development environment.
