### PR TITLE
Remove audit fields from `Description` download

### DIFF
--- a/OpenOversight/app/main/downloads.py
+++ b/OpenOversight/app/main/downloads.py
@@ -160,8 +160,5 @@ def descriptions_record_maker(description: Description) -> _Record:
     return {
         "id": description.id,
         "text_contents": description.text_contents,
-        "created_by": description.created_by,
         "officer_id": description.officer_id,
-        "created_at": description.created_at,
-        "last_updated_at": description.last_updated_at,
     }

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1746,10 +1746,7 @@ def download_dept_descriptions_csv(department_id: int):
     field_names = [
         "id",
         "text_contents",
-        "created_by",
         "officer_id",
-        "created_at",
-        "last_updated_at",
     ]
 
     return make_downloadable_csv(


### PR DESCRIPTION
## Description of Changes
Removed audit fields from the `Description` download function. They leak user information and provide data that isn't particularly useful outside of internal auditing.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
