### PR TITLE
Revert "Delete `create_db.py` (#1000)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         description: Only executable files should have shebangs (e.g. '#!/usr/bin/env python')
         entry: "#!/"
         pass_filenames: true
-        exclude: bin|cli|manage.py|app.py|setup.py|docs|test_data.py
+        exclude: bin|cli|docs|test_data.py
         files: \.py$
 
   - repo: https://github.com/ikamensh/flynt/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         description: Only executable files should have shebangs (e.g. '#!/usr/bin/env python')
         entry: "#!/"
         pass_filenames: true
-        exclude: bin|cli|manage.py|app.py|setup.py|docs|create_db.py|test_data.py
+        exclude: bin|cli|manage.py|app.py|setup.py|docs|test_data.py
         files: \.py$
 
   - repo: https://github.com/ikamensh/flynt/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         description: Only executable files should have shebangs (e.g. '#!/usr/bin/env python')
         entry: "#!/"
         pass_filenames: true
-        exclude: bin|cli|manage.py|app.py|setup.py|docs|test_data.py
+        exclude: bin|cli|manage.py|app.py|setup.py|docs|create_db.py|test_data.py
         files: \.py$
 
   - repo: https://github.com/ikamensh/flynt/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ create_db: start
 	done
 	@echo "Postgres is up"
 	## Creating database
-	docker compose run --rm web flask db stamp head
+	docker compose run --rm web python ./create_db.py
 
 .PHONY: create_db_diagram
 create_db_diagram:

--- a/OpenOversight/migrations/alembic.ini
+++ b/OpenOversight/migrations/alembic.ini
@@ -2,7 +2,6 @@
 script_location = ./OpenOversight/migrations/
 file_template = %%(year)d-%%(month).2d-%%(day).2d-%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
 truncate_slug_length = 40
-prepend_sys_path = .
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/OpenOversight/migrations/env.py
+++ b/OpenOversight/migrations/env.py
@@ -1,22 +1,23 @@
 import logging
-import os
 from logging.config import fileConfig
 
 from alembic import context
 from flask import current_app
 from sqlalchemy import engine_from_config, pool
 
-from OpenOversight.app import create_app, db
-from OpenOversight.app.utils.constants import KEY_DATABASE_URI, KEY_ENV, KEY_ENV_DEV
 
-
-app = create_app(os.environ.get(KEY_ENV, KEY_ENV_DEV))
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
 fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
+
+
+config.set_main_option(
+    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+)
+target_metadata = current_app.extensions["migrate"].db.metadata
 
 
 def run_migrations_offline():
@@ -77,14 +78,7 @@ def run_migrations_online():
         connection.close()
 
 
-with app.app_context():
-    config.set_main_option("sqlalchemy.url", current_app.config.get(KEY_DATABASE_URI))
-    target_metadata = current_app.extensions["migrate"].db.metadata
-
-    db.app = app
-    db.create_all()
-
-    if context.is_offline_mode():
-        run_migrations_offline()
-    else:
-        run_migrations_online()
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/OpenOversight/migrations/env.py
+++ b/OpenOversight/migrations/env.py
@@ -5,6 +5,8 @@ from alembic import context
 from flask import current_app
 from sqlalchemy import engine_from_config, pool
 
+from OpenOversight.app.utils.constants import KEY_DATABASE_URI
+
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -14,9 +16,7 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
 
-config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
-)
+config.set_main_option("sqlalchemy.url", current_app.config.get(KEY_DATABASE_URI))
 target_metadata = current_app.extensions["migrate"].db.metadata
 
 

--- a/create_db.py
+++ b/create_db.py
@@ -1,9 +1,9 @@
-#!/usr/bin/python
 from OpenOversight.app import create_app
 from OpenOversight.app.models.database import db
+from OpenOversight.app.utils.constants import KEY_ENV_DEV
 
 
-app = create_app("development")
+app = create_app(KEY_ENV_DEV)
 with app.app_context():
     db.app = app
     db.create_all()

--- a/create_db.py
+++ b/create_db.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+from OpenOversight.app import create_app
+from OpenOversight.app.models.database import db
+
+
+app = create_app("development")
+with app.app_context():
+    db.app = app
+    db.create_all()

--- a/dockerfiles/web/Dockerfile-dev
+++ b/dockerfiles/web/Dockerfile-dev
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y xvfb libpq-dev python3-dev graphviz-dev
 COPY requirements.txt /usr/src/app/
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-COPY test_data.py /usr/src/app/
+COPY create_db.py test_data.py /usr/src/app/
 
 ENV SECRET_KEY 4Q6ZaQQdiqtmvZaxP1If
 ENV SQLALCHEMY_DATABASE_URI postgresql://openoversight:terriblepassword@postgres/openoversight-dev

--- a/dockerfiles/web/Dockerfile-prod
+++ b/dockerfiles/web/Dockerfile-prod
@@ -28,6 +28,9 @@ COPY requirements.txt /usr/src/app/
 # Install required python packages with pip.
 RUN pip3 install -r requirements.txt
 
+# Copy python script to initialize database.
+COPY create_db.py /usr/src/app/
+
 WORKDIR /usr/src/app/
 
 FROM base as production

--- a/dockerfiles/web/Dockerfile-test
+++ b/dockerfiles/web/Dockerfile-test
@@ -30,7 +30,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 install --no-cache-dir -r dev-requirements.txt
 
-COPY test_data.py /usr/src/app/
+COPY create_db.py test_data.py /usr/src/app/
 
 ENV PATH="/usr/src/app/geckodriver:${PATH}"
 ENV SECRET_KEY 4Q6ZaQQdiqtmvZaxP1If

--- a/test_data.py
+++ b/test_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import argparse
 
 from OpenOversight.app import create_app

--- a/test_data.py
+++ b/test_data.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import argparse
 
 from OpenOversight.app import create_app


### PR DESCRIPTION
## Fixes issue

#1000 unfortunately broke alembic's functionality to create migrations that include new tables (Using `flask db migrate`). The issue is that before alembic has a change to analyze the difference between existing database and schema from database.py the `db.create_all()` command automatically creates the tables making it so that they are not registered for the migration.

I could not come up with a way to reasonably work around this issue, so I think the best course of action is to revert the removal of the create_db.py file.


## Description of Changes

This reverts that breaking commit. It is not a clean revert of #1000, since that PR also included unrelated changes to tests and constants. Those changes were not reverted.


## Notes for Deployment

I have verified the changes in my local environment and the tests are passing, but I have not tested that the changes work as expected in a completely fresh environment (which would use the create_db file)

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [ ] (N/A) Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
