### PR TITLE
Fix submit image page and python sqlite bug

### DIFF
--- a/OpenOversight/app/models/config.py
+++ b/OpenOversight/app/models/config.py
@@ -105,6 +105,11 @@ class TestingConfig(BaseConfig):
         self.NUM_OFFICERS = 120
         self.RATELIMIT_ENABLED = False
         self.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+        # Disable sqlite cached statements
+        # https://github.com/python/cpython/issues/118172
+        self.SQLALCHEMY_ENGINE_OPTIONS = {
+            "connect_args": {"cached_statements": 0},
+        }
 
 
 class ProductionConfig(BaseConfig):


### PR DESCRIPTION
## Description of Changes

_Changes carried over from https://github.com/OrcaCollective/OpenOversight/pull/533_

Fix bug where submit image page department selector was not submitting images to the correct department.

It looks like the current implementation was using `selectedIndex` (the index of the selected `<option>` element in the `<select>`) to determine the initial department id, which assumes the departments are loaded in order:

https://github.com/OrcaCollective/OpenOversight/blob/2c5ad9a74687943eac5e71a874c0f4ceb4784fa0/OpenOversight/app/templates/submit_image.html#L79-L82

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Testing instructions
1. Log in as admin user.
2. Create a new department "Peoria Police Department (PPD)" at http://localhost:3000/departments/new.
3. Update the user's preferred department to PPD at http://localhost:3000/auth/change-dept/.
4. Visit the Submit Image page (http://localhost:3000/submit) and confirm that the populated department is BPD.
5. Upload an image.
6. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/4.
7. Update the department selector to Springfield Police Department.
8. Upload an image.
9. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/1.
10. Change the preferred department to Springfield Police Department at http://localhost:3000/auth/change-dept/.
11. Visit the Submit Image page (http://localhost:3000/submit) and confirm that the populated department is now SPD.
12. Upload an image.
13. Verify in devtools that an image was submitted to http://localhost:3000/upload/departments/1.

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
