### PR TITLE
Default to "N/A" if dept state is invalid

### DIFF
--- a/OpenOversight/app/filters.py
+++ b/OpenOversight/app/filters.py
@@ -101,6 +101,10 @@ def display_currency(value: float) -> str:
 def get_state_full_name(abbrev: str) -> str:
     if abbrev == "FA":
         return "Federal"
+
+    state = us.states.lookup(abbrev)
+    if state is None:
+        return "N/A"
     return us.states.lookup(abbrev).name
 
 

--- a/OpenOversight/tests/test_filters.py
+++ b/OpenOversight/tests/test_filters.py
@@ -126,6 +126,7 @@ def test_thousands_separator():
 
 
 def test_get_state_full_name():
+    assert "N/A" == filters.get_state_full_name("??")
     assert "Federal" == filters.get_state_full_name("FA")
     with patch("us.states.lookup") as mock_lookup:
         mock_lookup.return_value = us.states.OR


### PR DESCRIPTION
## Description of Changes
Default to "N/A" if department state is invalid

In [the migration](https://github.com/lucyparsons/OpenOversight/blob/develop/OpenOversight/migrations/versions/2023-07-26-1551_18f43ac4622f_add_state_column_to_departments.py) where we introduced the department state column, we defaulted to empty string for existing departments. We think this may have broken the browse page when trying to load the browse page.

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
Reproduced the internal server error by setting the department state to empty string
```
openoversight-dev=# update departments set state='' where id = 1;                                                                                                                       
```

Checked that the error was no longer displayed once this change was implemented

- [x] This branch is up-to-date with the `develop` branch.
- [ ] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
