### PR TITLE
Allow /find form to handle omitted age range.

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -122,8 +122,12 @@ class FindOfficerForm(Form):
         choices=GENDER_CHOICES,
         validators=[AnyOf(allowed_values(GENDER_CHOICES))],
     )
-    min_age = IntegerField("min_age", validators=[NumberRange(min=16, max=100)])
-    max_age = IntegerField("max_age", validators=[NumberRange(min=16, max=100)])
+    min_age = IntegerField(
+        "min_age", validators=[Optional(), NumberRange(min=16, max=100)]
+    )
+    max_age = IntegerField(
+        "max_age", validators=[Optional(), NumberRange(min=16, max=100)]
+    )
     require_photo = BooleanField(
         "require_photo", default=False, validators=[Optional()]
     )


### PR DESCRIPTION
## Fixes issue
An issue was introduced in #1155, where the default values for the age fields in the `FindOfficerForm` were removed. This leads to validation errors when submitting the form without setting an age.  
This can be verified here: https://staging.openoversight.com/find (pressing "Generate Officer Gallery" will show the validation error)

![find-form-age-bug](https://github.com/user-attachments/assets/142dda48-b5b7-429e-8f21-35e67d1a1b96)

 

## Description of Changes

Adding the `Optional()` validator will prevent this issue.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [ ] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
