### PR TITLE
Use playwright for functional tests

### DIFF
--- a/.github/workflows/test_prs.yml
+++ b/.github/workflows/test_prs.yml
@@ -17,6 +17,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run tests
         run: PYTHON_VERSION=${{ matrix.python-version }} make test_with_version
+      # Upload playwright traces if tests fail
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-traces
+          path: build/test-results/
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -23,6 +23,12 @@ We use [pre-commit](https://pre-commit.com/) for automated linting and style che
 
 You can run `pre-commit run --all-files` or `make lint` to run pre-commit over your local codebase, or `pre-commit run` to run it only over the currently stages files.
 
+## Testing
+
+To run tests, run `make test` once your containers are up and running.
+
+We use Playwright for functional testing. If functional tests fail locally, you can find per-test traces in the `build/test-results` directory. In the Lint and Test GitHub action, traces are uploaded as an artifact you can download via the "Upload Artifact" step. Once you have your trace, you can upload it to the [Playwright Trace Viewer](https://trace.playwright.dev/) tool for debugging.
+
 ### Accessibility
 Keep in mind when adding images that `alt` tags are required for screen readers. If text outside of the image explains what the image is or is referring to, the tag can be an empty string (`alt=""`). The tag can also be empty if the image is decoration and does not add information or context. If the image has text or important information, use the present tense to describe what is happening in the image.
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build_with_version: create_empty_secret create_default_env
 .PHONY: test_with_version
 test_with_version: build_with_version
 	touch OpenOversight/tests/coverage.xml
-	docker compose run --rm web-test pytest --cov=OpenOversight --cov-report xml:OpenOversight/tests/coverage.xml --doctest-modules -n 4 --dist=loadfile -v OpenOversight/tests/
+	docker compose run --rm web-test pytest --cov-report xml:OpenOversight/tests/coverage.xml -n 4 --dist=loadfile -v OpenOversight/tests/
 
 # Run containers
 .PHONY: start
@@ -70,9 +70,9 @@ populate: create_db
 .PHONY: test
 test: start
 	if [ -z "$(name)" ]; then \
-		docker compose run --rm web-test pytest --cov --doctest-modules -n auto --dist=loadfile -v OpenOversight/tests/; \
+		docker compose run --rm web-test pytest -n auto --dist=loadfile -v OpenOversight/tests/; \
 	else \
-		docker compose run --rm web-test pytest --cov --doctest-modules -v OpenOversight/tests/ -k $(name); \
+		docker compose run --rm web-test pytest -v OpenOversight/tests/ -k $(name); \
 	fi
 
 .PHONY: lint

--- a/OpenOversight/app/static/js/find_officer.js
+++ b/OpenOversight/app/static/js/find_officer.js
@@ -34,6 +34,7 @@ $(document).ready(function() {
             $('#current-uii').text(deptUiidLabel);
             $('#uii-question').show();
         } else {
+            $('#unique_internal_identifier').text('');
             $('#uii-question').hide();
         }
     });

--- a/OpenOversight/pytest.ini
+++ b/OpenOversight/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts =  --cov --doctest-modules --tracing=retain-on-failure --output=/test-results

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -8,7 +8,6 @@ import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
-from time import sleep
 from typing import List, Optional
 
 import pytest

--- a/OpenOversight/tests/conftest.py
+++ b/OpenOversight/tests/conftest.py
@@ -15,11 +15,8 @@ import pytest
 from faker import Faker
 from flask import current_app
 from PIL import Image as Pimage
-from selenium import webdriver
-from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.firefox.service import Service
+from playwright.sync_api import Page
 from sqlalchemy.orm import scoped_session, sessionmaker
-from xvfbwrapper import Xvfb
 
 from OpenOversight.app import create_app
 from OpenOversight.app.models.database import (
@@ -895,28 +892,15 @@ def server_port(worker_number):
 
 
 @pytest.fixture(scope="session")
-def browser(app, server_port):
+def server(app, server_port):
     # start server
     port = server_port
     print("Starting server at port {port}")
     threading.Thread(
         target=app.run, daemon=True, kwargs={"debug": False, "port": port}
     ).start()
-    # give the server a few seconds to ensure it is up
-    sleep(10)
 
-    # start headless webdriver
-    visual_display = Xvfb()
-    visual_display.start()
-    options = Options()
-    options.add_argument("--headless")
-    driver = webdriver.Firefox(
-        options=options, service=Service(log_path="/tmp/geckodriver.log")
-    )
-    # wait for browser to start up
-    sleep(3)
-    yield driver
 
-    # shutdown headless webdriver
-    driver.quit()
-    visual_display.stop()
+@pytest.fixture
+def page(app, server, page: Page):
+    yield page

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-import pytest
 from flask import current_app
 from playwright.sync_api import expect
 from sqlalchemy.sql.expression import func

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,17 +1,13 @@
 import os
-from contextlib import contextmanager
+import re
 
 import pytest
 from flask import current_app
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.select import Select
-from selenium.webdriver.support.ui import WebDriverWait
+from playwright.sync_api import expect
 from sqlalchemy.sql.expression import func
 
 from OpenOversight.app.models.database import Department, Incident, Officer, Unit
-from OpenOversight.app.utils.constants import FILE_TYPE_HTML, KEY_OFFICERS_PER_PAGE
+from OpenOversight.app.utils.constants import KEY_OFFICERS_PER_PAGE
 from OpenOversight.tests.conftest import AC_DEPT
 from OpenOversight.tests.constants import ADMIN_USER_EMAIL
 
@@ -19,195 +15,132 @@ from OpenOversight.tests.constants import ADMIN_USER_EMAIL
 DESCRIPTION_CUTOFF = 700
 
 
-@contextmanager
-def wait_for_page_load(browser, timeout=10):
-    old_page = browser.find_element(By.TAG_NAME, FILE_TYPE_HTML)
-    yield
-    WebDriverWait(browser, timeout).until(expected_conditions.staleness_of(old_page))
+def expect_banner_with_text(page, text):
+    banner = page.get_by_text(text)
+    expect(banner).to_be_visible()
+    # Close banner to make sure it doesn't obscure other elements
+    banner.locator(".btn-close").click()
 
 
-def login_admin(browser, server_port):
-    browser.get(f"http://localhost:{server_port}/auth/login")
-    with wait_for_page_load(browser):
-        elem = browser.find_element(By.ID, "email")
-        elem.clear()
-        elem.send_keys(ADMIN_USER_EMAIL)
-        elem = browser.find_element(By.ID, "password")
-        elem.clear()
-        elem.send_keys("testtest")
-        with wait_for_page_load(browser):
-            browser.find_element(By.ID, "submit").click()
-            wait_for_element(browser, By.TAG_NAME, "body")
+def login_admin(page, server_port):
+    page.goto(f"http://localhost:{server_port}/auth/login")
+    page.locator("#email").fill(ADMIN_USER_EMAIL)
+    page.locator("#password").fill("testtest")
+    page.locator("#submit").click()
+    page.wait_for_load_state()
 
 
-def logout(browser, server_port):
-    browser.get(f"http://localhost:{server_port}/auth/logout")
-    wait_for_page_load(browser)
+def logout(page, server_port):
+    page.goto(f"http://localhost:{server_port}/auth/logout")
+    expect_banner_with_text(page, "You have been logged out.")
 
 
-def submit_image_to_dropzone(browser, img_path):
-    # Submit files in selenium: https://stackoverflow.com/a/61566075
-    wait_for_element(browser, By.CLASS_NAME, "dz-hidden-input")
-    upload = browser.find_element(By.CLASS_NAME, "dz-hidden-input")
-    upload.send_keys(img_path)
-    wait_for_element(browser, By.CLASS_NAME, "dz-success")
+def submit_image_to_dropzone(page, img_path):
+    page.locator(".dz-hidden-input").set_input_files(img_path)
+    expect(page.locator(".dz-success")).to_be_visible()
 
 
-def wait_for_element(browser, locator, text, timeout=10):
-    try:
-        element_present = expected_conditions.presence_of_element_located(
-            (locator, text)
-        )
-        WebDriverWait(browser, timeout).until(element_present)
-    except TimeoutException:
-        pytest.fail("Timed out while waiting for element to appear")
-
-
-def wait_for_element_to_be_visible(browser, locator, text, timeout=10):
-    try:
-        element_visible = expected_conditions.visibility_of_element_located(
-            (locator, text)
-        )
-        WebDriverWait(browser, timeout).until(element_visible)
-    except TimeoutException:
-        pytest.fail("Timed out while waiting for element to become visible")
-
-
-def scroll_to_element(browser, element):
-    browser.execute_script(
-        "arguments[0].scrollIntoView({ behavior: 'instant', block: 'center' });",
-        element,
-    )
-    return element
-
-
-def test_user_can_load_homepage_and_get_to_form(mockdata, browser, server_port):
-    browser.get(f"http://localhost:{server_port}")
-    wait_for_element_to_be_visible(browser, By.ID, "cpd")
+def test_user_can_load_homepage_and_get_to_form(mockdata, page, server_port):
+    page.goto(f"http://localhost:{server_port}")
 
     # Complainant loads homepage
-    assert "OpenOversight" in browser.title
-    element = browser.find_element(By.ID, "cpd")
-    scroll_to_element(browser, element)
-    element.click()
+    expect(page).to_have_title(re.compile(r"OpenOversight.*"))
+    page.locator("#cpd").click()
 
-    page_text = browser.find_element(By.TAG_NAME, "body").text
-    assert "Find an Officer" in page_text
+    expect(page).to_have_title(re.compile(r"Find an officer.*"))
 
 
-def test_user_can_get_to_complaint(browser, server_port):
-    browser.get(
+def test_user_can_get_to_complaint(page, server_port):
+    page.goto(
         f"http://localhost:{server_port}/complaints?officer_star=6265&"
         "officer_first_name=IVANA&officer_last_name=SNOTBALL&officer_middle_initial="
         "&officer_image=static%2Fimages%2Ftest_cop2.png"
     )
 
-    wait_for_element(browser, By.TAG_NAME, "h1")
-    # Complaint arrives at page with the badge number, name, and link
+    # Complainant arrives at page with the badge number, name, and link
     # to complaint form
-
-    title_text = browser.find_element(By.TAG_NAME, "h1").text
-    assert "File a Complaint" in title_text
+    expect(page.get_by_text("File a Complaint")).to_be_visible()
 
 
-def test_officer_browse_pagination(mockdata, browser, server_port):
+def test_officer_browse_pagination(mockdata, page, server_port):
     total = Officer.query.filter_by(department_id=AC_DEPT).count()
 
     # first page of results
-    browser.get(
+    page.goto(
         f"http://localhost:{server_port}/departments/{AC_DEPT}?page=1&gender=Not+Sure"
     )
-    wait_for_element(browser, By.TAG_NAME, "body")
-    page_text = browser.find_element(By.TAG_NAME, "body").text
     expected = f"Showing 1-{current_app.config[KEY_OFFICERS_PER_PAGE]} of {total}"
-    assert expected in page_text
+    expect(page.get_by_text(expected).first).to_be_visible()
 
     # check that "Next" pagination link does not automatically add require_photo parameter
-    next_link = browser.find_elements(By.XPATH, '//li[@class="next"]/a')[
-        0
-    ].get_attribute("href")
+    next_link = page.locator('//li[@class="next"]/a').first.get_attribute("href")
     assert "gender" in next_link
     assert "require_photo" not in next_link
 
     # last page of results
     last_page_index = (total // current_app.config[KEY_OFFICERS_PER_PAGE]) + 1
-    browser.get(
+    page.goto(
         f"http://localhost:{server_port}/departments/{AC_DEPT}?page={last_page_index}&gender=Not+Sure"
     )
-    wait_for_element(browser, By.TAG_NAME, "body")
-    page_text = browser.find_element(By.TAG_NAME, "body").text
     start_of_page = (
         current_app.config[KEY_OFFICERS_PER_PAGE]
         * (total // current_app.config[KEY_OFFICERS_PER_PAGE])
         + 1
     )
     expected = f"Showing {start_of_page}-{total} of {total}"
-    assert expected in page_text
+    expect(page.get_by_text(expected).first).to_be_visible()
 
     # check that "Previous" pagination link does not automatically add require_photo parameter
-    previous_link = browser.find_elements(By.CSS_SELECTOR, "li.previous a")[
-        0
-    ].get_attribute("href")
+    previous_link = page.locator("li.previous a").first.get_attribute("href")
     assert "gender" in previous_link
     assert "require_photo" not in previous_link
 
 
 def test_find_officer_can_see_uii_question_for_depts_with_uiis(
-    mockdata, browser, server_port
+    mockdata, page, server_port
 ):
-    browser.get(f"http://localhost:{server_port}/find")
-    wait_for_element(browser, By.TAG_NAME, "body")
+    page.goto(f"http://localhost:{server_port}/find")
 
     dept_with_uii = Department.query.filter(
         Department.unique_internal_identifier_label.is_not(None)
     ).first()
 
-    dept_selector = Select(browser.find_element(By.ID, "dept"))
-    uii_element = browser.find_element(By.ID, "uii-question")
-
-    dept_selector.select_by_value(str(dept_with_uii.id))
-    assert uii_element.is_displayed()
+    page.locator("#dept").select_option(str(dept_with_uii.id))
+    expect(page.locator("#uii-question")).to_be_visible()
 
 
 def test_find_officer_cannot_see_uii_question_for_depts_without_uiis(
-    mockdata, browser, server_port
+    mockdata, page, server_port
 ):
-    browser.get(f"http://localhost:{server_port}/find")
-    wait_for_element(browser, By.TAG_NAME, "body")
+    page.goto(f"http://localhost:{server_port}/find")
 
     dept_without_uii = Department.query.filter_by(
         unique_internal_identifier_label=None
     ).first()
 
-    dept_selector = browser.find_element(By.ID, "dept")
-    scroll_to_element(browser, dept_selector)
-    Select(dept_selector).select_by_value(str(dept_without_uii.id))
-
-    uii_element = browser.find_element(By.ID, "uii-question")
-    assert not uii_element.is_displayed()
+    page.locator("#dept").select_option(str(dept_without_uii.id))
+    expect(page.locator("#uii-question")).to_be_hidden()
 
 
 def test_incident_detail_display_read_more_button_for_descriptions_over_cutoff(
-    mockdata, browser, server_port
+    mockdata, page, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
-    browser.get(f"http://localhost:{server_port}/officers/1")
+    page.goto(f"http://localhost:{server_port}/officers/1")
 
     incident_long_description = Incident.query.filter(
         func.length(Incident.description) > DESCRIPTION_CUTOFF
     ).one_or_none()
     incident_id = str(incident_long_description.id)
 
-    result = browser.find_element(By.ID, "description-overflow-row_" + incident_id)
-    scroll_to_element(browser, result)
-    assert result.is_displayed()
+    expect(page.locator("#description-overflow-row_" + incident_id)).to_be_visible()
 
 
 def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
-    mockdata, browser, server_port
+    mockdata, page, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
-    browser.get(f"http://localhost:{server_port}/officers/1")
+    page.goto(f"http://localhost:{server_port}/officers/1")
 
     incident_long_description = Incident.query.filter(
         func.length(Incident.description) > DESCRIPTION_CUTOFF
@@ -215,29 +148,25 @@ def test_incident_detail_truncate_description_for_descriptions_over_cutoff(
     incident_id = str(incident_long_description.id)
 
     # Check that the text is truncated and contains more than just the ellipsis
-    truncated_text = browser.find_element(
-        By.ID, "incident-description_" + incident_id
-    ).text
+    truncated_text = page.locator("#incident-description_" + incident_id).inner_text()
     assert "…" in truncated_text
     # Include buffer for jinja rendered spaces
     assert DESCRIPTION_CUTOFF + 20 > len(truncated_text) > 100
 
 
 def test_incident_detail_do_not_display_read_more_button_for_descriptions_under_cutoff(
-    mockdata, browser, server_port
+    mockdata, page, server_port
 ):
     # Navigate to profile page for officer with short and long incident descriptions
-    browser.get(f"http://localhost:{server_port}/officers/1")
+    page.goto(f"http://localhost:{server_port}/officers/1")
 
     # Select incident for officer that has description under cutoff chars
-    result = browser.find_element(By.ID, "description-overflow-row_1")
-    scroll_to_element(browser, result)
-    assert not result.is_displayed()
+    expect(page.locator("#description-overflow-row_1")).to_be_hidden()
 
 
-def test_click_to_read_more_displays_full_description(mockdata, browser, server_port):
+def test_click_to_read_more_displays_full_description(mockdata, page, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
-    browser.get(f"http://localhost:{server_port}/officers/1")
+    page.goto(f"http://localhost:{server_port}/officers/1")
 
     incident_long_description = Incident.query.filter(
         func.length(Incident.description) > DESCRIPTION_CUTOFF
@@ -245,36 +174,31 @@ def test_click_to_read_more_displays_full_description(mockdata, browser, server_
     original_description = incident_long_description.description.strip()
     incident_id = str(incident_long_description.id)
 
-    button = browser.find_element(By.ID, "description-overflow-button_" + incident_id)
-    scroll_to_element(browser, button)
-    button.click()
+    page.locator("#description-overflow-button_" + incident_id).click()
 
-    description_text = browser.find_element(
-        By.ID, "incident-description_" + incident_id
-    ).text.strip()
+    description_text = (
+        page.locator("#incident-description_" + incident_id).inner_text().strip()
+    )
     assert len(description_text) == len(original_description)
     assert description_text == original_description
 
 
-def test_click_to_read_more_hides_the_read_more_button(mockdata, browser, server_port):
+def test_click_to_read_more_hides_the_read_more_button(mockdata, page, server_port):
     # Navigate to profile page for officer with short and long incident descriptions
-    browser.get(f"http://localhost:{server_port}/officers/1")
+    page.goto(f"http://localhost:{server_port}/officers/1")
 
     incident_long_description = Incident.query.filter(
         func.length(Incident.description) > DESCRIPTION_CUTOFF
     ).one_or_none()
     incident_id = str(incident_long_description.id)
 
-    button = browser.find_element(By.ID, "description-overflow-button_" + incident_id)
-    scroll_to_element(browser, button)
-    button.click()
+    page.locator("#description-overflow-button_" + incident_id).click()
 
-    buttonRow = browser.find_element(By.ID, "description-overflow-row_" + incident_id)
-    assert not buttonRow.is_displayed()
+    expect(page.locator("#description-overflow-row_" + incident_id)).to_be_hidden()
 
 
-def test_officer_form_has_units_alpha_sorted(browser, server_port, session):
-    login_admin(browser, server_port)
+def test_officer_form_has_units_alpha_sorted(page, server_port, session):
+    login_admin(page, server_port)
 
     # get the units from the DB in the sort we expect
     db_units_sorted = [
@@ -285,20 +209,22 @@ def test_officer_form_has_units_alpha_sorted(browser, server_port, session):
     db_units_sorted.insert(0, "None")
 
     # Check for the Unit sort on the 'add officer' form
-    browser.get(f"http://localhost:{server_port}/officers/new")
-    unit_select = Select(browser.find_element(By.ID, "unit"))
-    select_units_sorted = [x.text for x in unit_select.options]
+    page.goto(f"http://localhost:{server_port}/officers/new")
+    select_units_sorted = page.locator("#unit").evaluate(
+        "select => Array.from(select).map(option => option.label)"
+    )
     assert db_units_sorted == select_units_sorted
 
     # Check for the Unit sort on the 'add assignment' form
-    browser.get(f"http://localhost:{server_port}/officers/1")
-    unit_select = Select(browser.find_element(By.ID, "unit"))
-    select_units_sorted = [x.text for x in unit_select.options]
+    page.goto(f"http://localhost:{server_port}/officers/1")
+    select_units_sorted = page.locator("#unit").evaluate(
+        "select => Array.from(select).map(option => option.label)"
+    )
     assert db_units_sorted == select_units_sorted
 
 
 def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
-    browser, server_port, session
+    page, server_port, session
 ):
     # Set NULL race and gender for officer 1
     session.execute(
@@ -306,179 +232,131 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
     )
     session.commit()
 
-    login_admin(browser, server_port)
+    login_admin(page, server_port)
 
     # Navigate to edit officer page for officer having NULL race and gender
-    browser.get(f"http://localhost:{server_port}/officers/1/edit")
+    page.goto(f"http://localhost:{server_port}/officers/1/edit")
 
-    wait_for_element(browser, By.ID, "gender")
-    select = Select(browser.find_element(By.ID, "gender"))
-    selected_option = select.first_selected_option
-    selected_text = selected_option.text
+    select = page.locator("#gender")
+    selected_text = select.evaluate("select => select.selectedOptions[0].label")
     assert selected_text == "Not Sure"
 
-    wait_for_element(browser, By.ID, "race")
-    select = Select(browser.find_element(By.ID, "race"))
-    selected_option = select.first_selected_option
-    selected_text = selected_option.text
+    select = page.locator("#race")
+    selected_text = select.evaluate("select => select.selectedOptions[0].label")
     assert selected_text == "Not Sure"
 
 
-def test_image_classification_and_tagging(browser, server_port, session):
+def test_image_classification_and_tagging(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
     star_no = 1312
 
-    login_admin(browser, server_port)
+    login_admin(page, server_port)
 
     # 1. Create new department (to avoid mockdata)
-    browser.get(f"http://localhost:{server_port}/departments/new")
-    wait_for_page_load(browser)
-    browser.find_element(By.ID, "name").send_keys("Auburn Police Department")
-    browser.find_element(By.ID, "short_name").send_keys("APD")
-    Select(browser.find_element(By.ID, "state")).select_by_value("WA")
-
-    submit = browser.find_element(By.ID, "submit")
-    scroll_to_element(browser, submit)
-    submit.click()
-
-    wait_for_page_load(browser)
+    page.goto(f"http://localhost:{server_port}/departments/new")
+    page.locator("#name").fill("Auburn Police Department")
+    page.locator("#short_name").fill("APD")
+    page.locator("#state").select_option("WA")
+    page.locator("#submit").click()
 
     # 2. Add a new officer
-    browser.get(f"http://localhost:{server_port}/officers/new")
-    wait_for_page_load(browser)
+    page.goto(f"http://localhost:{server_port}/officers/new")
 
-    dept_select = Select(browser.find_element(By.ID, "department"))
-    dept_select.select_by_visible_text("Auburn Police Department")
-    dept_id = dept_select.first_selected_option.get_attribute("value")
+    dept_select = page.locator("#department")
+    dept_select.select_option(label="Auburn Police Department")
+    dept_id = dept_select.evaluate("select => select.selectedOptions[0].value")
 
-    browser.find_element(By.ID, "first_name").send_keys("Officer")
-    browser.find_element(By.ID, "last_name").send_keys("Friendly")
-    browser.find_element(By.ID, "star_no").send_keys(star_no)
+    page.locator("#first_name").fill("Officer")
+    page.locator("#last_name").fill("Friendly")
+    page.locator("#star_no").fill(str(star_no))
+    page.locator("#submit").click()
 
-    wait_for_element(browser, By.ID, "submit")
-    submit = browser.find_element(By.ID, "submit")
-    scroll_to_element(browser, submit)
-    submit.click()
-
-    wait_for_page_load(browser)
     # expected url: http://localhost:{server_port}/submit_officer_images/officer/<id>
-    officer_id = browser.current_url.split("/")[-1]
+    officer_id = page.url.split("/")[-1]
 
     # 3. Submit an image
-    browser.get(f"http://localhost:{server_port}/submit")
-    wait_for_page_load(browser)
-
-    select = browser.find_element(By.ID, "department")
-    scroll_to_element(browser, select)
-    Select(select).select_by_value(dept_id)
-    submit_image_to_dropzone(browser, img_path)
+    page.goto(f"http://localhost:{server_port}/submit")
+    page.locator("#department").select_option(dept_id)
+    submit_image_to_dropzone(page, img_path)
 
     # 4. Classify the uploaded image
-    browser.get(f"http://localhost:{server_port}/sort/departments/{dept_id}")
+    page.goto(f"http://localhost:{server_port}/sort/departments/{dept_id}")
 
     # Check that image loaded correctly: https://stackoverflow.com/a/36296478
-    wait_for_element(browser, By.TAG_NAME, "img")
-    image = browser.find_element(By.TAG_NAME, "img")
-    assert image.get_attribute("complete") == "true"
-    assert int(image.get_attribute("naturalHeight")) > 0
+    image = page.locator("img.img-responsive")
+    assert image.evaluate("image => image.complete") is True
+    assert image.evaluate("image => image.naturalHeight") > 0
 
-    browser.find_element(By.ID, "answer-yes").click()
-
-    wait_for_page_load(browser)
-    page_text = browser.find_element(By.TAG_NAME, "body").text
-    assert "All images have been classified!" in page_text
+    page.locator("#answer-yes").click()
+    expect_banner_with_text(page, "Updated image classification")
+    expect(page.get_by_text("All images have been classified!")).to_be_visible()
 
     # 5. Identify the new officer in the uploaded image
-    browser.get(f"http://localhost:{server_port}/cop_faces/departments/{dept_id}")
-    wait_for_page_load(browser)
-    browser.find_element(By.ID, "officer_id").send_keys(officer_id)
-    add_face = browser.find_element(
-        By.CSS_SELECTOR, "input[value='Add identified face']"
-    )
-    scroll_to_element(browser, add_face)
-    add_face.click()
+    page.goto(f"http://localhost:{server_port}/cop_faces/departments/{dept_id}")
+    page.locator("#officer_id").fill(str(officer_id))
+    page.locator("input[value='Add identified face']").click()
 
-    wait_for_page_load(browser)
-    page_text = browser.find_element(By.TAG_NAME, "body").text
-    assert "Tag added to database" in page_text
+    expect_banner_with_text(page, "Tag added to database")
 
     # 6. Log out as admin
-    logout(browser, server_port)
+    logout(page, server_port)
 
     # 7. Check that the tag appears on the officer page
-    browser.get(f"http://localhost:{server_port}/officers/{officer_id}")
-    wait_for_page_load(browser)
-    browser.find_element(By.CSS_SELECTOR, "a > img.officer-face").click()
-
-    wait_for_page_load(browser)
-    image = browser.find_element(By.TAG_NAME, "img")
-    frame = browser.find_element(By.ID, "face-tag-frame")
+    page.goto(f"http://localhost:{server_port}/officers/{officer_id}")
+    page.locator("a > img.officer-face").click()
 
     # 8. Check that the tag frame is fully contained within the image
-    wait_for_element_to_be_visible(browser, By.ID, "face-tag-frame")
-    assert image.location["x"] <= frame.location["x"]
-    assert image.location["y"] <= frame.location["y"]
-    assert (
-        image.location["x"] + image.size["width"]
-        >= frame.location["x"] + frame.size["width"]
-    )
-    assert (
-        image.location["y"] + image.size["height"]
-        >= frame.location["y"] + frame.size["height"]
-    )
-    assert image.location["y"] <= frame.location["y"]
+    page.locator("#face-tag-frame").wait_for(state="visible")
+
+    image_box = page.locator("#face-img").bounding_box()
+    frame_box = page.locator("#face-tag-frame").bounding_box()
+    assert image_box["x"] <= frame_box["x"]
+    assert image_box["y"] <= frame_box["y"]
+    assert image_box["x"] + image_box["width"] >= frame_box["x"] + frame_box["width"]
+    assert image_box["y"] + image_box["height"] >= frame_box["y"] + frame_box["height"]
+    assert image_box["y"] <= frame_box["y"]
 
 
-def test_anonymous_user_can_upload_image(browser, server_port, session):
+def test_anonymous_user_can_upload_image(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
 
-    login_admin(browser, server_port)
+    login_admin(page, server_port)
 
     # 1. Create new department as admin (to avoid mockdata)
-    browser.get(f"http://localhost:{server_port}/departments/new")
-    wait_for_page_load(browser)
-    browser.find_element(By.ID, "name").send_keys("Auburn Police Department")
-    browser.find_element(By.ID, "short_name").send_keys("APD")
-    Select(browser.find_element(By.ID, "state")).select_by_value("WA")
-
-    submit = browser.find_element(By.ID, "submit")
-    scroll_to_element(browser, submit)
-    submit.click()
-
-    wait_for_page_load(browser)
+    page.goto(f"http://localhost:{server_port}/departments/new")
+    page.locator("#name").fill("Auburn Police Department")
+    page.locator("#short_name").fill("APD")
+    page.locator("#state").select_option("WA")
+    page.locator("#submit").click()
 
     # 2. Log out
-    logout(browser, server_port)
+    logout(page, server_port)
 
     # 3. Upload image
-    browser.get(f"http://localhost:{server_port}/submit")
-    wait_for_page_load(browser)
+    page.goto(f"http://localhost:{server_port}/submit")
 
-    select = browser.find_element(By.ID, "department")
-    dept_select = Select(select)
-    scroll_to_element(browser, select)
-    dept_select.select_by_visible_text("Auburn Police Department")
-    dept_id = dept_select.first_selected_option.get_attribute("value")
+    dept_select = page.locator("#department")
+    dept_select.select_option(label="Auburn Police Department")
+    dept_id = dept_select.evaluate("select => select.selectedOptions[0].value")
 
-    submit_image_to_dropzone(browser, img_path)
+    submit_image_to_dropzone(page, img_path)
 
     # 4. Login as admin again
-    login_admin(browser, server_port)
+    login_admin(page, server_port)
 
     # 5. Check that there is 1 image to classify
-    browser.get(f"http://localhost:{server_port}/sort/departments/{dept_id}")
-    wait_for_page_load(browser)
+    page.goto(f"http://localhost:{server_port}/sort/departments/{dept_id}")
 
-    page_text = browser.find_element(By.TAG_NAME, "body").text
-    assert (
-        "Do you see uniformed law enforcement officers in the photo below?" in page_text
-    )
+    expect(
+        page.get_by_text(
+            "Do you see uniformed law enforcement officers in the photo below?"
+        )
+    ).to_be_visible()
 
-    browser.find_element(By.ID, "answer-yes").click()
-    wait_for_page_load(browser)
+    page.locator("#answer-yes").click()
 
     # 6. All images tagged!
-    page_text = browser.find_element(By.TAG_NAME, "body").text
-    assert "All images have been classified!" in page_text
+    expect_banner_with_text(page, "Updated image classification")
+    expect(page.get_by_text("All images have been classified!")).to_be_visible()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,3 +107,4 @@ services:
      TIMEZONE: "America/Chicago"
    volumes:
      - ./OpenOversight/:/usr/src/app/OpenOversight/:z
+     - ./build/test-results:/test-results

--- a/dockerfiles/web/Dockerfile-test
+++ b/dockerfiles/web/Dockerfile-test
@@ -6,22 +6,11 @@ WORKDIR /usr/src/app
 ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf -L --max-redirs 1 -O"
 
 ENV DEBIAN-FRONTEND noninteractive
-ENV DISPLAY=:1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # install apt dependencies
-RUN apt-get update && apt-get install -y curl xvfb firefox-esr libpq-dev python3-dev && \
+RUN apt-get update && apt-get install -y curl libpq-dev python3-dev && \
     apt-get install -y libsqlite3-0 graphviz-dev graphviz && apt-get clean
-
-# install geckodriver
-ENV GECKODRIVER_VERSION="v0.35.0"
-ENV GECKODRIVER_SHA=ac26e9ba8f3b8ce0fbf7339b9c9020192f6dcfcbf04a2bcd2af80dfe6bb24260
-ENV GECKODRIVER_BASE_URL="https://github.com/mozilla/geckodriver/releases/download"
-RUN curl ${CURL_FLAGS} \
-      ${GECKODRIVER_BASE_URL}/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
-RUN echo "${GECKODRIVER_SHA}  geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz" | sha256sum --check -
-RUN mkdir geckodriver
-RUN tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
 
 COPY requirements.txt dev-requirements.txt /usr/src/app/
 # install rust and cargo so we can use jellyfish
@@ -30,9 +19,10 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     pip3 install --no-cache-dir -r requirements.txt && \
     pip3 install --no-cache-dir -r dev-requirements.txt
 
+RUN playwright install --with-deps chromium
+
 COPY create_db.py test_data.py /usr/src/app/
 
-ENV PATH="/usr/src/app/geckodriver:${PATH}"
 ENV SECRET_KEY 4Q6ZaQQdiqtmvZaxP1If
 
 WORKDIR /usr/src/app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,13 +50,13 @@ psycopg2==2.9.6
 pycparser~=2.21
 Pygments~=2.15.1
 pytest~=7.4.0
+pytest-playwright==0.7.0
 python-dateutil==2.8.2
 PyYAML~=6.0
 recommonmark==0.7.1
 requests==2.32.0
 rich~=13.4.2
 s3transfer~=0.6.1
-selenium==4.26.0
 six~=1.16.0
 sphinx==7.1.2
 SQLAlchemy==1.4.52
@@ -70,5 +70,4 @@ Werkzeug==3.0.6
 wrapt~=1.15.0
 wtforms==3.0.1
 WTForms-SQLAlchemy==0.3.0
-xvfbwrapper~=0.2.9
 zipp==3.19.1


### PR DESCRIPTION
## Description of Changes
_Cherry-picked from https://github.com/OrcaCollective/OpenOversight/pull/537__

Switch to Playwright for functional tests. The Playwright API seems easier to use in many ways than Selenium

## Notes for Deployment
None! This only applies to tests

## Screenshots (if appropriate)
N/A

## Testing instructions
Run `just test`

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
