### PR TITLE
Overhaul the `/departments/<department_id>` view

### DIFF
--- a/OpenOversight/app/main/forms.py
+++ b/OpenOversight/app/main/forms.py
@@ -12,6 +12,7 @@ from wtforms import (
     HiddenField,
     IntegerField,
     SelectField,
+    SelectMultipleField,
     StringField,
     SubmitField,
     TextAreaField,
@@ -27,7 +28,7 @@ from wtforms.validators import (
     Regexp,
     ValidationError,
 )
-from wtforms_sqlalchemy.fields import QuerySelectField
+from wtforms_sqlalchemy.fields import QuerySelectField, QuerySelectMultipleField
 
 from OpenOversight.app.formfields import TimeField
 from OpenOversight.app.models.database import Officer, db
@@ -41,6 +42,11 @@ from OpenOversight.app.utils.choices import (
     SUFFIX_CHOICES,
 )
 from OpenOversight.app.utils.db import dept_choices, unit_choices
+from OpenOversight.app.utils.general import (
+    multi_selection_valid_or_default,
+    parse_int_or_default,
+    single_selection_valid_or_default,
+)
 from OpenOversight.app.widgets import BootstrapListWidget, FormFieldWidget
 
 
@@ -561,49 +567,59 @@ class IncidentForm(DateFieldForm):
 class BrowseForm(Form):
     # Any fields added to this form should generally also be added to FindOfficerForm
     # query set in view function
-    rank = QuerySelectField(
+    rank = QuerySelectMultipleField(
         "rank",
         validators=[Optional()],
         get_label="job_title",
         get_pk=lambda job: job.job_title,
+        default=[],
     )
     # query set in view function
-    unit = QuerySelectField(
+    unit = QuerySelectMultipleField(
         "unit",
         validators=[Optional()],
         get_label="description",
         get_pk=lambda unit: unit.description,
+        default=[],
     )
-    current_job = BooleanField("current_job", default=None, validators=[Optional()])
-    name = StringField("Last name")
+    current_job = BooleanField(
+        "current_job", default=False, false_values=(False, "False", "false", "")
+    )
+    first_name = StringField("First name")
+    last_name = StringField("Last name")
     badge = StringField("Badge number")
     unique_internal_identifier = StringField("Unique ID")
-    race = SelectField(
+    race = SelectMultipleField(
         "race",
         default="Not Sure",
         choices=RACE_CHOICES,
-        validators=[AnyOf(allowed_values(RACE_CHOICES))],
+        filters=[multi_selection_valid_or_default(allowed_values(RACE_CHOICES), [])],
     )
-    gender = SelectField(
+    gender = SelectMultipleField(
         "gender",
         default="Not Sure",
         choices=GENDER_CHOICES,
-        validators=[AnyOf(allowed_values(GENDER_CHOICES))],
+        filters=[multi_selection_valid_or_default(allowed_values(GENDER_CHOICES), [])],
     )
     min_age = SelectField(
         "minimum age",
-        default=16,
+        default=None,
         choices=AGE_CHOICES,
-        validators=[AnyOf(allowed_values(AGE_CHOICES))],
+        filters=[single_selection_valid_or_default(allowed_values(AGE_CHOICES), None)],
     )
     max_age = SelectField(
         "maximum age",
-        default=100,
+        default=None,
         choices=AGE_CHOICES,
-        validators=[AnyOf(allowed_values(AGE_CHOICES))],
+        filters=[single_selection_valid_or_default(allowed_values(AGE_CHOICES), None)],
     )
     require_photo = BooleanField(
-        "require_photo", default=False, validators=[Optional()]
+        "require_photo",
+        default=False,
+        false_values=(False, "False", "false", ""),
+    )
+    page = HiddenField(
+        "page", default=1, filters=[lambda val: max(parse_int_or_default(val), 1)]
     )
     submit = SubmitField(label="Submit")
 

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -918,16 +918,19 @@ def list_officer(
         error_out=False,
     )
 
-    img_id_to_officer = {}
+    img_id_to_officers: dict[int, list[Officer]] = {}
     for officer in officers.items:
         if officer.face:
             face_image_id = sorted(
                 officer.face, key=lambda x: x.featured, reverse=True
             )[0].img_id
-            img_id_to_officer[face_image_id] = officer
-    images = Image.query.filter(Image.id.in_(img_id_to_officer.keys())).all()
+            if face_image_id not in img_id_to_officers:
+                img_id_to_officers[face_image_id] = []
+            img_id_to_officers[face_image_id].append(officer)
+    images = Image.query.filter(Image.id.in_(img_id_to_officers.keys())).all()
     for image in images:
-        img_id_to_officer[image.id].image = serve_image(image.filepath)
+        for officer in img_id_to_officers[image.id]:
+            officer.image = serve_image(image.filepath)
 
     next_url = url_for_target_null_values_skipped(
         "main.list_officer",

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from http import HTTPMethod, HTTPStatus
 from traceback import format_exc
 from typing import Optional
+from urllib.parse import urlencode
 
 from flask import (
     Blueprint,
@@ -72,7 +73,6 @@ from OpenOversight.app.models.database import (
     db,
 )
 from OpenOversight.app.utils.auth import ac_or_admin_required, admin_required
-from OpenOversight.app.utils.choices import AGE_CHOICES, GENDER_CHOICES, RACE_CHOICES
 from OpenOversight.app.utils.cloud import crop_image, save_image_to_s3_and_db
 from OpenOversight.app.utils.constants import (
     ENCODING_UTF_8,
@@ -113,6 +113,7 @@ from OpenOversight.app.utils.general import (
     get_random_image,
     replace_list,
     serve_image,
+    url_for_target_null_values_skipped,
     validate_redirect_url,
 )
 
@@ -866,39 +867,12 @@ def edit_department(department_id: int):
 @main.route("/department/<int:department_id>")
 def redirect_list_officer(
     department_id: int,
-    page: int = 1,
-    race=None,
-    gender=None,
-    rank=None,
-    min_age=None,
-    max_age=None,
-    last_name=None,
-    first_name=None,
-    badge=None,
-    unique_internal_identifier=None,
-    unit=None,
-    current_job=None,
-    require_photo: Optional[bool] = None,
 ):
     flash(FLASH_MSG_PERMANENT_REDIRECT)
     return redirect(
-        url_for(
-            "main.list_officer",
-            department_id=department_id,
-            page=page,
-            race=race,
-            gender=gender,
-            rank=rank,
-            min_age=min_age,
-            max_age=max_age,
-            last_name=last_name,
-            first_name=first_name,
-            badge=badge,
-            unique_internal_identifier=unique_internal_identifier,
-            unit=unit,
-            current_job=current_job,
-            require_photo=require_photo,
-        ),
+        url_for("main.list_officer", department_id=department_id)
+        + "?"
+        + urlencode(request.args.to_dict(flat=False), doseq=True),
         code=HTTPStatus.PERMANENT_REDIRECT,
     )
 
@@ -906,19 +880,6 @@ def redirect_list_officer(
 @main.route("/departments/<int:department_id>")
 def list_officer(
     department_id: int,
-    page: int = 1,
-    race=None,
-    gender=None,
-    rank=None,
-    min_age=None,
-    max_age=None,
-    last_name=None,
-    first_name=None,
-    badge=None,
-    unique_internal_identifier=None,
-    unit=None,
-    current_job=None,
-    require_photo: Optional[bool] = None,
 ):
     try:
         department = Department.query.filter_by(id=department_id).one()
@@ -926,83 +887,20 @@ def list_officer(
         abort(HTTPStatus.NOT_FOUND)
 
     form = BrowseForm()
-    form.rank.query = (
+    form.rank.query = list(
         Job.query.filter_by(department_id=department_id, is_sworn_officer=True)
         .order_by(Job.order.asc())
         .all()
     )
-    form_data = form.data
-    form_data["race"] = race or []
-    form_data["gender"] = gender or []
-    form_data["rank"] = rank or []
-    form_data["min_age"] = min_age
-    form_data["max_age"] = max_age
-    form_data["last_name"] = last_name
-    form_data["first_name"] = first_name
-    form_data["badge"] = badge
-    form_data["unit"] = unit or []
-    form_data["current_job"] = current_job
-    form_data["unique_internal_identifier"] = unique_internal_identifier
-    form_data["require_photo"] = require_photo
-
-    age_range = {ac[0] for ac in AGE_CHOICES}
-
-    # Set form data based on URL
-    if (min_age_arg := request.args.get("min_age")) and min_age_arg in age_range:
-        form_data["min_age"] = min_age_arg
-    if (max_age_arg := request.args.get("max_age")) and max_age_arg in age_range:
-        form_data["max_age"] = max_age_arg
-    if page_arg := request.args.get("page"):
-        page = int(page_arg)
-    if last_name_arg := request.args.get("last_name"):
-        form_data["last_name"] = last_name_arg
-    if first_name_arg := request.args.get("first_name"):
-        form_data["first_name"] = first_name_arg
-    if badge_arg := request.args.get("badge"):
-        form_data["badge"] = badge_arg
-    if uid := request.args.get("unique_internal_identifier"):
-        form_data["unique_internal_identifier"] = uid
-    if (races := request.args.getlist("race")) and all(
-        race in [rc[0] for rc in RACE_CHOICES] for race in races
-    ):
-        form_data["race"] = races
-    if (genders := request.args.getlist("gender")) and all(
-        # Every time you complain we add a new gender
-        gender in [gc[0] for gc in GENDER_CHOICES]
-        for gender in genders
-    ):
-        form_data["gender"] = genders
-    if require_photo_arg := request.args.get("require_photo"):
-        form_data["require_photo"] = require_photo_arg
-
-    unit_selections = ["Not Sure"] + [
-        uc[0]
-        for uc in db.session.query(Unit.description)
-        .filter_by(department_id=department_id)
+    form.unit.query = list(
+        Unit.query.filter_by(department_id=department_id)
         .order_by(Unit.description.asc())
         .all()
-    ]
-    rank_selections = [
-        jc[0]
-        for jc in db.session.query(Job.job_title, Job.order)
-        .filter_by(department_id=department_id)
-        .order_by(Job.job_title)
-        .all()
-    ]
-    if (units := request.args.getlist("unit")) and all(
-        unit in unit_selections for unit in units
-    ):
-        form_data["unit"] = units
-    if (ranks := request.args.getlist("rank")) and all(
-        rank in rank_selections for rank in ranks
-    ):
-        form_data["rank"] = ranks
-    if current_job_arg := request.args.get("current_job"):
-        form_data["current_job"] = current_job_arg
+    ) + [Unit(id=None, description="Not Sure")]
+    form.process(request.args)
+    form_data = form.data
 
-    officers = filter_by_form(form_data, Officer.query, department_id).filter(
-        Officer.department_id == department_id
-    )
+    officers = filter_by_form(form_data, Officer.query, department_id)
 
     # Filter officers by presence of a photo
     if form_data["require_photo"]:
@@ -1010,29 +908,28 @@ def list_officer(
     else:
         officers = officers.options(selectinload(Officer.face))
 
+    officers = officers.options(selectinload(Officer.incidents))
+
     officers = officers.order_by(Officer.last_name, Officer.first_name, Officer.id)
 
     officers = officers.paginate(
-        page=page, per_page=current_app.config[KEY_OFFICERS_PER_PAGE], error_out=False
+        page=form_data["page"],
+        per_page=current_app.config[KEY_OFFICERS_PER_PAGE],
+        error_out=False,
     )
 
+    img_id_to_officer = {}
     for officer in officers.items:
-        officer_face = sorted(officer.face, key=lambda x: x.featured, reverse=True)
+        if officer.face:
+            face_image_id = sorted(
+                officer.face, key=lambda x: x.featured, reverse=True
+            )[0].img_id
+            img_id_to_officer[face_image_id] = officer
+    images = Image.query.filter(Image.id.in_(img_id_to_officer.keys())).all()
+    for image in images:
+        img_id_to_officer[image.id].image = serve_image(image.filepath)
 
-        # Could do some extra work to not lazy load images but load them all together.
-        # To do that properly we would want to ensure to only load the first picture of
-        # each officer.
-        if officer_face and officer_face[0].image:
-            officer.image = officer_face[0].image.filepath
-
-    choices = {
-        "race": RACE_CHOICES,
-        "gender": GENDER_CHOICES,
-        "rank": [(rc, rc) for rc in rank_selections],
-        "unit": [(uc, uc) for uc in unit_selections],
-    }
-
-    next_url = url_for(
+    next_url = url_for_target_null_values_skipped(
         "main.list_officer",
         department_id=department.id,
         page=officers.next_num,
@@ -1049,7 +946,7 @@ def list_officer(
         current_job=form_data["current_job"],
         require_photo=form_data["require_photo"],
     )
-    prev_url = url_for(
+    prev_url = url_for_target_null_values_skipped(
         "main.list_officer",
         department_id=department.id,
         page=officers.prev_num,
@@ -1073,7 +970,6 @@ def list_officer(
         department=department,
         officers=officers,
         form_data=form_data,
-        choices=choices,
         next_url=next_url,
         prev_url=prev_url,
         jsloads=["js/select2.min.js", "js/list_officer.js"],

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -91,7 +91,8 @@
                                 name="rank"
                                 class="select2-multi-search"
                                 multiple="multiple">
-                          {% for rank_key, rank, selected in form.rank.iter_choices() %}
+                          {% for choice in form.rank.iter_choices() %}
+                            {% set rank_key, rank, selected = choice[:3] %}
                             <option value="{{ rank_key }}"
                                     {% if selected %}selected="selected"{% endif %}>{{ rank }}</option>
                           {% endfor %}
@@ -106,7 +107,8 @@
                                 name="unit"
                                 class="select2-multi-search"
                                 multiple="multiple">
-                          {% for unit_key, unit, selected in form.unit.iter_choices() %}
+                          {% for choice in form.unit.iter_choices() %}
+                            {% set unit_key, unit, selected = choice[:3] %}
                             <option value="{{ unit_key }}"
                                     {% if selected %}selected="selected"{% endif %}>{{ unit }}</option>
                           {% endfor %}
@@ -141,7 +143,8 @@
                   <div class="panel-body">
                     <div class="form-group checkbox mb-3">
                       <label for="race">Officer Race</label>
-                      {% for race_key, race, selected in form.race.iter_choices() %}
+                      {% for choice in form.race.iter_choices() %}
+                        {% set race_key, race, selected = choice[:3] %}
                         <label class="form-check">
                           <input type="checkbox"
                                  class="form-check-input"
@@ -155,7 +158,8 @@
                     </div>
                     <div class="form-group radio mb-3">
                       <label for="race">Officer Gender</label>
-                      {% for gender_key, gender, selected in form.gender.iter_choices() %}
+                      {% for choice in form.gender.iter_choices() %}
+                        {% set gender_key, gender, selected = choice[:3] %}
                         <label class="form-check">
                           <input type="radio"
                                  class="form-check-input"

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -91,11 +91,9 @@
                                 name="rank"
                                 class="select2-multi-search"
                                 multiple="multiple">
-                          {% for rank_key, rank in choices['rank'] %}
+                          {% for rank_key, rank, selected in form.rank.iter_choices() %}
                             <option value="{{ rank_key }}"
-                                    {% if rank_key in form_data['rank'] %}selected="selected"{% endif %}>
-                              {{ rank }}
-                            </option>
+                                    {% if selected %}selected="selected"{% endif %}>{{ rank }}</option>
                           {% endfor %}
                         </select>
                       </div>
@@ -108,11 +106,9 @@
                                 name="unit"
                                 class="select2-multi-search"
                                 multiple="multiple">
-                          {% for unit_key, unit in choices['unit'] %}
+                          {% for unit_key, unit, selected in form.unit.iter_choices() %}
                             <option value="{{ unit_key }}"
-                                    {% if unit_key in form_data['unit'] %}selected="selected"{% endif %}>
-                              {{ unit }}
-                            </option>
+                                    {% if selected %}selected="selected"{% endif %}>{{ unit }}</option>
                           {% endfor %}
                         </select>
                       </div>
@@ -145,28 +141,28 @@
                   <div class="panel-body">
                     <div class="form-group checkbox mb-3">
                       <label for="race">Officer Race</label>
-                      {% for race_key, race in choices['race'] %}
+                      {% for race_key, race, selected in form.race.iter_choices() %}
                         <label class="form-check">
                           <input type="checkbox"
                                  class="form-check-input"
                                  id="race-{{ race_key }}"
                                  name="race"
                                  value="{{ race_key }}"
-                                 {% if race_key in form_data['race'] %}checked="checked"{% endif %} />
+                                 {% if selected %}checked="checked"{% endif %} />
                           {{ race }}
                         </label>
                       {% endfor %}
                     </div>
                     <div class="form-group radio mb-3">
                       <label for="race">Officer Gender</label>
-                      {% for gender_key, gender in choices['gender'] %}
+                      {% for gender_key, gender, selected in form.gender.iter_choices() %}
                         <label class="form-check">
                           <input type="radio"
                                  class="form-check-input"
                                  id="gender-{{ gender_key }}"
                                  name="gender"
                                  value="{{ gender_key }}"
-                                 {% if gender_key in form_data['gender'] %}checked="checked"{% endif %} />
+                                 {% if selected %}checked="checked"{% endif %} />
                           {{ gender }}
                         </label>
                       {% endfor %}

--- a/OpenOversight/app/utils/forms.py
+++ b/OpenOversight/app/utils/forms.py
@@ -23,7 +23,6 @@ from OpenOversight.app.models.database import (
     Note,
     Officer,
     Salary,
-    Unit,
     User,
     db,
 )
@@ -283,8 +282,7 @@ def filter_by_form(form_data: BrowseForm, officer_query, department_id=None):
         officer_query = officer_query.filter(
             Officer.first_name.ilike(f"%%{form_data['first_name']}%%")
         )
-    if not department_id and form_data.get("dept"):
-        department_id = form_data["dept"].id
+    if department_id:
         officer_query = officer_query.filter(Officer.department_id == department_id)
 
     if form_data.get("unique_internal_identifier"):
@@ -323,50 +321,24 @@ def filter_by_form(form_data: BrowseForm, officer_query, department_id=None):
             )
         )
 
-    job_ids = []
-    if form_data.get("rank"):
-        job_ids = [
-            job.id
-            for job in Job.query.filter_by(department_id=department_id)
-            .filter(Job.job_title.in_(form_data.get("rank")))
-            .all()
-        ]
+    job_ids = [job.id for job in form_data.get("rank", [])]
 
-        if "Not Sure" in form_data["rank"]:
-            form_data["rank"].append(None)
+    unit_ids = {unit.id for unit in form_data.get("unit", [])}
 
-    unit_ids = []
-    include_null_unit = False
-    if form_data.get("unit"):
-        unit_ids = [
-            unit.id
-            for unit in Unit.query.filter_by(department_id=department_id)
-            .filter(Unit.description.in_(form_data.get("unit")))
-            .all()
-        ]
-
-        if "Not Sure" in form_data["unit"]:
-            include_null_unit = True
-
-    if (
-        form_data.get("badge")
-        or unit_ids
-        or include_null_unit
-        or job_ids
-        or form_data.get("current_job")
-    ):
+    if form_data.get("badge") or unit_ids or job_ids or form_data.get("current_job"):
         officer_query = officer_query.join(Officer.assignments)
         if form_data.get("badge"):
             officer_query = officer_query.filter(
                 Assignment.star_no.like(f"%%{form_data['badge']}%%")
             )
 
-        if unit_ids or include_null_unit:
+        if unit_ids:
             # Split into 2 expressions because the SQL IN keyword does not match NULLs
             unit_filters = []
-            if unit_ids:
-                unit_filters.append(Assignment.unit_id.in_(unit_ids))
-            if include_null_unit:
+            nn_unit_ids = unit_ids - {None}
+            if nn_unit_ids:
+                unit_filters.append(Assignment.unit_id.in_(nn_unit_ids))
+            if None in unit_ids:
                 unit_filters.append(Assignment.unit_id.is_(None))
             officer_query = officer_query.filter(or_(*unit_filters))
 
@@ -376,12 +348,7 @@ def filter_by_form(form_data: BrowseForm, officer_query, department_id=None):
         if form_data.get("current_job"):
             officer_query = officer_query.filter(Assignment.resign_date.is_(None))
     officer_query = officer_query.options(selectinload(Officer.assignments)).distinct()
-
     return officer_query
-
-
-def grab_officers(form):
-    return filter_by_form(form, Officer.query)
 
 
 def set_dynamic_default(form_field, value):

--- a/OpenOversight/app/utils/general.py
+++ b/OpenOversight/app/utils/general.py
@@ -1,7 +1,8 @@
 import random
 import sys
+from collections.abc import Callable, Hashable, Iterable
 from distutils.util import strtobool
-from typing import Optional, Union
+from typing import Any, Optional, TypeVar, Union
 from urllib.parse import urlparse
 from zoneinfo import available_timezones
 
@@ -159,6 +160,11 @@ def str_is_true(str_) -> bool:
     return bool(strtobool(str_.lower()))
 
 
+def url_for_target_null_values_skipped(target: str, **kwargs: Any) -> str:
+    kwargs_skipped = {key: value for key, value in kwargs.items() if value}
+    return url_for(target, **kwargs_skipped)
+
+
 def validate_redirect_url(url: Optional[str]) -> Optional[str]:
     """
     Check that a url does not redirect to another domain.
@@ -173,3 +179,35 @@ def validate_redirect_url(url: Optional[str]) -> Optional[str]:
         return None
 
     return url
+
+
+T = TypeVar("T", bound=Hashable)
+
+
+def multi_selection_valid_or_default(
+    choices: Iterable[T], default: Iterable[T]
+) -> Callable[[Iterable[T]], Iterable[T]]:
+    def filter(values: Iterable[T]) -> Iterable[T]:
+        if set(values).issubset(choices):
+            return values
+        return default
+
+    return filter
+
+
+def single_selection_valid_or_default(
+    choices: Iterable[T], default: T
+) -> Callable[[T], T]:
+    def filter(value: T) -> T:
+        if value in choices:
+            return value
+        return default
+
+    return filter
+
+
+def parse_int_or_default(value: str, default: int = 0) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return default

--- a/OpenOversight/tests/routes/route_helpers.py
+++ b/OpenOversight/tests/routes/route_helpers.py
@@ -76,7 +76,7 @@ def process_form_data(form_dict: dict) -> dict:
     new_dict = {}
     for key, value in form_dict.items():
         if isinstance(value, list):
-            if value[0]:
+            if len(value) > 0 and value[0]:
                 if isinstance(value[0], dict):
                     for idx, item in enumerate(value):
                         for sub_key, sub_value in item.items():

--- a/OpenOversight/tests/test_utils.py
+++ b/OpenOversight/tests/test_utils.py
@@ -4,8 +4,10 @@ import pytest
 from flask import current_app
 from flask_login import current_user
 from mock import MagicMock, Mock, patch
+from werkzeug.datastructures import MultiDict
 
-from OpenOversight.app.models.database import Department, Image, Officer, Unit
+from OpenOversight.app.main.forms import BrowseForm
+from OpenOversight.app.models.database import Department, Image, Job, Officer, Unit
 from OpenOversight.app.utils.cloud import (
     compute_hash,
     crop_image,
@@ -13,7 +15,7 @@ from OpenOversight.app.utils.cloud import (
     upload_file_to_s3,
 )
 from OpenOversight.app.utils.db import unit_choices
-from OpenOversight.app.utils.forms import filter_by_form, grab_officers
+from OpenOversight.app.utils.forms import filter_by_form
 from OpenOversight.app.utils.general import allowed_file, validate_redirect_url
 from OpenOversight.tests.routes.route_helpers import login_user
 
@@ -23,6 +25,22 @@ upload_s3_patch = patch(
     "OpenOversight.app.utils.cloud.upload_file_to_s3",
     MagicMock(return_value="https://s3-some-bucket/someaddress.jpg"),
 )
+
+
+def grab_officers(form_data, department_id):
+    form = BrowseForm()
+    form.rank.query = list(
+        Job.query.filter_by(department_id=department_id, is_sworn_officer=True)
+        .order_by(Job.order.asc())
+        .all()
+    )
+    form.unit.query = list(
+        Unit.query.filter_by(department_id=department_id)
+        .order_by(Unit.description.asc())
+        .all()
+    ) + [Unit(id=None, description="Not Sure")]
+    form.process(MultiDict(form_data))
+    return filter_by_form(form.data, Officer.query, department_id)
 
 
 def test_department_filter(mockdata):
@@ -36,9 +54,9 @@ def test_department_filter(mockdata):
             "max_age": 85,
             "name": "",
             "badge": "",
-            "dept": department,
             "unique_internal_identifier": "",
-        }
+        },
+        department_id=department.id,
     )
     for element in results.all():
         assert element.department == department
@@ -46,14 +64,14 @@ def test_department_filter(mockdata):
 
 def test_race_filter_select_all_black_officers(mockdata):
     department = Department.query.first()
-    results = grab_officers({"race": ["BLACK"], "dept": department})
+    results = grab_officers({"race": ["BLACK"]}, department_id=department.id)
     for element in results.all():
         assert element.race in ("BLACK", "Not Sure")
 
 
 def test_gender_filter_select_all_male_or_not_sure_officers(mockdata):
     department = Department.query.first()
-    results = grab_officers({"gender": ["M"], "dept": department})
+    results = grab_officers({"gender": ["M"]}, department_id=department.id)
 
     result_genders = [officer.gender for officer in results.all()]
     for element in results.all():
@@ -64,7 +82,7 @@ def test_gender_filter_select_all_male_or_not_sure_officers(mockdata):
 
 def test_gender_filter_include_all_genders_if_not_sure(mockdata):
     department = Department.query.first()
-    results = grab_officers({"gender": ["Not Sure"], "dept": department})
+    results = grab_officers({"gender": ["Not Sure"]}, department_id=department.id)
 
     result_genders = [officer.gender for officer in results.all()]
     for gender in ("M", "F", "Other", None):
@@ -76,7 +94,7 @@ def test_gender_filter_include_all_genders_if_not_sure(mockdata):
 
 def test_rank_filter_select_all_commanders(mockdata):
     department = Department.query.first()
-    results = grab_officers({"rank": ["Commander"], "dept": department})
+    results = grab_officers({"rank": ["Commander"]}, department_id=department.id)
     for element in results.all():
         assignment = element.assignments[0]
         assert assignment.job.job_title in ("Commander", "Not Sure")
@@ -84,7 +102,7 @@ def test_rank_filter_select_all_commanders(mockdata):
 
 def test_rank_filter_select_all_police_officers(mockdata):
     department = Department.query.first()
-    results = grab_officers({"rank": ["Police Officer"], "dept": department})
+    results = grab_officers({"rank": ["Police Officer"]}, department_id=department.id)
     for element in results.all():
         assignment = element.assignments[0]
         assert assignment.job.job_title in ("Police Officer", "Not Sure")
@@ -92,14 +110,14 @@ def test_rank_filter_select_all_police_officers(mockdata):
 
 def test_filter_by_name(mockdata):
     department = Department.query.first()
-    results = grab_officers({"last_name": "J", "dept": department})
+    results = grab_officers({"last_name": "J"}, department_id=department.id)
     for element in results.all():
         assert "J" in element.last_name
 
 
 def test_filters_do_not_exclude_officers_without_assignments(mockdata):
     department = Department.query.first()
-    results = grab_officers({"name": "S", "dept": department})
+    results = grab_officers({"name": "S"}, department_id=department.id)
     no_assignments = False
     for element in results.all():
         if len(element.assignments) == 0:
@@ -110,7 +128,7 @@ def test_filters_do_not_exclude_officers_without_assignments(mockdata):
 
 def test_filter_by_badge_no(mockdata):
     department = Department.query.first()
-    results = grab_officers({"badge": "12", "dept": department})
+    results = grab_officers({"badge": "12"}, department_id=department.id)
     for element in results.all():
         assignment = element.assignments[0]
         assert "12" in str(assignment.star_no)
@@ -128,9 +146,9 @@ def test_filter_by_full_unique_internal_identifier_returns_officers(mockdata):
             "max_age": 85,
             "name": "",
             "badge": "",
-            "dept": department,
             "unique_internal_identifier": target_unique_internal_id,
-        }
+        },
+        department_id=department.id,
     )
     for element in results:
         returned_unique_internal_id = element.unique_internal_identifier
@@ -150,9 +168,9 @@ def test_filter_by_partial_unique_internal_identifier_returns_officers(mockdata)
             "max_age": 85,
             "name": "",
             "badge": "",
-            "dept": department,
             "unique_internal_identifier": partial_identifier,
-        }
+        },
+        department_id=department.id,
     )
     for element in results:
         returned_identifier = element.unique_internal_identifier
@@ -316,7 +334,7 @@ def test_filter_by_form_filter_unit(
     unit_id = Unit.query.filter_by(description="Donut Devourers").one().id
     department_id = Department.query.first().id
 
-    officers = filter_by_form(form_data, Officer.query, department_id).all()
+    officers = grab_officers(form_data, department_id).all()
 
     for officer in officers:
         found = False


### PR DESCRIPTION
## Description of Changes

I ran into this when working on #1148

The BrowseForm was basically only used as a data-container, this change is making sure we also use it to filter the incoming data to simplify the code in the view file. I also included other improvements like reducing the number of SQL queries sent.

Functionality wasn't changed (at least that was the goal), so the user experience should remain the same.


## Notes for Deployment
N/A

## Screenshots (if appropriate)


## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [ ] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
