### PR TITLE
Revert GitHub Action update for deploying workflow

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@4
+        uses: actions/checkout@3
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
         with:
@@ -58,7 +58,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: install fabric
         run: pip install fabric2
       - name: setup ssh connection


### PR DESCRIPTION
## Fixes issue
https://github.com/lucyparsons/OpenOversight/actions/runs/13974726061/job/39137399086

## Description of Changes
The version update broke the deployment workflow, so I am reverting those specific changes.\

Changes made in previous PR:
<img width="911" alt="Screenshot 2025-03-20 at 3 33 36 PM" src="https://github.com/user-attachments/assets/d92260f7-625a-4528-a87a-1244208616ea" />

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
