### PR TITLE
Fix edit user form

### DIFF
--- a/OpenOversight/app/auth/forms.py
+++ b/OpenOversight/app/auth/forms.py
@@ -1,3 +1,4 @@
+from flask_login import current_user
 from flask_wtf import FlaskForm as Form
 from wtforms import (
     BooleanField,
@@ -133,6 +134,15 @@ class EditUserForm(Form):
     submit = SubmitField(label="Update", false_values={"False", "false", ""})
     resend = SubmitField(label="Resend", false_values={"False", "false", ""})
     delete = SubmitField(label="Delete", false_values={"False", "false", ""})
+
+    def populate_obj(self, obj):
+        obj.is_area_coordinator = self.is_area_coordinator.data
+        obj.ac_department = self.ac_department.data
+        obj.is_administrator = self.is_administrator.data
+
+        obj.disable_user(current_user.id, self.is_disabled.data)
+        obj.approve_user(current_user.id, self.approved.data)
+        obj.confirm_user(current_user.id, self.confirmed.data)
 
     def validate(self, extra_validators=None):
         success = super(EditUserForm, self).validate(extra_validators=None)

--- a/OpenOversight/app/auth/views.py
+++ b/OpenOversight/app/auth/views.py
@@ -315,6 +315,9 @@ def edit_user(user_id):
 
     if request.method == HTTPMethod.GET:
         form = EditUserForm(obj=user)
+        form.is_disabled.data = user.disabled_by and user.disabled_at
+        form.approved.data = user.approved_by and user.approved_at
+        form.confirmed.data = user.confirmed_by and user.confirmed_at
         return render_template("auth/user.html", user=user, form=form)
     elif request.method == HTTPMethod.POST:
         form = EditUserForm()
@@ -333,17 +336,7 @@ def edit_user(user_id):
                 already_approved = (
                     user.approved_at is not None and user.approved_by is not None
                 )
-                if form.approved.data:
-                    user.approve_user(current_user.id)
-
-                if form.confirmed.data:
-                    user.confirm_user(current_user.id)
-
-                if form.is_disabled.data:
-                    user.disable_user(current_user.id)
-
                 form.populate_obj(user)
-                db.session.add(user)
                 db.session.commit()
 
                 # automatically send a confirmation email when approving an

--- a/OpenOversight/app/models/database.py
+++ b/OpenOversight/app/models/database.py
@@ -1085,35 +1085,35 @@ class User(UserMixin, BaseModel):
         """Override UserMixin.is_active to prevent disabled users from logging in."""
         return not self.disabled_at
 
-    def approve_user(self, approving_user_id: int):
+    def approve_user(self, approving_user_id: int, approved: bool):
         """Handle approving logic."""
-        if self.approved_at or self.approved_by:
-            return False
+        if approved and not self.approved_by and not self.approved_at:
+            self.approved_at = datetime.now(timezone.utc)
+            self.approved_by = approving_user_id
+            db.session.commit()
+        elif not approved and self.approved_by and self.approved_at:
+            self.approved_at = None
+            self.approved_by = None
+            db.session.commit()
 
-        self.approved_at = datetime.now(timezone.utc)
-        self.approved_by = approving_user_id
-        db.session.add(self)
-        db.session.commit()
-        return True
-
-    def confirm_user(self, confirming_user_id: int):
+    def confirm_user(self, confirming_user_id: int, confirmed: bool):
         """Handle confirming logic."""
-        if self.confirmed_at or self.confirmed_by:
-            return False
+        if confirmed and not self.confirmed_by and not self.confirmed_at:
+            self.confirmed_at = datetime.now(timezone.utc)
+            self.confirmed_by = confirming_user_id
+            db.session.commit()
+        elif not confirmed and self.confirmed_by and self.confirmed_at:
+            self.confirmed_at = None
+            self.confirmed_by = None
+            db.session.commit()
 
-        self.confirmed_at = datetime.now(timezone.utc)
-        self.confirmed_by = confirming_user_id
-        db.session.add(self)
-        db.session.commit()
-        return True
-
-    def disable_user(self, disabling_user_id: int):
+    def disable_user(self, disabling_user_id: int, is_disabled: bool):
         """Handle disabling logic."""
-        if self.disabled_at or self.disabled_by:
-            return False
-
-        self.disabled_at = datetime.now(timezone.utc)
-        self.disabled_by = disabling_user_id
-        db.session.add(self)
-        db.session.commit()
-        return True
+        if is_disabled and not self.disabled_by and not self.disabled_at:
+            self.disabled_at = datetime.now(timezone.utc)
+            self.disabled_by = disabling_user_id
+            db.session.commit()
+        elif not is_disabled and self.disabled_by and self.disabled_at:
+            self.disabled_at = None
+            self.disabled_by = None
+            db.session.commit()

--- a/OpenOversight/tests/routes/test_auth.py
+++ b/OpenOversight/tests/routes/test_auth.py
@@ -469,13 +469,13 @@ def test_disabled_user_cannot_visit_pages_requiring_auth(client, session):
         user = User.query.filter_by(email=MOD_DISABLED_USER_EMAIL).one()
         user.disabled_at = None
         user.disabled_by = None
-        session.add(user)
+        session.commit()
 
         rv, _ = login_modified_disabled_user(client)
         assert b"/user/sam" in rv.data
 
         # Disable account again and check that login_required redirects user correctly
-        user.disable_user(User.query.filter_by(is_administrator=True).first().id)
+        user.disable_user(User.query.filter_by(is_administrator=True).first().id, True)
 
         # Logged in disabled user cannot access pages requiring auth
         rv = client.get("/auth/logout")

--- a/OpenOversight/tests/routes/test_user_api.py
+++ b/OpenOversight/tests/routes/test_user_api.py
@@ -213,7 +213,7 @@ def test_admin_can_enable_user(client, session):
         _, current_user = login_admin(client)
 
         user = User.query.filter_by(email=GENERAL_USER_EMAIL).one()
-        user.disable_user(current_user.id)
+        user.disable_user(current_user.id, True)
 
         user = session.get(User, user.id)
         assert user.disabled_at is not None
@@ -233,8 +233,8 @@ def test_admin_can_enable_user(client, session):
         assert "updated!" in rv.data.decode(ENCODING_UTF_8)
 
         user = session.get(User, user.id)
-        assert user.disabled_at is not None
-        assert user.disabled_by == current_user.id
+        assert user.disabled_at is None
+        assert user.disabled_by is None
 
 
 def test_admin_can_resend_user_confirmation_email(client, session):
@@ -352,14 +352,14 @@ def test_admin_approval_sends_confirmation_email(
 
         user = User.query.filter_by(is_administrator=False).first()
         if currently_approved:
-            user.approve_user(current_user.id)
+            user.approve_user(current_user.id, True)
         else:
             user.approved_at = None
             user.approved_by = None
             session.commit()
 
         if currently_confirmed:
-            user.confirm_user(current_user.id)
+            user.confirm_user(current_user.id, True)
         else:
             user.confirmed_at = None
             user.confirmed_by = None

--- a/OpenOversight/tests/test_models.py
+++ b/OpenOversight/tests/test_models.py
@@ -613,94 +613,123 @@ def test_officer_incident_sort_order(mockdata, session):
     assert officer.incidents == sorted_incidents
 
 
-def test_user_confirmed_constraint(mockdata, session, faker):
-    email = faker.company_email()
-
-    session.add(
-        User(
-            email=email,
-            username=faker.word(),
-            password=faker.word(),
-        )
+def test_user_approved(mockdata, session, faker):
+    user = User(
+        email=faker.company_email(),
+        username=faker.word(),
+        password=faker.word(),
     )
+    session.add(user)
     session.commit()
 
-    user_one = User.query.filter_by(email=email).one()
+    # Unapproved -> Approved
+    user.approve_user(1, True)
+    assert user.approved_at is not None
+    assert user.approved_by == 1
 
-    assert user_one.confirm_user(1) is True
-    assert user_one.confirmed_at is not None
-    assert user_one.confirmed_by is not None
-    session.add(user_one)
-    session.commit()
+    # Approved -> Approved
+    old_approved_at = user.approved_at
+    user.approve_user(1, True)
+    assert user.approved_at == old_approved_at
+    assert user.approved_by == 1
 
-    user_two = User.query.filter_by(email=email).one()
-    assert user_two.confirm_user(1) is False
+    # Approved -> Unapproved
+    user.approve_user(1, False)
+    assert user.approved_at is None
+    assert user.approved_by is None
 
-    user_two.confirmed_by = None
-    session.add(user_two)
-
-    # Confirm that both _at and _by fields must be not None
-    with pytest.raises(IntegrityError):
-        session.commit()
+    # Unapproved -> Unapproved
+    user.approve_user(1, False)
+    assert user.approved_at is None
+    assert user.approved_by is None
 
 
-def test_user_approved_constraint(mockdata, session, faker):
-    email = faker.company_email()
-
-    session.add(
-        User(
-            email=email,
-            username=faker.word(),
-            password=faker.word(),
-        )
+def test_user_confirmed(mockdata, session, faker):
+    user = User(
+        email=faker.company_email(),
+        username=faker.word(),
+        password=faker.word(),
     )
+    session.add(user)
     session.commit()
 
-    user_one = User.query.filter_by(email=email).one()
+    # Unconfirmed -> Confirmed
+    user.confirm_user(1, True)
+    assert user.confirmed_at is not None
+    assert user.confirmed_by == 1
 
-    assert user_one.approve_user(1) is True
-    assert user_one.approved_at is not None
-    assert user_one.approved_by is not None
-    session.add(user_one)
-    session.commit()
+    # Confirmed -> Confirmed
+    old_confirmed_at = user.confirmed_at
+    user.confirm_user(1, True)
+    assert user.confirmed_at == old_confirmed_at
+    assert user.confirmed_by == 1
 
-    user_two = User.query.filter_by(email=email).one()
-    assert user_two.approve_user(1) is False
+    # Confirmed -> Unconfirmed
+    user.confirm_user(1, False)
+    assert user.confirmed_at is None
+    assert user.confirmed_by is None
 
-    user_two.approved_by = None
-    session.add(user_two)
-
-    # Confirm that both _at and _by fields must be not None
-    with pytest.raises(IntegrityError):
-        session.commit()
+    # Unconfirmed -> Unconfirmed
+    user.confirm_user(1, False)
+    assert user.confirmed_at is None
+    assert user.confirmed_by is None
 
 
-def test_user_disabled_constraint(mockdata, session, faker):
-    email = faker.company_email()
-
-    session.add(
-        User(
-            email=email,
-            username=faker.word(),
-            password=faker.word(),
-        )
+def test_user_disabled(mockdata, session, faker):
+    user = User(
+        email=faker.company_email(),
+        username=faker.word(),
+        password=faker.word(),
     )
+    session.add(user)
     session.commit()
 
-    user_one = User.query.filter_by(email=email).one()
+    # Undisabled -> Disabled
+    user.disable_user(1, True)
+    assert user.disabled_at is not None
+    assert user.disabled_by == 1
 
-    assert user_one.disable_user(1) is True
-    assert user_one.disabled_at is not None
-    assert user_one.disabled_by is not None
-    session.add(user_one)
+    # Disabled -> Disabled
+    old_disabled_at = user.disabled_at
+    user.disable_user(1, True)
+    assert user.disabled_at == old_disabled_at
+    assert user.disabled_by == 1
+
+    # Disabled -> Undisabled
+    user.disable_user(1, False)
+    assert user.disabled_at is None
+    assert user.disabled_by is None
+
+    # Undisabled -> Undisabled
+    user.disable_user(1, False)
+    assert user.disabled_at is None
+    assert user.disabled_by is None
+
+
+@pytest.mark.parametrize(
+    "by_attr, at_attr",
+    [
+        ("approved_by", "approved_at"),
+        ("confirmed_by", "confirmed_at"),
+        ("disabled_by", "disabled_at"),
+    ],
+)
+def test_user_constraints(mockdata, session, faker, by_attr, at_attr):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    user = User(
+        email=faker.company_email(),
+        username=faker.word(),
+        password=faker.word(),
+    )
+    session.add(user)
     session.commit()
 
-    user_two = User.query.filter_by(email=email).one()
-    assert user_two.disable_user(1) is False
+    setattr(user, at_attr, now)
+    setattr(user, by_attr, 1)
+    session.commit()
 
-    user_two.disabled_by = None
-    session.add(user_two)
-
-    # Confirm that both _at and _by fields must be not None
+    # Both or neither "_at" and "_by" must be set
+    setattr(user, at_attr, None)
+    setattr(user, by_attr, 1)
     with pytest.raises(IntegrityError):
         session.commit()


### PR DESCRIPTION
## Fixes issue
Fixes #1172 

## Description of Changes
Fix edit user form

1. Checkboxes to approve/confirm/disable users were not populated correctly
2. Users could not be un-approved/confirmed/disabled once approved/confirmed/disabled

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] Ran `make create_db_diagram` command.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
