### PR TITLE
Remove `docker-compose` versions

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - main
       - develop
-  pull_request:
-    branches:
-      - develop
 
 env:
   image_name: lucyparsons/openoversight

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - develop
+  pull_request:
+    branches:
+      - develop
 
 env:
   image_name: lucyparsons/openoversight

--- a/docker-compose.prod-img.yml
+++ b/docker-compose.prod-img.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 secrets:
   service-account-key:
     file: ./service_account_key.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 volumes:
   minio:
   postgres:


### PR DESCRIPTION
## Description of Changes
The docker-compose `version` tag is now obsolete, so I removed it from the files.

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative you'll receive a warning message that it is obsolete if used.

> Compose doesn't use version to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented.

Source: [Link](https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md)

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
- [x] `build_deploy` still works: [Link](https://github.com/lucyparsons/OpenOversight/actions/runs/14455440793/job/40537505981?pr=1178)
    - It failed because the there was no PR to merge, but it otherwise seemed fine. Docker did not immediately error out.