### PR TITLE
Fix officer face aspect ratio

### DIFF
--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -455,6 +455,7 @@ tr:hover .row-actions {
     border: none;
     height: 300px;
     margin: auto;
+    object-fit: cover;
 }
 
 .officer-face.officer-profile {


### PR DESCRIPTION
## Description of Changes
*Cherry-picked from https://github.com/OrcaCollective/OpenOversight/pull/548*
Fix officer face aspect ratio on the browse page.

The officer face thumbnail currently inherits the column width (`col-md-4 col-12`) and has a set height of 300. This causes images that aren't this particular size to become warped.

This change adds the `object-fit: cover` CSS property to the `officer-face` class, which preserves the thumbnail aspect ratio.
https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit

## Notes for Deployment
None!

## Screenshots (if appropriate)
Before:
![1](https://github.com/user-attachments/assets/da1bf767-c30f-4072-9a5a-e27334f68f7c)


After:
![2](https://github.com/user-attachments/assets/d8424970-575d-43b3-878f-78b43810d898)


## Testing instructions

## Checks

 - [x] I have rebased my changes on `main`

 - [x] `just lint` passes

 - [x] `just test` passes
