### PR TITLE
Fix officer tagging when department not set

### DIFF
--- a/OpenOversight/app/templates/cop_face.html
+++ b/OpenOversight/app/templates/cop_face.html
@@ -24,7 +24,7 @@
           </div>
         </div>
         <div class="card p-5">
-          <form action="{{ url_for('main.label_data', image_id=image.id, department_id=department.id if department else 0) }}"
+          <form action="{{ url_for('main.label_data', image_id=image.id, department_id=department.id if department else None) }}"
                 method="post">
             {% if form.errors %}
               <div>
@@ -118,7 +118,7 @@
             </div>
           </div>
           <div class="text-center mt-3">
-            <a href="{{ url_for('main.complete_tagging', image_id=image.id, department_id=department.id if department else 0, contains_cops=0) }}"
+            <a href="{{ url_for('main.complete_tagging', image_id=image.id, department_id=department.id if department else None, contains_cops=0) }}"
                class="done-button btn btn-lg btn-success mx-auto">
               {{ render_icon("check") }}
               All officers have been identified!
@@ -126,7 +126,7 @@
           </div>
         </div>
         <div class="mt-5 text-md-end text-center">
-          <a href="{{ url_for('main.label_data', department_id=department.id if department else 0) }}"
+          <a href="{{ url_for('main.label_data', department_id=department.id if department else None) }}"
              class="skip-button btn btn-lg btn-primary"
              role="button">
             Next Photo


### PR DESCRIPTION
## Description of Changes
Fix officer tagging when department no set.

Currently, we default to department id 0 in several urls when department id is not set. This causes issues because there is no department 0.

This change fixes this by defaulting to None instead.

**To Reproduce:**
1. Prerequisite: Have at least 1 image uploaded
2. Visit http://localhost:3000/cop_faces/images/1
3. Enter an officer id and click "Add identified face"
4. This will send a post request to http://localhost:3000/cop_faces/departments/0/images/4 which should fail due to foreign key constraint

## Notes for Deployment
None!

## Screenshots (if appropriate)
N/A

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
