### PR TITLE
Remove transitive dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ boto3==1.28.1
 botocore==1.31.1
 cachetools==5.3.1
 certifi==2024.07.04
-cffi==1.17.1
 click==8.1.4
 cryptography==44.0.1
 Deprecated~=1.2.14
@@ -31,18 +30,12 @@ Flask-SQLAlchemy==3.0.5
 Flask-WTF==1.1.2
 google-api-python-client==2.92.0
 gunicorn==22.0.0
-httplib2==0.22.0
-idna~=3.7
 itsdangerous~=2.1.2
-Jinja2~=3.1.3
-jmespath~=1.0.1
 limits~=3.5.0
 Mako~=1.2.4
 Markdown==3.4.3
 MarkupSafe==2.1.3
-mdurl~=0.1.2
 mock~=5.0.2
-packaging~=23.1
 Pillow==10.4.0
 pip==23.3
 platformdirs==3.8.1


### PR DESCRIPTION
## Fixes issue
Removes unused top-level dependencies from `requirements.txt` to improve maintainability and reduce risk of conflicts.

## Description of Changes
As part of our ongoing research on Python dependency management, we analyzed the declared dependencies in `requirements.txt` and removed the following packages:

- `cffi`
- `httpplib2`
- `idna`
- `itsdangerous`
- `Jinja2`
- `jmespath`
- `mdurl`
- `mock`
- `packaging`

These packages are either:
- Not used directly in the codebase, or
- Installed transitively by higher-level packages.

By removing them from the top-level requirements, we avoid unnecessarily pinning versions and let the resolver install the most compatible versions as needed. This cleanup follows pip’s best practices for dependency declaration and reduces the risk of dependency hell in future upgrades.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
