### PR TITLE
Update `depends_on` for web image

### DIFF
--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,5 +1,6 @@
 import os
 import re
+from unittest import skip
 
 from flask import current_app
 from playwright.sync_api import expect
@@ -245,6 +246,7 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
     assert selected_text == "Not Sure"
 
 
+@skip("Sporadically fails, S3 mock seems wonky")
 def test_image_classification_and_tagging(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
@@ -317,6 +319,7 @@ def test_image_classification_and_tagging(page, server_port, session):
     assert image_box["y"] <= frame_box["y"]
 
 
+@skip("Sporadically fails, S3 mock seems wonky")
 def test_anonymous_user_can_upload_image(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")

--- a/OpenOversight/tests/test_functional.py
+++ b/OpenOversight/tests/test_functional.py
@@ -1,6 +1,5 @@
 import os
 import re
-from unittest import skip
 
 from flask import current_app
 from playwright.sync_api import expect
@@ -246,7 +245,6 @@ def test_edit_officer_form_coerces_none_race_or_gender_to_not_sure(
     assert selected_text == "Not Sure"
 
 
-@skip("Sporadically fails, S3 mock seems wonky")
 def test_image_classification_and_tagging(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")
@@ -319,7 +317,6 @@ def test_image_classification_and_tagging(page, server_port, session):
     assert image_box["y"] <= frame_box["y"]
 
 
-@skip("Sporadically fails, S3 mock seems wonky")
 def test_anonymous_user_can_upload_image(page, server_port, session):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     img_path = os.path.join(test_dir, "images/200Cat.jpeg")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,11 @@ services:
      - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
+   healthcheck:
+     test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER" ]
+     interval: 5s
+     timeout: 5s
+     retries: 5
 
  web:
    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,6 @@ services:
      - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
-   healthcheck:
-     test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER" ]
-     interval: 5s
-     timeout: 5s
-     retries: 5
 
  web:
    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
  postgres:
    restart: always
-   image: postgres:latest
+   image: postgres:17
    environment:
      POSTGRES_USER: openoversight
      POSTGRES_PASSWORD: terriblepassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,11 +61,13 @@ services:
  web:
    restart: always
    build:
-      context: .
-      dockerfile: dockerfiles/web/Dockerfile-dev
+     context: .
+     dockerfile: dockerfiles/web/Dockerfile-dev
    depends_on:
-     - postgres
-     - minio
+     postgres:
+       condition: service_healthy
+     minio:
+       condition: service_started
    env_file:
      - .env
    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,12 +29,12 @@ services:
  createbucket:
    image: minio/mc
    depends_on:
-     - minio
+     minio:
+       condition: service_healthy
    env_file:
      - .env
    entrypoint: >
      /bin/sh -c "
-     sleep 5;
      /usr/bin/mc config host add myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
      /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
      /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};
@@ -52,6 +52,11 @@ services:
      - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
+   healthcheck:
+     test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
+     interval: 10s
+     timeout: 5s
+     retries: 5
 
  web:
    restart: always
@@ -59,8 +64,10 @@ services:
       context: .
       dockerfile: dockerfiles/web/Dockerfile-dev
    depends_on:
-     - postgres
-     - minio
+     minio:
+       condition: service_healthy
+     postgres:
+      condition: service_healthy
    env_file:
      - .env
    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
      minio:
        condition: service_healthy
      postgres:
-      condition: service_healthy
+       condition: service_healthy
    env_file:
      - .env
    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
      - .env
    entrypoint: >
      /bin/sh -c "
+     sleep 5;
      /usr/bin/mc alias set myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
      /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
      /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};
@@ -52,6 +53,11 @@ services:
      - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
+   healthcheck:
+     test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
+     interval: 10s
+     timeout: 5s
+     retries: 5
 
  web:
    restart: always
@@ -59,8 +65,10 @@ services:
       context: .
       dockerfile: dockerfiles/web/Dockerfile-dev
    depends_on:
-     - postgres
-     - minio
+     minio:
+       condition: service_healthy
+     postgres:
+       condition: service_healthy
    env_file:
      - .env
    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
      - .env
    entrypoint: >
      /bin/sh -c "
-     sleep 5;
      /usr/bin/mc alias set myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
      /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
      /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,13 +61,11 @@ services:
  web:
    restart: always
    build:
-     context: .
-     dockerfile: dockerfiles/web/Dockerfile-dev
+      context: .
+      dockerfile: dockerfiles/web/Dockerfile-dev
    depends_on:
-     postgres:
-       condition: service_healthy
-     minio:
-       condition: service_started
+     - postgres
+     - minio
    env_file:
      - .env
    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
      - .env
    entrypoint: >
      /bin/sh -c "
-     sleep 5;
      /usr/bin/mc alias set myminio http://minio:9000 minio ${MINIO_ROOT_PASSWORD};
      /usr/bin/mc mb myminio/${S3_BUCKET_NAME};
      /usr/bin/mc anonymous set public myminio/${S3_BUCKET_NAME};
@@ -53,11 +52,6 @@ services:
      - postgres:/var/lib/postgresql/data
    ports:
      - "5432:5432"
-   healthcheck:
-     test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
-     interval: 10s
-     timeout: 5s
-     retries: 5
 
  web:
    restart: always
@@ -65,10 +59,8 @@ services:
       context: .
       dockerfile: dockerfiles/web/Dockerfile-dev
    depends_on:
-     minio:
-       condition: service_healthy
-     postgres:
-       condition: service_healthy
+     - postgres
+     - minio
    env_file:
      - .env
    environment:


### PR DESCRIPTION
## Fixes issue(s)
https://github.com/lucyparsons/OpenOversight/issues/1199

## Description of Changes
The `sleep` command feels a bit arbitrary, so I updated the `depends_on` instead.

## Tests and Linting
- [x] This branch is up-to-date with the `develop` branch.
- [x] `pytest` passes on my local development environment.
- [x] `pre-commit` passes on my local development environment.
- [x] Build is successful and the error does not come back.

<details><summary>Application Build</summary>

```console
(env) michaelp@MacBook-Air-18 OpenOversight % make start
touch service_account_key.json || \
        (echo "Need to delete that empty directory first"; \
         sudo rm -d service_account_key.json/; \
         touch service_account_key.json)
if [ ! -f .env ]; then cp .env.example .env; fi
docker compose build
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
[+] Building 0.5s (22/22) FINISHED                                                                                                                      docker:desktop-linux
 => [web internal] load build definition from Dockerfile-dev                                                                                                            0.0s
 => => transferring dockerfile: 855B                                                                                                                                    0.0s
 => [web-test internal] load metadata for docker.io/library/python:3.11-bullseye                                                                                        0.5s
 => [web-test internal] load build definition from Dockerfile-test                                                                                                      0.0s
 => => transferring dockerfile: 943B                                                                                                                                    0.0s
 => [web-test internal] load .dockerignore                                                                                                                              0.0s
 => => transferring context: 154B                                                                                                                                       0.0s
 => [web internal] load .dockerignore                                                                                                                                   0.0s
 => => transferring context: 154B                                                                                                                                       0.0s
 => [web-test 1/8] FROM docker.io/library/python:3.11-bullseye@sha256:df0bd610af061603b29d63eb82027b64d5a3f15506e39270422b10b2a55079fc                                  0.0s
 => [web internal] load build context                                                                                                                                   0.0s
 => => transferring context: 306B                                                                                                                                       0.0s
 => [web-test internal] load build context                                                                                                                              0.0s
 => => transferring context: 383B                                                                                                                                       0.0s
 => CACHED [web 2/8] WORKDIR /usr/src/app                                                                                                                               0.0s
 => CACHED [web-test 3/8] RUN apt-get update && apt-get install -y curl libpq-dev python3-dev &&     apt-get install -y libsqlite3-0 graphviz-dev graphviz && apt-get   0.0s
 => CACHED [web-test 4/8] COPY requirements.txt dev-requirements.txt /usr/src/app/                                                                                      0.0s
 => CACHED [web-test 5/8] RUN curl https://sh.rustup.rs -sSf | sh -s -- -y &&     . "$HOME/.cargo/env" &&     pip3 install --no-cache-dir -r requirements.txt &&     p  0.0s
 => CACHED [web-test 6/8] RUN playwright install --with-deps chromium                                                                                                   0.0s
 => CACHED [web-test 7/8] COPY create_db.py test_data.py /usr/src/app/                                                                                                  0.0s
 => CACHED [web-test 8/8] WORKDIR /usr/src/app/                                                                                                                         0.0s
 => CACHED [web 3/7] RUN apt-get update && apt-get install -y xvfb libpq-dev python3-dev graphviz-dev graphviz &&     apt-get clean                                     0.0s
 => CACHED [web 4/7] COPY requirements.txt /usr/src/app/                                                                                                                0.0s
 => CACHED [web 5/7] RUN pip3 install --no-cache-dir -r requirements.txt                                                                                                0.0s
 => CACHED [web 6/7] COPY create_db.py test_data.py /usr/src/app/                                                                                                       0.0s
 => CACHED [web 7/7] WORKDIR /usr/src/app/                                                                                                                              0.0s
 => [web-test] exporting to image                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                 0.0s
 => => writing image sha256:79c9774d4cd7293576b8101d730810964fc6bd311d1b7a13bd7eb48641ec0eca                                                                            0.0s
 => => naming to docker.io/library/openoversight-web-test                                                                                                               0.0s
 => [web] exporting to image                                                                                                                                            0.0s
 => => exporting layers                                                                                                                                                 0.0s
 => => writing image sha256:35ec3218f21b194a1ea4b566b00d32ef82973dd69f6d0ea00a7a1536ba65f07f                                                                            0.0s
 => => naming to docker.io/library/openoversight-web                                                                                                                    0.0s
docker compose up -d
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
[+] Running 31/3
 ✔ postgres 14 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                           9.8s 
 ✔ minio 9 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                    3.0s 
 ✔ createbucket 5 layers [⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                 6.0s 
[+] Running 5/8
 ⠏ Network openoversight_default           Created                                                                                                                      0.9s 
 ⠏ Volume "openoversight_minio"            Created                                                                                                                      0.9s 
 ⠏ Volume "openoversight_postgres"         Created                                                                                                                      0.9s 
 ✔ Container openoversight-postgres-1      Started                                                                                                                      0.5s 
 ✔ Container openoversight-minio-1         Started                                                                                                                      0.5s 
 ✔ Container openoversight-createbucket-1  Started                                                                                                                      0.4s 
 ✔ Container openoversight-web-1           Started                                                                                                                      0.5s 
 ✔ Container openoversight-web-test-1      Started                                                                                                                      0.6s 
(env) michaelp@MacBook-Air-18 OpenOversight % make populate
touch service_account_key.json || \
        (echo "Need to delete that empty directory first"; \
         sudo rm -d service_account_key.json/; \
         touch service_account_key.json)
if [ ! -f .env ]; then cp .env.example .env; fi
docker compose build
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
[+] Building 0.3s (22/22) FINISHED                                                                                                                      docker:desktop-linux
 => [web-test internal] load build definition from Dockerfile-test                                                                                                      0.0s
 => => transferring dockerfile: 943B                                                                                                                                    0.0s
 => [web-test internal] load metadata for docker.io/library/python:3.11-bullseye                                                                                        0.2s
 => [web internal] load build definition from Dockerfile-dev                                                                                                            0.0s
 => => transferring dockerfile: 855B                                                                                                                                    0.0s
 => [web internal] load .dockerignore                                                                                                                                   0.0s
 => => transferring context: 154B                                                                                                                                       0.0s
 => [web-test internal] load .dockerignore                                                                                                                              0.0s
 => => transferring context: 154B                                                                                                                                       0.0s
 => [web 1/8] FROM docker.io/library/python:3.11-bullseye@sha256:df0bd610af061603b29d63eb82027b64d5a3f15506e39270422b10b2a55079fc                                       0.0s
 => [web-test internal] load build context                                                                                                                              0.0s
 => => transferring context: 383B                                                                                                                                       0.0s
 => [web internal] load build context                                                                                                                                   0.0s
 => => transferring context: 306B                                                                                                                                       0.0s
 => CACHED [web-test 2/8] WORKDIR /usr/src/app                                                                                                                          0.0s
 => CACHED [web 3/7] RUN apt-get update && apt-get install -y xvfb libpq-dev python3-dev graphviz-dev graphviz &&     apt-get clean                                     0.0s
 => CACHED [web 4/7] COPY requirements.txt /usr/src/app/                                                                                                                0.0s
 => CACHED [web 5/7] RUN pip3 install --no-cache-dir -r requirements.txt                                                                                                0.0s
 => CACHED [web 6/7] COPY create_db.py test_data.py /usr/src/app/                                                                                                       0.0s
 => CACHED [web 7/7] WORKDIR /usr/src/app/                                                                                                                              0.0s
 => CACHED [web-test 3/8] RUN apt-get update && apt-get install -y curl libpq-dev python3-dev &&     apt-get install -y libsqlite3-0 graphviz-dev graphviz && apt-get   0.0s
 => CACHED [web-test 4/8] COPY requirements.txt dev-requirements.txt /usr/src/app/                                                                                      0.0s
 => CACHED [web-test 5/8] RUN curl https://sh.rustup.rs -sSf | sh -s -- -y &&     . "$HOME/.cargo/env" &&     pip3 install --no-cache-dir -r requirements.txt &&     p  0.0s
 => CACHED [web-test 6/8] RUN playwright install --with-deps chromium                                                                                                   0.0s
 => CACHED [web-test 7/8] COPY create_db.py test_data.py /usr/src/app/                                                                                                  0.0s
 => CACHED [web-test 8/8] WORKDIR /usr/src/app/                                                                                                                         0.0s
 => [web] exporting to image                                                                                                                                            0.0s
 => => exporting layers                                                                                                                                                 0.0s
 => => writing image sha256:35ec3218f21b194a1ea4b566b00d32ef82973dd69f6d0ea00a7a1536ba65f07f                                                                            0.0s
 => => naming to docker.io/library/openoversight-web                                                                                                                    0.0s
 => [web-test] exporting to image                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                 0.0s
 => => writing image sha256:79c9774d4cd7293576b8101d730810964fc6bd311d1b7a13bd7eb48641ec0eca                                                                            0.0s
 => => naming to docker.io/library/openoversight-web-test                                                                                                               0.0s
docker compose up -d
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
[+] Running 5/0
 ✔ Container openoversight-postgres-1      Running                                                                                                                      0.0s 
 ✔ Container openoversight-minio-1         Running                                                                                                                      0.0s 
 ✔ Container openoversight-web-1           Running                                                                                                                      0.0s 
 ✔ Container openoversight-createbucket-1  Started                                                                                                                      0.0s 
 ✔ Container openoversight-web-test-1      Started                                                                                                                      0.0s 
Postgres is up
## Creating database
docker compose run --rm web python ./create_db.py
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
[+] Creating 2/0
 ✔ Container openoversight-minio-1     Running                                                                                                                          0.0s 
 ✔ Container openoversight-postgres-1  Running                                                                                                                          0.0s 
[2026-01-31 04:10:20,779] INFO in email_client: Using email provider: GmailEmailProvider
/usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
  warnings.warn(
[2026-01-31 04:10:20,799] INFO in __init__: OpenOversight startup
[2026-01-31 04:10:20,824] INFO in __init__: OpenOversight startup
2026-01-31 04:10:20,828 INFO sqlalchemy.engine.Engine select pg_catalog.version()
2026-01-31 04:10:20,828 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:20,829 INFO sqlalchemy.engine.Engine select current_schema()
2026-01-31 04:10:20,829 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:20,829 INFO sqlalchemy.engine.Engine show standard_conforming_strings
2026-01-31 04:10:20,829 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:20,829 INFO sqlalchemy.engine.Engine BEGIN (implicit)
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine [generated in 0.00006s] {'name': 'officer_links'}
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine [cached since 0.0004664s ago] {'name': 'officer_incidents'}
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,830 INFO sqlalchemy.engine.Engine [cached since 0.0007454s ago] {'name': 'departments'}
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine [cached since 0.001041s ago] {'name': 'jobs'}
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine [cached since 0.001294s ago] {'name': 'notes'}
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine [cached since 0.001563s ago] {'name': 'descriptions'}
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,831 INFO sqlalchemy.engine.Engine [cached since 0.001785s ago] {'name': 'officers'}
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine [cached since 0.002023s ago] {'name': 'salaries'}
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine [cached since 0.002274s ago] {'name': 'assignments'}
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine [cached since 0.00254s ago] {'name': 'unit_types'}
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,832 INFO sqlalchemy.engine.Engine [cached since 0.002794s ago] {'name': 'faces'}
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine [cached since 0.003002s ago] {'name': 'raw_images'}
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine [cached since 0.003226s ago] {'name': 'incident_links'}
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine [cached since 0.003422s ago] {'name': 'incident_license_plates'}
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,833 INFO sqlalchemy.engine.Engine [cached since 0.003648s ago] {'name': 'incident_officers'}
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine [cached since 0.003902s ago] {'name': 'locations'}
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine [cached since 0.004104s ago] {'name': 'license_plates'}
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine [cached since 0.004295s ago] {'name': 'links'}
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine [cached since 0.0045s ago] {'name': 'incidents'}
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s
2026-01-31 04:10:20,834 INFO sqlalchemy.engine.Engine [cached since 0.004718s ago] {'name': 'users'}
2026-01-31 04:10:20,835 INFO sqlalchemy.engine.Engine 
CREATE TABLE departments (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        name VARCHAR(255) NOT NULL, 
        short_name VARCHAR(100) NOT NULL, 
        state VARCHAR(2) DEFAULT '' NOT NULL, 
        unique_internal_identifier_label VARCHAR(100), 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT departments_name_state UNIQUE (name, state)
)


2026-01-31 04:10:20,835 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,837 INFO sqlalchemy.engine.Engine 
CREATE TABLE users (
        id SERIAL NOT NULL, 
        _uuid VARCHAR(36) NOT NULL, 
        email VARCHAR(64), 
        username VARCHAR(64), 
        password_hash VARCHAR(128), 
        confirmed_at TIMESTAMP WITH TIME ZONE, 
        confirmed_by INTEGER, 
        approved_at TIMESTAMP WITH TIME ZONE, 
        approved_by INTEGER, 
        is_area_coordinator BOOLEAN, 
        ac_department_id INTEGER, 
        is_administrator BOOLEAN, 
        disabled_at TIMESTAMP WITH TIME ZONE, 
        disabled_by INTEGER, 
        last_confirmation_sent_at TIMESTAMP WITH TIME ZONE, 
        last_reset_sent_at TIMESTAMP WITH TIME ZONE, 
        dept_pref INTEGER, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (id), 
        CONSTRAINT users_disabled_constraint CHECK ((disabled_at IS NULL and disabled_by IS NULL) or (disabled_at IS NOT NULL and disabled_by IS NOT NULL)), 
        CONSTRAINT users_confirmed_constraint CHECK ((confirmed_at IS NULL and confirmed_by IS NULL) or (confirmed_at IS NOT NULL and confirmed_by IS NOT NULL)), 
        CONSTRAINT users_approved_constraint CHECK ((approved_at IS NULL and approved_by IS NULL) or (approved_at IS NOT NULL and approved_by IS NOT NULL))
)


2026-01-31 04:10:20,837 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,837 INFO sqlalchemy.engine.Engine CREATE UNIQUE INDEX ix_users__uuid ON users (_uuid)
2026-01-31 04:10:20,837 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine CREATE UNIQUE INDEX ix_users_username ON users (username)
2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine CREATE UNIQUE INDEX ix_users_email ON users (email)
2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine 
CREATE TABLE jobs (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        job_title VARCHAR(255) NOT NULL, 
        is_sworn_officer BOOLEAN, 
        "order" INTEGER NOT NULL, 
        department_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT unique_department_job_titles UNIQUE (job_title, department_id), 
        CONSTRAINT jobs_department_id_fkey FOREIGN KEY(department_id) REFERENCES departments (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,838 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,839 INFO sqlalchemy.engine.Engine CREATE INDEX ix_jobs_job_title ON jobs (job_title)
2026-01-31 04:10:20,839 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,840 INFO sqlalchemy.engine.Engine CREATE INDEX ix_jobs_is_sworn_officer ON jobs (is_sworn_officer)
2026-01-31 04:10:20,840 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,840 INFO sqlalchemy.engine.Engine CREATE INDEX ix_jobs_order ON jobs ("order")
2026-01-31 04:10:20,840 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,840 INFO sqlalchemy.engine.Engine 
CREATE TABLE officers (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        last_name VARCHAR(120), 
        first_name VARCHAR(120), 
        middle_initial VARCHAR(120), 
        suffix VARCHAR(120), 
        race VARCHAR(120), 
        gender VARCHAR(5), 
        employment_date DATE, 
        birth_year INTEGER, 
        department_id INTEGER, 
        unique_internal_identifier VARCHAR(50), 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT gender_options CHECK (gender in ('M', 'F', 'Other')), 
        CONSTRAINT officers_department_id_fkey FOREIGN KEY(department_id) REFERENCES departments (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,841 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_suffix ON officers (suffix)
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_first_name ON officers (first_name)
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine CREATE UNIQUE INDEX ix_officers_unique_internal_identifier ON officers (unique_internal_identifier)
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_last_name ON officers (last_name)
2026-01-31 04:10:20,842 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_employment_date ON officers (employment_date)
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_gender ON officers (gender)
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_birth_year ON officers (birth_year)
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine CREATE INDEX ix_officers_race ON officers (race)
2026-01-31 04:10:20,843 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,844 INFO sqlalchemy.engine.Engine 
CREATE TABLE unit_types (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        description VARCHAR(120), 
        department_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT unit_types_department_id_fkey FOREIGN KEY(department_id) REFERENCES departments (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,844 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,844 INFO sqlalchemy.engine.Engine CREATE INDEX ix_unit_types_description ON unit_types (description)
2026-01-31 04:10:20,844 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,845 INFO sqlalchemy.engine.Engine 
CREATE TABLE raw_images (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        filepath VARCHAR(255), 
        hash_img VARCHAR(120), 
        taken_at TIMESTAMP WITH TIME ZONE, 
        contains_cops BOOLEAN, 
        is_tagged BOOLEAN, 
        department_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT raw_images_department_id_fkey FOREIGN KEY(department_id) REFERENCES departments (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,845 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,845 INFO sqlalchemy.engine.Engine CREATE INDEX ix_raw_images_taken_at ON raw_images (taken_at)
2026-01-31 04:10:20,845 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,846 INFO sqlalchemy.engine.Engine 
CREATE TABLE locations (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        street_name VARCHAR(100), 
        cross_street1 VARCHAR(100), 
        cross_street2 VARCHAR(100), 
        city VARCHAR(100), 
        state VARCHAR(2), 
        zip_code VARCHAR(5), 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,846 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine CREATE INDEX ix_locations_street_name ON locations (street_name)
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine CREATE INDEX ix_locations_city ON locations (city)
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine CREATE INDEX ix_locations_state ON locations (state)
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine CREATE INDEX ix_locations_zip_code ON locations (zip_code)
2026-01-31 04:10:20,847 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine 
CREATE TABLE license_plates (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        number VARCHAR(8) NOT NULL, 
        state VARCHAR(2), 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine CREATE INDEX ix_license_plates_state ON license_plates (state)
2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine CREATE INDEX ix_license_plates_number ON license_plates (number)
2026-01-31 04:10:20,848 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,849 INFO sqlalchemy.engine.Engine 
CREATE TABLE links (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        title VARCHAR(100), 
        url TEXT NOT NULL, 
        link_type VARCHAR(100), 
        description TEXT, 
        author VARCHAR(255), 
        has_content_warning BOOLEAN NOT NULL, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,849 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine CREATE INDEX ix_links_link_type ON links (link_type)
2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine CREATE INDEX ix_links_title ON links (title)
2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine 
CREATE TABLE officer_links (
        officer_id INTEGER NOT NULL, 
        link_id INTEGER NOT NULL, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (officer_id, link_id), 
        CONSTRAINT officer_links_officer_id_fkey FOREIGN KEY(officer_id) REFERENCES officers (id), 
        CONSTRAINT officer_links_link_id_fkey FOREIGN KEY(link_id) REFERENCES links (id)
)


2026-01-31 04:10:20,850 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,851 INFO sqlalchemy.engine.Engine 
CREATE TABLE notes (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        text_contents TEXT, 
        officer_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        FOREIGN KEY(officer_id) REFERENCES officers (id) ON DELETE CASCADE, 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,851 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,852 INFO sqlalchemy.engine.Engine 
CREATE TABLE descriptions (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        text_contents TEXT, 
        officer_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        FOREIGN KEY(officer_id) REFERENCES officers (id) ON DELETE CASCADE, 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,852 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,853 INFO sqlalchemy.engine.Engine 
CREATE TABLE salaries (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        officer_id INTEGER, 
        salary FLOAT NOT NULL, 
        overtime_pay FLOAT, 
        year INTEGER NOT NULL, 
        is_fiscal_year BOOLEAN NOT NULL, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT salaries_officer_id_fkey FOREIGN KEY(officer_id) REFERENCES officers (id) ON DELETE CASCADE, 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,853 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,853 INFO sqlalchemy.engine.Engine CREATE INDEX ix_salaries_salary ON salaries (salary)
2026-01-31 04:10:20,853 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine CREATE INDEX ix_salaries_year ON salaries (year)
2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine CREATE INDEX ix_salaries_overtime_pay ON salaries (overtime_pay)
2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine 
CREATE TABLE assignments (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        officer_id INTEGER, 
        star_no VARCHAR(120), 
        job_id INTEGER NOT NULL, 
        unit_id INTEGER, 
        start_date DATE, 
        resign_date DATE, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT assignments_officer_id_fkey FOREIGN KEY(officer_id) REFERENCES officers (id) ON DELETE CASCADE, 
        CONSTRAINT assignments_job_id_fkey FOREIGN KEY(job_id) REFERENCES jobs (id), 
        CONSTRAINT assignments_unit_id_fkey FOREIGN KEY(unit_id) REFERENCES unit_types (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,854 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,855 INFO sqlalchemy.engine.Engine CREATE INDEX ix_assignments_start_date ON assignments (start_date)
2026-01-31 04:10:20,855 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,855 INFO sqlalchemy.engine.Engine CREATE INDEX ix_assignments_star_no ON assignments (star_no)
2026-01-31 04:10:20,855 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,856 INFO sqlalchemy.engine.Engine CREATE INDEX ix_assignments_resign_date ON assignments (resign_date)
2026-01-31 04:10:20,856 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,856 INFO sqlalchemy.engine.Engine 
CREATE TABLE faces (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        officer_id INTEGER, 
        img_id INTEGER, 
        original_image_id INTEGER, 
        face_position_x INTEGER, 
        face_position_y INTEGER, 
        face_width INTEGER, 
        face_height INTEGER, 
        featured BOOLEAN DEFAULT 'false' NOT NULL, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT unique_faces UNIQUE (officer_id, img_id), 
        CONSTRAINT faces_officer_id_fkey FOREIGN KEY(officer_id) REFERENCES officers (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,856 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,857 INFO sqlalchemy.engine.Engine 
CREATE TABLE incidents (
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        last_updated_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        id SERIAL NOT NULL, 
        date DATE, 
        time TIME WITHOUT TIME ZONE, 
        report_number VARCHAR(50), 
        description TEXT, 
        address_id INTEGER, 
        department_id INTEGER, 
        created_by INTEGER, 
        last_updated_by INTEGER, 
        PRIMARY KEY (id), 
        CONSTRAINT incidents_address_id_fkey FOREIGN KEY(address_id) REFERENCES locations (id), 
        CONSTRAINT incidents_department_id_fkey FOREIGN KEY(department_id) REFERENCES departments (id), 
        FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL, 
        FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
)


2026-01-31 04:10:20,857 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine CREATE INDEX ix_incidents_report_number ON incidents (report_number)
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine CREATE INDEX ix_incidents_date ON incidents (date)
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine CREATE INDEX ix_incidents_time ON incidents (time)
2026-01-31 04:10:20,858 INFO sqlalchemy.engine.Engine [no key 0.00004s] {}
2026-01-31 04:10:20,859 INFO sqlalchemy.engine.Engine 
CREATE TABLE officer_incidents (
        officer_id INTEGER NOT NULL, 
        incident_id INTEGER NOT NULL, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (officer_id, incident_id), 
        CONSTRAINT officer_incidents_officer_id_fkey FOREIGN KEY(officer_id) REFERENCES officers (id), 
        CONSTRAINT officer_incidents_incident_id_fkey FOREIGN KEY(incident_id) REFERENCES incidents (id)
)


2026-01-31 04:10:20,859 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,859 INFO sqlalchemy.engine.Engine 
CREATE TABLE incident_links (
        incident_id INTEGER NOT NULL, 
        link_id INTEGER NOT NULL, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (incident_id, link_id), 
        CONSTRAINT incident_links_incident_id_fkey FOREIGN KEY(incident_id) REFERENCES incidents (id), 
        CONSTRAINT incident_links_link_id_fkey FOREIGN KEY(link_id) REFERENCES links (id)
)


2026-01-31 04:10:20,859 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,860 INFO sqlalchemy.engine.Engine 
CREATE TABLE incident_license_plates (
        incident_id INTEGER NOT NULL, 
        license_plate_id INTEGER NOT NULL, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (incident_id, license_plate_id), 
        CONSTRAINT incident_license_plates_incident_id_fkey FOREIGN KEY(incident_id) REFERENCES incidents (id), 
        CONSTRAINT incident_license_plates_license_plate_id_fkey FOREIGN KEY(license_plate_id) REFERENCES license_plates (id)
)


2026-01-31 04:10:20,860 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,860 INFO sqlalchemy.engine.Engine 
CREATE TABLE incident_officers (
        incident_id INTEGER NOT NULL, 
        officers_id INTEGER NOT NULL, 
        created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL, 
        PRIMARY KEY (incident_id, officers_id), 
        CONSTRAINT incident_officers_incident_id_fkey FOREIGN KEY(incident_id) REFERENCES incidents (id), 
        CONSTRAINT incident_officers_officers_id_fkey FOREIGN KEY(officers_id) REFERENCES officers (id)
)


2026-01-31 04:10:20,860 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,861 INFO sqlalchemy.engine.Engine ALTER TABLE faces ADD CONSTRAINT fk_face_image_id FOREIGN KEY(img_id) REFERENCES raw_images (id) ON DELETE CASCADE ON UPDATE CASCADE
2026-01-31 04:10:20,861 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,861 INFO sqlalchemy.engine.Engine ALTER TABLE users ADD CONSTRAINT users_ac_department_id_fkey FOREIGN KEY(ac_department_id) REFERENCES departments (id)
2026-01-31 04:10:20,861 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine ALTER TABLE users ADD CONSTRAINT users_dept_pref_fkey FOREIGN KEY(dept_pref) REFERENCES departments (id)
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine ALTER TABLE departments ADD FOREIGN KEY(created_by) REFERENCES users (id) ON DELETE SET NULL
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine ALTER TABLE users ADD CONSTRAINT users_approved_by_fkey FOREIGN KEY(approved_by) REFERENCES users (id) ON DELETE SET NULL
2026-01-31 04:10:20,862 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine ALTER TABLE users ADD CONSTRAINT users_confirmed_by_fkey FOREIGN KEY(confirmed_by) REFERENCES users (id) ON DELETE SET NULL
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine ALTER TABLE users ADD CONSTRAINT users_disabled_by_fkey FOREIGN KEY(disabled_by) REFERENCES users (id) ON DELETE SET NULL
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine [no key 0.00002s] {}
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine ALTER TABLE departments ADD FOREIGN KEY(last_updated_by) REFERENCES users (id) ON DELETE SET NULL
2026-01-31 04:10:20,863 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,864 INFO sqlalchemy.engine.Engine ALTER TABLE faces ADD CONSTRAINT fk_face_original_image_id FOREIGN KEY(original_image_id) REFERENCES raw_images (id) ON DELETE SET NULL ON UPDATE CASCADE
2026-01-31 04:10:20,864 INFO sqlalchemy.engine.Engine [no key 0.00003s] {}
2026-01-31 04:10:20,864 INFO sqlalchemy.engine.Engine COMMIT
Postgres is up
## Populate database with test data
docker compose run --rm web python ./test_data.py -p
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "S3_BUCKET_NAME" variable is not set. Defaulting to a blank string. 
WARN[0000] The "APPROVE_REGISTRATIONS" variable is not set. Defaulting to a blank string. 
[+] Creating 2/0
 ✔ Container openoversight-minio-1     Running                                                                                                                          0.0s 
 ✔ Container openoversight-postgres-1  Running                                                                                                                          0.0s 
[2026-01-31 04:10:22,070] INFO in email_client: Using email provider: GmailEmailProvider
/usr/local/lib/python3.11/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend for documentation about configuring the storage backend.
  warnings.warn(
[2026-01-31 04:10:22,092] INFO in __init__: OpenOversight startup
[2026-01-31 04:10:22,194] INFO in __init__: OpenOversight startup
[*] Populating database with test data...
2026-01-31 04:10:22,525 INFO sqlalchemy.engine.Engine select pg_catalog.version()
2026-01-31 04:10:22,525 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:22,525 INFO sqlalchemy.engine.Engine select current_schema()
2026-01-31 04:10:22,525 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:22,525 INFO sqlalchemy.engine.Engine show standard_conforming_strings
2026-01-31 04:10:22,526 INFO sqlalchemy.engine.Engine [raw sql] {}
2026-01-31 04:10:22,526 INFO sqlalchemy.engine.Engine BEGIN (implicit)
...
2026-01-31 04:10:31,014 INFO sqlalchemy.engine.Engine [generated in 0.00006s] {'pk_1': 1}
[*] Completed successfully!
(env) michaelp@MacBook-Air-18 OpenOversight % 

```

</details>
